### PR TITLE
[rspec-support] Diff string arrays like other arrays

### DIFF
--- a/rspec-support/lib/rspec/support/differ.rb
+++ b/rspec-support/lib/rspec/support/differ.rb
@@ -15,7 +15,7 @@ module RSpec
 
         unless actual.nil? || expected.nil?
           if all_strings?(actual, expected)
-            if any_multiline_strings?(actual, expected)
+            if all_arrays?(actual, expected) || any_multiline_strings?(actual, expected)
               diff = diff_as_string(coerce_to_string(actual), coerce_to_string(expected))
             end
           elsif all_hashes?(actual, expected)
@@ -93,6 +93,10 @@ module RSpec
       end
 
     private
+
+      def all_arrays?(*args)
+        args.all? { |a| Array === a }
+      end
 
       def no_procs?(*args)
         safely_flatten(args).none? { |a| Proc === a }

--- a/rspec-support/spec/rspec/support/differ_spec.rb
+++ b/rspec-support/spec/rspec/support/differ_spec.rb
@@ -271,6 +271,43 @@ module RSpec
           expect(diff).to be_diffed_as(expected_diff)
         end
 
+        it 'outputs unified diff message of two string arrays' do
+          expected = ['foo', 'bar', 'baz', 'quux']
+          actual = ['foo', 'bar', 'corge', 'quux', 'garply']
+          expected_diff = dedent(<<-EOD)
+            |
+            |
+            |@@ -1,6 +1,5 @@
+            | foo
+            | bar
+            |-corge
+            |+baz
+            | quux
+            |-garply
+            |
+          EOD
+          diff = differ.diff(expected,actual)
+          expect(diff).to be_diffed_as(expected_diff)
+        end
+
+        it 'outputs unified diff message of nested string arrays' do
+          expected = ['foo', ['bar', 'baz'], 'quux']
+          actual = ['foo', ['bar', 'corge'], 'quux', 'garply']
+          expected_diff = dedent(<<-EOD)
+            |
+            |
+            |@@ -1,5 +1,4 @@
+            | foo
+            |-["bar", "corge"]
+            |+["bar", "baz"]
+            | quux
+            |-garply
+            |
+          EOD
+          diff = differ.diff(expected,actual)
+          expect(diff).to be_diffed_as(expected_diff)
+        end
+
         it "outputs unified diff message of two hashes" do
           expected = { :foo => 'bar', :baz => 'quux', :metasyntactic => 'variable', :delta => 'charlie', :width =>'quite wide' }
           actual   = { :foo => 'bar', :metasyntactic => 'variable', :delta => 'charlotte', :width =>'quite wide' }

--- a/rspec-support/spec/rspec/support/differ_spec.rb
+++ b/rspec-support/spec/rspec/support/differ_spec.rb
@@ -274,10 +274,12 @@ module RSpec
         it 'outputs unified diff message of two string arrays' do
           expected = ['foo', 'bar', 'baz', 'quux']
           actual = ['foo', 'bar', 'corge', 'quux', 'garply']
+
+          added_line_index = ::Diff::LCS::VERSION.to_f < 1.4 ? 7 : 5
           expected_diff = dedent(<<-EOD)
             |
             |
-            |@@ -1,6 +1,5 @@
+            |@@ -1,6 +1,#{added_line_index} @@
             | foo
             | bar
             |-corge
@@ -293,10 +295,12 @@ module RSpec
         it 'outputs unified diff message of nested string arrays' do
           expected = ['foo', ['bar', 'baz'], 'quux']
           actual = ['foo', ['bar', 'corge'], 'quux', 'garply']
+
+          added_line_index = ::Diff::LCS::VERSION.to_f < 1.4 ? 6 : 4
           expected_diff = dedent(<<-EOD)
             |
             |
-            |@@ -1,5 +1,4 @@
+            |@@ -1,5 +1,#{added_line_index} @@
             | foo
             |-["bar", "corge"]
             |+["bar", "baz"]


### PR DESCRIPTION
Migrated from rspec/rspec-support#518 / rspec/rspec-support#519

Fixes rspec/rspec#100

