### PR TITLE
[rspec-support] Switch thread local data to local attr

### DIFF
--- a/rspec-support/Changelog.md
+++ b/rspec-support/Changelog.md
@@ -12,6 +12,11 @@ Enchancements
 No changes. Released during the monorepo migration to test release processes, but accidentally
 contained no changes.
 
+Bug Fixes:
+
+* Switch current thread data to alias/accessors to avoid issues with mocked systems.
+  (Jon Rowe, #610)
+
 ### 3.13.1 / 2024-02-23
 [Full Changelog](http://github.com/rspec/rspec-support/compare/v3.13.0...v3.13.1)
 

--- a/rspec-support/lib/rspec/support.rb
+++ b/rspec-support/lib/rspec/support.rb
@@ -2,6 +2,10 @@
 
 class Thread
   attr_accessor :__rspec_local_data
+
+  class << self
+    alias __rspec_current_thread current
+  end
 end
 
 module RSpec
@@ -96,7 +100,7 @@ module RSpec
 
     # A single thread local variable so we don't excessively pollute that namespace.
     def self.thread_local_data
-      Thread.current.__rspec_local_data ||= {}
+      Thread.__rspec_current_thread.__rspec_local_data ||= {}
     end
 
     # @api private

--- a/rspec-support/lib/rspec/support.rb
+++ b/rspec-support/lib/rspec/support.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
 
+class Thread
+  attr_accessor :__rspec_local_data
+end
+
 module RSpec
   module Support
     # @api private
@@ -91,14 +95,8 @@ module RSpec
     end
 
     # A single thread local variable so we don't excessively pollute that namespace.
-    if RUBY_VERSION.to_f >= 2
-      def self.thread_local_data
-        Thread.current.thread_variable_get(:__rspec) || Thread.current.thread_variable_set(:__rspec, {})
-      end
-    else
-      def self.thread_local_data
-        Thread.current[:__rspec] ||= {}
-      end
+    def self.thread_local_data
+      Thread.current.__rspec_local_data ||= {}
     end
 
     # @api private

--- a/rspec-support/spec/rspec/support_spec.rb
+++ b/rspec-support/spec/rspec/support_spec.rb
@@ -207,6 +207,13 @@ module RSpec
         end
       end
 
+      it "works when Thread.current is mocked" do
+        expect(Thread).to_not receive(:current)
+
+        RSpec::Support.thread_local_data[:__for_test] = :oh_hai
+        expect(RSpec::Support.thread_local_data[:__for_test]).to eq :oh_hai
+      end
+
       it "works when Thread#thread_variable_get and Thread#thread_variable_set are mocked" do
         expect(Thread.current).to receive(:thread_variable_set).with(:test, true).once.and_return(true)
         expect(Thread.current).to receive(:thread_variable_get).with(:test).once.and_return(true)

--- a/rspec-support/spec/rspec/support_spec.rb
+++ b/rspec-support/spec/rspec/support_spec.rb
@@ -206,6 +206,17 @@ module RSpec
           end.resume
         end
       end
+
+      it "works when Thread#thread_variable_get and Thread#thread_variable_set are mocked" do
+        expect(Thread.current).to receive(:thread_variable_set).with(:test, true).once.and_return(true)
+        expect(Thread.current).to receive(:thread_variable_get).with(:test).once.and_return(true)
+
+        Thread.current.thread_variable_set(:test, true)
+        expect(Thread.current.thread_variable_get(:test)).to eq true
+
+        RSpec::Support.thread_local_data[:__for_test] = :oh_hai
+        expect(RSpec::Support.thread_local_data[:__for_test]).to eq :oh_hai
+      end
     end
 
     describe "failure notification" do

--- a/rspec-support/spec/rspec/support_spec.rb
+++ b/rspec-support/spec/rspec/support_spec.rb
@@ -198,7 +198,20 @@ module RSpec
       end
 
       if defined?(Fiber) && RUBY_VERSION.to_f >= 2.0
-        it "shares data across fibres" do
+        broken_on_jruby =
+          if RSpec::Support::Ruby.jruby?
+            "As Fiber.new creates a new thread on JRuby this is currently " \
+              "broken. There are alternative implementations that do work but " \
+              "they cause issues for mocks, so given this is a minor edge case " \
+              "and thread data is already broken, its acceptable. Pending " \
+              "because future JRuby may fix this. see: " \
+              "https://github.com/jruby/jruby/issues/1806 and " \
+              "https://github.com/rspec/rspec-support/pull/610"
+          else
+            false
+          end
+
+        it "shares data across fibers", :pending => broken_on_jruby do
           RSpec::Support.thread_local_data[:__for_test] = :oh_hai
 
           Fiber.new do


### PR DESCRIPTION
Originally suggested to fix https://github.com/rspec/rspec-support/issues/580 I turned this down because of waryness over patching thread, but given the conversation about mocking in https://github.com/rspec/rspec/issues/103 and https://github.com/rspec/rspec-support/pull/606 I think this is a better solution than capturing methods and other overly complicated solutions.

Additionally we patch in an alias for Thread.current to protect access to that when mocked.

(Notes this has been migrated over from rspec-support, it hadn't been merged due to a build failure, todo TM).