### PR TITLE
[rspec-core] Add deprecate warning when example doc string is not a string object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,25 +21,25 @@ jobs:
     uses: rspec/rspec/.github/workflows/rubocop.yml@main
 
   core:
-    uses: rspec/rspec/.github/workflows/rspec.yml@3-13-maintenance
+    uses: rspec/rspec/.github/workflows/rspec.yml@3-99-maintenance
     with:
       library: 'rspec-core'
-      rspec_version: '~> 3.13.0'
+      rspec_version: '~> 3.99.0'
 
   mocks:
-    uses: rspec/rspec/.github/workflows/rspec.yml@3-13-maintenance
+    uses: rspec/rspec/.github/workflows/rspec.yml@3-99-maintenance
     with:
       library: 'rspec-mocks'
-      rspec_version: '~> 3.13.0'
+      rspec_version: '~> 3.99.0'
 
   expectations:
-    uses: rspec/rspec/.github/workflows/rspec.yml@3-13-maintenance
+    uses: rspec/rspec/.github/workflows/rspec.yml@3-99-maintenance
     with:
       library: 'rspec-expectations'
-      rspec_version: '~> 3.13.0'
+      rspec_version: '~> 3.99.0'
 
   support:
-    uses: rspec/rspec/.github/workflows/rspec.yml@3-13-maintenance
+    uses: rspec/rspec/.github/workflows/rspec.yml@3-99-maintenance
     with:
       library: 'rspec-support'
-      rspec_version: '~> 3.13.0'
+      rspec_version: '~> 3.99.0'

--- a/rspec-core/Changelog.md
+++ b/rspec-core/Changelog.md
@@ -3,7 +3,7 @@
 
 Deprecations:
 
-* Add RSpec 4 deprecation warnings. (Phil Pirozhkov, Jon Rowe, rspec/rspec-core#2880, rspec/rspec#106)
+* Add RSpec 4 deprecation warnings. (Phil Pirozhkov, Jon Rowe, rspec/rspec-core#2880, rspec/rspec#106, rspec/rspec#243)
 
 Enhancements:
 

--- a/rspec-core/Changelog.md
+++ b/rspec-core/Changelog.md
@@ -1,5 +1,5 @@
 ### Development
-[Full Changelog](https://github.com/rspec/rspec/compare/rspec-core-v3.13.5...3-13-maintenance)
+[Full Changelog](https://github.com/rspec/rspec/compare/rspec-core-v3.13.5...3-99-maintenance)
 
 ### 3.13.5 / 2025-06-25
 [Full Changelog](http://github.com/rspec/rspec/compare/rspec-core-v3.13.4...rspec-core-v3.13.5)

--- a/rspec-core/Changelog.md
+++ b/rspec-core/Changelog.md
@@ -5,6 +5,11 @@ Deprecations:
 
 * Add RSpec 4 deprecation warnings. (Phil Pirozhkov, Jon Rowe, rspec/rspec-core#2880, rspec/rspec#106)
 
+Enhancements:
+
+* Expand `RSpec::Core::Configuration#warnings=` to take `:all`, `:deprecations_only` and `:none`
+  options. (Jean Boussier, rspec/rspec#161)
+
 ### 3.13.5 / 2025-06-25
 [Full Changelog](http://github.com/rspec/rspec/compare/rspec-core-v3.13.4...rspec-core-v3.13.5)
 

--- a/rspec-core/Changelog.md
+++ b/rspec-core/Changelog.md
@@ -1,6 +1,10 @@
 ### Development
 [Full Changelog](https://github.com/rspec/rspec/compare/rspec-core-v3.13.5...3-99-maintenance)
 
+Deprecations:
+
+* Add RSpec 4 deprecation warnings. (Phil Pirozhkov, Jon Rowe, rspec/rspec-core#2880)
+
 ### 3.13.5 / 2025-06-25
 [Full Changelog](http://github.com/rspec/rspec/compare/rspec-core-v3.13.4...rspec-core-v3.13.5)
 

--- a/rspec-core/Changelog.md
+++ b/rspec-core/Changelog.md
@@ -3,7 +3,7 @@
 
 Deprecations:
 
-* Add RSpec 4 deprecation warnings. (Phil Pirozhkov, Jon Rowe, rspec/rspec-core#2880)
+* Add RSpec 4 deprecation warnings. (Phil Pirozhkov, Jon Rowe, rspec/rspec-core#2880, rspec/rspec#106)
 
 ### 3.13.5 / 2025-06-25
 [Full Changelog](http://github.com/rspec/rspec/compare/rspec-core-v3.13.4...rspec-core-v3.13.5)

--- a/rspec-core/README.md
+++ b/rspec-core/README.md
@@ -89,7 +89,7 @@ You can declare examples within a group using any of `it`, `specify`, or
 ## Shared Examples and Contexts
 
 Declare a shared example group using `shared_examples`, and then include it
-in any group using `include_examples`.
+in any group using `it_behaves_like` or `include_examples`.
 
 ```ruby
 RSpec.shared_examples "collections" do |collection_class|
@@ -98,14 +98,38 @@ RSpec.shared_examples "collections" do |collection_class|
   end
 end
 
+RSpec.shared_examples "implements #empty?" do
+  it "returns true when there are no members" do
+    expect(empty_target).to be_empty
+  end
+
+  it "returns false when there are members" do
+    expect(non_empty_target).to_not be_empty
+  end
+end
+
 RSpec.describe Array do
   include_examples "collections", Array
+
+  it_behaves_like "implements #empty?" do
+    let(:empty_target) { Array.new }
+    let(:non_empty_target) { [:key] }
+  end
 end
 
 RSpec.describe Hash do
   include_examples "collections", Hash
+
+  it_behaves_like "implements #empty?" do
+    let(:empty_target) { Hash.new }
+    let(:non_empty_target) { {key: :value} }
+  end
 end
 ```
+
+Note that `include_examples` directly includes examples into the current context, whilst
+`it_behaves_like` wraps the examples in a new context which allows you to pass a block
+to customise things like `let` or `subject` without using local variables passed in.
 
 Nearly anything that can be declared within an example group can be declared
 within a shared example group. This includes `before`, `after`, and `around`

--- a/rspec-core/features/clear_examples.feature
+++ b/rspec-core/features/clear_examples.feature
@@ -32,7 +32,7 @@ Feature: Running specs multiple times with different runner options in the same 
     require 'spec_helper'
 
     RSpec.describe "truth" do
-      describe true do
+      describe "true" do
         it "is truthy" do
           expect(true).to be_truthy
         end
@@ -42,12 +42,12 @@ Feature: Running specs multiple times with different runner options in the same 
         end
       end
 
-      describe false do
+      describe "false" do
         it "is falsy" do
           expect(false).to be_falsy
         end
 
-        it "is truthy" do
+        it "is not truthy" do
           expect(false).not_to be_truthy
         end
       end

--- a/rspec-core/features/command_line/line_number_appended_to_path.feature
+++ b/rspec-core/features/command_line/line_number_appended_to_path.feature
@@ -41,7 +41,8 @@ Feature: `<file>:<line_number>` (line number appended to file path)
       """
     And a file named "one_liner_spec.rb" with:
       """ruby
-      RSpec.describe 9 do
+      RSpec.describe "9" do
+        subject(:number) { 9 }
 
         it { is_expected.to be > 8 }
 
@@ -153,7 +154,7 @@ Feature: `<file>:<line_number>` (line number appended to file path)
     And the output should not contain "second file"
 
   Scenario: Matching one-liners
-    When I run `rspec one_liner_spec.rb:3 --format doc`
+    When I run `rspec one_liner_spec.rb:4 --format doc`
     Then the examples should all pass
     Then the output should contain "is expected to be > 8"
     But the output should not contain "is expected to be < 10"

--- a/rspec-core/features/command_line/ruby.feature
+++ b/rspec-core/features/command_line/ruby.feature
@@ -12,7 +12,7 @@ Feature: Run with `ruby` command
       """ruby
       require 'rspec/autorun'
 
-      RSpec.describe 1 do
+      RSpec.describe "1" do
         it "is < 2" do
           expect(1).to be < 2
         end

--- a/rspec-core/features/configuration/deprecation_stream.feature
+++ b/rspec-core/features/configuration/deprecation_stream.feature
@@ -20,6 +20,10 @@ Feature: Custom deprecation stream
   Background:
     Given a file named "lib/foo.rb" with:
       """ruby
+      RSpec.configure do |c|
+        c.order = :defined
+      end
+
       class Foo
         def bar
           RSpec.deprecate "Foo#bar"

--- a/rspec-core/features/example_groups/shared_examples.feature
+++ b/rspec-core/features/example_groups/shared_examples.feature
@@ -58,9 +58,7 @@ Feature: Using shared examples
   end
   ```
 
-  To prevent this kind of subtle error a warning is emitted if you declare multiple
-  methods with the same name in the same context. Should you get this warning
-  the simplest solution is to replace `include_examples` with `it_behaves_like`, in this
+  The simplest solution is to replace `include_examples` with `it_behaves_like`, in this
   way method overriding is avoided because of the nested context created by `it_behaves_like`
 
   Conventions:

--- a/rspec-core/features/expectation_framework_integration/configure_expectation_framework.feature
+++ b/rspec-core/features/expectation_framework_integration/configure_expectation_framework.feature
@@ -21,7 +21,8 @@ Feature: Configuring an expectation framework
         end
       end
 
-      RSpec.describe 6 do
+      RSpec.describe "multiple" do
+        subject(:number) { 6 }
         it { is_expected.to be_a_multiple_of 3 }
       end
       """
@@ -35,9 +36,10 @@ Feature: Configuring an expectation framework
         config.expect_with :rspec
       end
 
-      RSpec.describe 5 do
+      RSpec.describe "numeric comparison" do
+        subject(:number) { 5 }
         it "is greater than 4" do
-          expect(5).to be > 4
+          expect(number).to be > 4
         end
       end
       """
@@ -52,15 +54,17 @@ Feature: Configuring an expectation framework
         config.expect_with :test_unit
       end
 
-      RSpec.describe [1] do
+      RSpec.describe 'Array comparison' do
+        subject(:array) { [1] }
+
         it "is equal to [1]" do
-          assert_equal [1], [1], "expected [1] to equal [1]"
+          assert_equal [1], array, "expected [1] to equal [1]"
         end
 
-        specify { assert_not_equal [1], [] }
+        specify { assert_not_equal [], array }
 
         it "is equal to [2] (intentional failure)" do
-          assert [1] == [2], "errantly expected [2] to equal [1]"
+          assert array == [2], "errantly expected [2] to equal [1]"
         end
       end
       """
@@ -114,9 +118,11 @@ Feature: Configuring an expectation framework
         config.expect_with :rspec, :test_unit
       end
 
-      RSpec.describe [1] do
+      RSpec.describe 'Array comparison' do
+        subject(:array) { [1] }
+
         it "is equal to [1]" do
-          assert_equal [1], [1], "expected [1] to equal [1]"
+          assert_equal [1], array, "expected [1] to equal [1]"
         end
 
         it "matches array [1]" do
@@ -156,19 +162,21 @@ Feature: Configuring an expectation framework
         config.expect_with :test_unit, :minitest
       end
 
-      RSpec.describe [1] do
+      RSpec.describe 'Array comparison' do
+        subject(:array) { [1] }
+
         it "is equal to [1]" do
-          assert_equal [1], [1], "expected [1] to equal [1]"
+          assert_equal [1], array, "expected [1] to equal [1]"
         end
 
-        specify { assert_not_equal [1], [] }
+        specify { assert_not_equal [], array }
 
         it "the an object is the same as itself" do
           x = [1]
           assert_same x, x, "expected x to be the same x"
         end
 
-        specify { refute_same [1], [1] }
+        specify { refute_same [1], array }
       end
       """
     When I run `rspec example_spec.rb`

--- a/rspec-core/features/support/require_expect_syntax_in_aruba_specs.rb
+++ b/rspec-core/features/support/require_expect_syntax_in_aruba_specs.rb
@@ -26,7 +26,9 @@ else
   end
 
   RSpec.configure do |rspec|
-    rspec.disable_monkey_patching!
+    rspec.suppress_deprecations do
+      rspec.disable_monkey_patching!
+    end
     rspec.include DisallowOneLinerShould unless ENV['ALLOW_ONELINER_SHOULD']
   end
 end

--- a/rspec-core/lib/rspec/core/configuration.rb
+++ b/rspec-core/lib/rspec/core/configuration.rb
@@ -636,6 +636,16 @@ module RSpec
       # rubocop:enable Metrics/AbcSize
       # rubocop:enable Metrics/MethodLength
 
+      def issue_config_deprecations
+        unless ordering_manager.order_set?
+          RSpec.deprecate(
+            "Default order of :defined",
+            :replacement => "`config.order = :defined` or set any other order option",
+            :call_site => false
+          )
+        end
+      end
+
       # @private
       #
       # Used to set higher priority option values from the command line.

--- a/rspec-core/lib/rspec/core/configuration.rb
+++ b/rspec-core/lib/rspec/core/configuration.rb
@@ -2402,7 +2402,10 @@ module RSpec
         return unless disable_monkey_patching && rspec_mocks_loaded?
 
         RSpec::Mocks.configuration.tap do |config|
-          config.syntax = :expect
+          suppress_deprecations do
+            config.syntax = :expect
+          end
+
           config.patch_marshal_to_support_partial_doubles = false
         end
       end

--- a/rspec-core/lib/rspec/core/configuration.rb
+++ b/rspec-core/lib/rspec/core/configuration.rb
@@ -2410,7 +2410,9 @@ module RSpec
       def conditionally_disable_expectations_monkey_patching
         return unless disable_monkey_patching && rspec_expectations_loaded?
 
-        RSpec::Expectations.configuration.syntax = :expect
+        suppress_deprecations do
+          RSpec::Expectations.configuration.syntax = :expect
+        end
       end
 
       def rspec_mocks_loaded?

--- a/rspec-core/lib/rspec/core/dsl.rb
+++ b/rspec-core/lib/rspec/core/dsl.rb
@@ -81,7 +81,10 @@ module RSpec
       def self.expose_example_group_alias_globally(method_name)
         change_global_dsl do
           remove_method(method_name) if method_defined?(method_name)
-          define_method(method_name) { |*a, &b| ::RSpec.__send__(method_name, *a, &b) }
+          define_method(method_name) do |*a, &b|
+            RSpec.deprecate("Globally-exposed DSL (`#{method_name}`)", :replacement => "`RSpec.#{method_name}`")
+            ::RSpec.__send__(method_name, *a, &b)
+          end
         end
       end
 

--- a/rspec-core/lib/rspec/core/example.rb
+++ b/rspec-core/lib/rspec/core/example.rb
@@ -109,6 +109,7 @@ module RSpec
       # @note If there are multiple examples identified by this location, they will use {#id}
       #   to rerun instead, but this method will still return the location (that's why it is deprecated!).
       def rerun_argument
+        RSpec.deprecate("RSpec::Core::Example#rerun_argument", :replacement => "`location_rerun_argument`")
         location_rerun_argument
       end
 

--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -146,6 +146,11 @@ module RSpec
         idempotently_define_singleton_method(name) do |*all_args, &block|
           desc, *args = *all_args
 
+          unless NilClass === desc || String === desc
+            RSpec.deprecate("#{desc.class} object `#{desc.inspect}` as example doc string",
+                            :replacement => 'a string')
+          end
+
           options = Metadata.build_hash_from(args)
           options.update(:skip => RSpec::Core::Pending::NOT_YET_IMPLEMENTED) unless block
           options.update(extra_options)

--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -275,6 +275,11 @@ module RSpec
             combined_metadata.merge!(args.pop) if args.last.is_a? Hash
             args << combined_metadata
 
+            unless NilClass === description || String === description || Class === description || Module === description
+              RSpec.deprecate("#{description.class} object `#{description.inspect}` as example group doc string",
+                              :replacement => 'a string or a class')
+            end
+
             subclass(self, description, args, registration_collection, &example_group_block)
           ensure
             thread_data.delete(:in_example_group) if top_level

--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -352,6 +352,8 @@ module RSpec
       #
       # @see SharedExampleGroup
       def self.include_context(name, *args, &block)
+        issue_block_inclusion_deprecation("include_context") if block
+
         find_and_eval_shared("context", name, caller.first, *args, &block)
       end
 
@@ -362,6 +364,8 @@ module RSpec
       #
       # @see SharedExampleGroup
       def self.include_examples(name, *args, &block)
+        issue_block_inclusion_deprecation("include_examples") if block
+
         find_and_eval_shared("examples", name, caller.first, *args, &block)
       end
 
@@ -397,6 +401,17 @@ module RSpec
         shared_module.include_in(
           self, Metadata.relative_path(inclusion_location),
           args, customization_block
+        )
+      end
+
+      # @private
+      def self.issue_block_inclusion_deprecation(method)
+        RSpec.deprecate(
+          "Passing a block to `#{method}`",
+          :replacement =>
+            "Either use `it_behaves_like` to wrap the block " \
+            "contents in a context, or place the block content " \
+            "within the parent context."
         )
       end
 

--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -323,6 +323,8 @@ module RSpec
       #   @see SharedExampleGroup
       def self.define_nested_shared_group_method(new_name, report_label="it should behave like")
         idempotently_define_singleton_method(new_name) do |name, *args, &customization_block|
+          yield if block_given? # to print a deprecation warning for it_should_behave_like usage
+
           # Pass :caller so the :location metadata is set properly.
           # Otherwise, it'll be set to the next line because that's
           # the block's source_location.
@@ -339,7 +341,9 @@ module RSpec
       define_nested_shared_group_method :it_behaves_like, "behaves like"
       # Generates a nested example group and includes the shared content
       # mapped to `name` in the nested group.
-      define_nested_shared_group_method :it_should_behave_like
+      define_nested_shared_group_method(:it_should_behave_like) do
+        RSpec.deprecate("`it_should_behave_like`", :replacement => "`it_behaves_like`")
+      end
 
       # Includes shared content mapped to `name` directly in the group in which
       # it is declared, as opposed to `it_behaves_like`, which creates a nested

--- a/rspec-core/lib/rspec/core/filter_manager.rb
+++ b/rspec-core/lib/rspec/core/filter_manager.rb
@@ -89,6 +89,16 @@ module RSpec
       def prune_conditionally_filtered_examples(examples)
         examples.reject do |ex|
           meta = ex.metadata
+          if meta.key?(:if)
+            RSpec.deprecate("`:if` metadata will have no special meaning in RSpec 4 and",
+                            :replacement => "`:skip` with a negated condition",
+                            :call_site => meta[:location])
+          end
+          if meta.key?(:unless)
+            RSpec.deprecate("`:unless` metadata will have no special meaning in RSpec 4 and",
+                            :replacement => "`:skip`",
+                            :call_site => meta[:location])
+          end
           !meta.fetch(:if, true) || meta[:unless]
         end
       end

--- a/rspec-core/lib/rspec/core/memoized_helpers.rb
+++ b/rspec-core/lib/rspec/core/memoized_helpers.rb
@@ -78,6 +78,7 @@ module RSpec
       # @note If you are using RSpec's newer expect-based syntax you may
       #       want to use `is_expected.to` instead of `should`.
       def should(matcher=nil, message=nil)
+        RSpec.deprecate("RSpec::Core::Example#should`", :replacement => "RSpec Expectations' `is_expected.to`")
         enforce_value_expectation(matcher, 'should')
         RSpec::Expectations::PositiveExpectationHandler.handle_matcher(subject, matcher, message)
       end
@@ -98,6 +99,7 @@ module RSpec
       # @note If you are using RSpec's newer expect-based syntax you may
       #       want to use `is_expected.to_not` instead of `should_not`.
       def should_not(matcher=nil, message=nil)
+        RSpec.deprecate("RSpec::Core::Example#should_not", :replacement => "RSpec Expectations' `is_expected.not_to`")
         enforce_value_expectation(matcher, 'should_not')
         RSpec::Expectations::NegativeExpectationHandler.handle_matcher(subject, matcher, message)
       end

--- a/rspec-core/lib/rspec/core/mocking_adapters/mocha.rb
+++ b/rspec-core/lib/rspec/core/mocking_adapters/mocha.rb
@@ -37,6 +37,7 @@ module RSpec
         begin
           include ::Mocha::API
         rescue NameError
+          RSpec.deprecate("Support for this version of Mocha is deprecated, please install >= 0.13")
           include ::Mocha::Standalone
         end
 

--- a/rspec-core/lib/rspec/core/notifications.rb
+++ b/rspec-core/lib/rspec/core/notifications.rb
@@ -44,6 +44,8 @@ module RSpec::Core
         return SkippedExampleNotification.new(example) if execution_result.example_skipped?
         return new(example) unless execution_result.status == :pending || execution_result.status == :failed
 
+        # Note these subclasses are deprecated and going away but they're still in use here, let us know
+        # if this caused an issue upgrading.
         klass = if execution_result.pending_fixed?
                   PendingExampleFixedNotification
                 elsif execution_result.status == :pending

--- a/rspec-core/lib/rspec/core/option_parser.rb
+++ b/rspec-core/lib/rspec/core/option_parser.rb
@@ -33,6 +33,7 @@ module RSpec::Core
   private
 
     # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/BlockLength
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/CyclomaticComplexity
     # rubocop:disable Metrics/PerceivedComplexity
@@ -141,6 +142,7 @@ module RSpec::Core
 
         parser.on('-c', '--color', '--colour', '') do |_o|
           # flag will be excluded from `--help` output because it is deprecated
+          RSpec.deprecate("--colo(u)r", :replacement => "--force-colo(u)r if needed, but color is automatic.")
           options[:color] = true
           options[:color_mode] = :automatic
         end
@@ -305,6 +307,7 @@ FILTERING
       end
     end
     # rubocop:enable Metrics/AbcSize
+    # rubocop:enable Metrics/BlockLength
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/CyclomaticComplexity
     # rubocop:enable Metrics/PerceivedComplexity

--- a/rspec-core/lib/rspec/core/ordering.rb
+++ b/rspec-core/lib/rspec/core/ordering.rb
@@ -149,6 +149,11 @@ module RSpec
           @seed = rand(0xFFFF)
           @seed_forced = false
           @order_forced = false
+          @order_set = false
+        end
+
+        def order_set?
+          @order_set || @order_forced
         end
 
         def seed_used?
@@ -183,6 +188,7 @@ module RSpec
                 Delayed.new(ordering_registry, ordering_name)
               end
 
+            @order_set = true
             register_ordering(:global, strategy)
           end
         end

--- a/rspec-core/lib/rspec/core/project_initializer/spec/spec_helper.rb
+++ b/rspec-core/lib/rspec/core/project_initializer/spec/spec_helper.rb
@@ -47,6 +47,11 @@ RSpec.configure do |config|
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin
+  # This setting turns on all Ruby warnings. It's recommended, but in some cases may
+  # be too noisy due to issues in dependencies. The default is set to `:deprecations_only`
+  # but it can also be set to `:none` to suppress them.
+  config.warnings = :all
+
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -63,10 +68,6 @@ RSpec.configure do |config|
   config.suppress_deprecations do
     config.disable_monkey_patching!
   end
-
-  # This setting enables warnings. It's recommended, but in some cases may
-  # be too noisy due to issues in dependencies.
-  config.warnings = true
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an

--- a/rspec-core/lib/rspec/core/project_initializer/spec/spec_helper.rb
+++ b/rspec-core/lib/rspec/core/project_initializer/spec/spec_helper.rb
@@ -59,10 +59,10 @@ RSpec.configure do |config|
   # you configure your source control system to ignore this file.
   config.example_status_persistence_file_path = "spec/examples.txt"
 
-  # Limits the available syntax to the non-monkey patched syntax that is
-  # recommended. For more details, see:
-  # https://rspec.info/features/3-12/rspec-core/configuration/zero-monkey-patching-mode/
-  config.disable_monkey_patching!
+  # These settings will be the default in RSpec 4
+  config.suppress_deprecations do
+    config.disable_monkey_patching!
+  end
 
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.

--- a/rspec-core/lib/rspec/core/runner.rb
+++ b/rspec-core/lib/rspec/core/runner.rb
@@ -86,6 +86,8 @@ module RSpec
         setup(err, out)
         return @configuration.reporter.exit_early(exit_code) if RSpec.world.wants_to_quit
 
+        @configuration.issue_config_deprecations
+
         run_specs(@world.ordered_example_groups).tap do
           persist_example_statuses
         end

--- a/rspec-core/lib/rspec/core/sandbox.rb
+++ b/rspec-core/lib/rspec/core/sandbox.rb
@@ -24,6 +24,7 @@ module RSpec
         orig_example = RSpec.current_example
 
         RSpec.configuration = RSpec::Core::Configuration.new
+        RSpec.configuration.order = :defined
         RSpec.world         = RSpec::Core::World.new(RSpec.configuration)
 
         yield RSpec.configuration

--- a/rspec-core/lib/rspec/core/version.rb
+++ b/rspec-core/lib/rspec/core/version.rb
@@ -3,7 +3,7 @@ module RSpec
     # Version information for RSpec Core.
     module Version
       # Current version of RSpec Core, in semantic versioning format.
-      STRING = '3.13.5'
+      STRING = '3.99.0'
     end
   end
 end

--- a/rspec-core/lib/rspec/core/warnings.rb
+++ b/rspec-core/lib/rspec/core/warnings.rb
@@ -8,6 +8,8 @@ module RSpec
       #
       # Used internally to print deprecation warnings.
       def deprecate(deprecated, data={})
+        return unless RSpec.configuration.issue_deprecation?
+
         RSpec.configuration.reporter.deprecation(
           {
             :deprecated => deprecated,

--- a/rspec-core/lib/rspec/core/warnings.rb
+++ b/rspec-core/lib/rspec/core/warnings.rb
@@ -10,10 +10,13 @@ module RSpec
       def deprecate(deprecated, data={})
         return unless RSpec.configuration.issue_deprecation?
 
+        unless data.key?(:call_site)
+          data[:call_site] = CallerFilter.first_non_rspec_line
+        end
+
         RSpec.configuration.reporter.deprecation(
           {
-            :deprecated => deprecated,
-            :call_site => CallerFilter.first_non_rspec_line
+            :deprecated => deprecated
           }.merge(data)
         )
       end

--- a/rspec-core/spec/integration/failed_line_detection_spec.rb
+++ b/rspec-core/spec/integration/failed_line_detection_spec.rb
@@ -75,7 +75,7 @@ RSpec.describe 'Failed line detection' do
       end
     "
 
-    run_command "./spec/default_config_spec.rb"
+    run_command "./spec/default_config_spec.rb --order defined"
 
     expect(
       last_cmd_stdout
@@ -92,6 +92,7 @@ RSpec.describe 'Failed line detection' do
       require './app/app_mod'
 
       RSpec.configure do |c|
+        c.order = :defined
         c.project_source_dirs = %w[ lib spec ]
       end
 

--- a/rspec-core/spec/integration/filtering_spec.rb
+++ b/rspec-core/spec/integration/filtering_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe 'Filtering' do
       expect(formatter.passed_examples).to eq 1
     end
 
-    it "trumps exclusions, except for :if/:unless (which are absolute exclusions)" do
+    it "trumps exclusions, except for :skip (which are absolute exclusions)" do
       write_file_formatted 'spec/a_spec.rb', "
         RSpec.configure do |c|
           c.filter_run_excluding :slow
@@ -122,12 +122,13 @@ RSpec.describe 'Filtering' do
         RSpec.describe 'A group with a slow example' do
           example('ex 3'              ) { }
           example('ex 4', :slow       ) { }
-          example('ex 5', :if => false) { }
+          example('ex 5', :skip => true) { }
         end
       "
 
       run_command "spec/a_spec.rb -fd"
-      expect(last_cmd_stdout).to include("1 example, 0 failures", "ex 3").and exclude("ex 1", "ex 2", "ex 4", "ex 5")
+      expect(last_cmd_stdout).to include("2 examples, 0 failures, 1 pending", "ex 3", "ex 5 (PENDING").
+        and exclude("ex 1", "ex 2", "ex 4")
 
       run_command "spec/a_spec.rb:5 -fd" # selecting 'A slow group'
       expect(last_cmd_stdout).to include("2 examples, 0 failures", "ex 1", "ex 2").and exclude("ex 3", "ex 4", "ex 5")
@@ -135,8 +136,9 @@ RSpec.describe 'Filtering' do
       run_command "spec/a_spec.rb:12 -fd" # selecting slow example
       expect(last_cmd_stdout).to include("1 example, 0 failures", "ex 4").and exclude("ex 1", "ex 2", "ex 3", "ex 5")
 
-      run_command "spec/a_spec.rb:13 -fd" # selecting :if => false example
-      expect(last_cmd_stdout).to include("0 examples, 0 failures").and exclude("ex 1", "ex 2", "ex 3", "ex 4", "ex 5")
+      run_command "spec/a_spec.rb:13 -fd" # selecting :skip => true example
+      expect(last_cmd_stdout).to include("1 example, 0 failures, 1 pending", "ex 5 (PENDING").
+        and exclude("ex 1", "ex 2", "ex 3", "ex 4")
     end
 
     it 'works correctly when line numbers align with a shared example group line number from another file' do

--- a/rspec-core/spec/integration/filtering_spec.rb
+++ b/rspec-core/spec/integration/filtering_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe 'Filtering' do
 
   it 'prints a rerun command for shared examples in external files that works to rerun' do
     write_file "spec/support/shared_examples.rb", "
+      RSpec.configure { |c| c.order = :defined }
+
       RSpec.shared_examples 'with a failing example' do
         example { expect(1).to eq(2) } # failing
         example { expect(2).to eq(2) } # passing
@@ -112,6 +114,7 @@ RSpec.describe 'Filtering' do
       write_file_formatted 'spec/a_spec.rb', "
         RSpec.configure do |c|
           c.filter_run_excluding :slow
+          c.order = :defined
         end
 
         RSpec.describe 'A slow group', :slow do
@@ -130,13 +133,13 @@ RSpec.describe 'Filtering' do
       expect(last_cmd_stdout).to include("2 examples, 0 failures, 1 pending", "ex 3", "ex 5 (PENDING").
         and exclude("ex 1", "ex 2", "ex 4")
 
-      run_command "spec/a_spec.rb:5 -fd" # selecting 'A slow group'
+      run_command "spec/a_spec.rb:6 -fd" # selecting 'A slow group'
       expect(last_cmd_stdout).to include("2 examples, 0 failures", "ex 1", "ex 2").and exclude("ex 3", "ex 4", "ex 5")
 
-      run_command "spec/a_spec.rb:12 -fd" # selecting slow example
+      run_command "spec/a_spec.rb:13 -fd" # selecting slow example
       expect(last_cmd_stdout).to include("1 example, 0 failures", "ex 4").and exclude("ex 1", "ex 2", "ex 3", "ex 5")
 
-      run_command "spec/a_spec.rb:13 -fd" # selecting :skip => true example
+      run_command "spec/a_spec.rb:14 -fd" # selecting :skip => true example
       expect(last_cmd_stdout).to include("1 example, 0 failures, 1 pending", "ex 5 (PENDING").
         and exclude("ex 1", "ex 2", "ex 3", "ex 4")
     end
@@ -221,6 +224,8 @@ RSpec.describe 'Filtering' do
   context "passing example ids at the command line" do
     it "selects matching examples" do
       write_file_formatted "spec/file_1_spec.rb", "
+        RSpec.configure { |c| c.order = :defined }
+
         RSpec.describe 'File 1' do
           1.upto(3) do |i|
             example('ex ' + i.to_s) { expect(i).to be_odd }

--- a/rspec-core/spec/rspec/core/configuration_spec.rb
+++ b/rspec-core/spec/rspec/core/configuration_spec.rb
@@ -1319,6 +1319,32 @@ module RSpec::Core
         config.run_all_when_everything_filtered = true
         expect(config.run_all_when_everything_filtered?).to be(true)
       end
+
+      it "emits a deprecation message when set" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /run_all_when_everything_filtered/)
+        config.run_all_when_everything_filtered = true
+      end
+    end
+
+    describe "#tty" do
+      it "emits a deprecation message" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /tty$/)
+        config.tty
+      end
+    end
+
+    describe "#tty?" do
+      it "emits a deprecation message" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /tty\?/)
+        config.tty?
+      end
+    end
+
+    describe "#tty=" do
+      it "emits a deprecation message when set" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /tty=/)
+        config.tty = true
+      end
     end
 
     describe "#color_mode" do
@@ -1410,8 +1436,20 @@ module RSpec::Core
       end
     end
 
+    describe "#color" do
+      it "emits a deprecation message" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /color/)
+        config.color
+      end
+    end
+
     describe "#color=" do
       before { config.color_mode = :automatic }
+
+      it "emits a deprecation message when set" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /color/)
+        config.color = true
+      end
 
       context "given false" do
         before { config.color = false }
@@ -2382,6 +2420,13 @@ module RSpec::Core
         end
       end
 
+      describe '#alias_it_should_behave_like_to' do
+        it "emits a deprecation message when used" do
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /alias_it_should_behave_like_to/)
+          config.alias_it_should_behave_like_to :it_should_have_behaved_like
+        end
+      end
+
       it_behaves_like "metadata hash builder" do
         def metadata_hash(*args)
           config.alias_example_group_to :my_group_method, *args
@@ -2391,6 +2436,7 @@ module RSpec::Core
       end
 
       it 'overrides existing definitions of the aliased method name without issuing warnings' do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /#expose_dsl_globally = true/)
         config.expose_dsl_globally = true
 
         class << ExampleGroup
@@ -2404,6 +2450,7 @@ module RSpec::Core
         config.alias_example_group_to :my_group_method
 
         expect(ExampleGroup.my_group_method).to be < ExampleGroup
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /Globally-exposed DSL/)
         expect(Module.new.my_group_method).to be < ExampleGroup
       end
 
@@ -2875,6 +2922,23 @@ module RSpec::Core
       end
     end
 
+    describe "#expose_dsl_globally?" do
+      it "is deprecated" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /#expose_dsl_globally\?/)
+        config.expose_dsl_globally?
+      end
+    end
+
+    describe "#expose_dsl_globally=" do
+      it "is deprecated" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /#expose_dsl_globally\?/)
+        value = config.expose_dsl_globally?
+
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /#expose_dsl_globally = #{value}/)
+        config.expose_dsl_globally = value
+      end
+    end
+
     describe 'recording spec start time (for measuring load)' do
       it 'returns a time' do
         expect(config.start_time).to be_an_instance_of ::Time
@@ -2959,6 +3023,16 @@ module RSpec::Core
           "shared_context_metadata_behavior",
           ":another_value", ":trigger_inclusion", ":apply_to_host_groups"
         ))
+      end
+
+      it "emits a deprecation message when set to :trigger_inclusion" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /shared_context_metadata_behavior/)
+        config.shared_context_metadata_behavior = :trigger_inclusion
+      end
+
+      it "does not emit a deprecation message when set to :apply_to_host_groups" do
+        expect_no_deprecation
+        config.shared_context_metadata_behavior = :apply_to_host_groups
       end
     end
 

--- a/rspec-core/spec/rspec/core/configuration_spec.rb
+++ b/rspec-core/spec/rspec/core/configuration_spec.rb
@@ -19,6 +19,14 @@ module RSpec::Core
       end
     end
 
+    describe '#issue_config_deprecations' do
+      it 'will issue warning if config has not had order set' do
+        expect(RSpec.configuration.reporter).to receive(:deprecation).
+          with(include(:deprecated => match(/Default order/), :call_site => eq(false)))
+        config.issue_config_deprecations
+      end
+    end
+
     describe '#on_example_group_definition' do
       before do
         RSpec.configure do |c|

--- a/rspec-core/spec/rspec/core/drb_spec.rb
+++ b/rspec-core/spec/rspec/core/drb_spec.rb
@@ -1,7 +1,7 @@
 require 'rspec/core/drb'
 
 RSpec.describe RSpec::Core::DRbRunner, :isolated_directory => true, :isolated_home => true, :type => :drb, :skip => RUBY_PLATFORM == 'java' do
-  let(:config) { RSpec::Core::Configuration.new }
+  let(:config) { RSpec::Core::Configuration.new.tap { |c| c.order = :defined } }
   let(:out)    { StringIO.new }
   let(:err)    { StringIO.new }
 
@@ -67,6 +67,7 @@ RSpec.describe RSpec::Core::DRbRunner, :isolated_directory => true, :isolated_ho
       def self.run(argv, err, out)
         options = RSpec::Core::ConfigurationOptions.new(argv)
         config  = RSpec::Core::Configuration.new
+        config.order = :defined
         RSpec.configuration = config
         RSpec::Core::Runner.new(options, config).run(err, out)
       end
@@ -119,6 +120,7 @@ RSpec.describe RSpec::Core::DRbOptions, :isolated_directory => true, :isolated_h
 
     def drb_filter_manager_for(args)
       configuration = RSpec::Core::Configuration.new
+      configuration.order = :defined
       RSpec::Core::DRbRunner.new(config_options_object(*args), configuration).drb_argv
       configuration.filter_manager
     end

--- a/rspec-core/spec/rspec/core/dsl_spec.rb
+++ b/rspec-core/spec/rspec/core/dsl_spec.rb
@@ -27,6 +27,24 @@ RSpec.describe "The RSpec DSL" do
           expect(Object.new).not_to respond_to(*method_names)
         end
       end
+
+      it 'emits a deprecation warning' do
+        in_sub_process do
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 9, /Globally-exposed DSL \(`describe`\)/)
+          changing_expose_dsl_globally do
+            expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)
+            RSpec.configuration.expose_dsl_globally = true
+
+            expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)
+            expect(RSpec.configuration.expose_dsl_globally?).to eq true
+
+            Module.new do
+              describe 'monkey' do
+              end
+            end
+          end
+        end
+      end
     end
 
     context "when expose_dsl_globally is disabled" do

--- a/rspec-core/spec/rspec/core/dsl_spec.rb
+++ b/rspec-core/spec/rspec/core/dsl_spec.rb
@@ -72,29 +72,29 @@ RSpec.describe "The RSpec DSL" do
   end
 
   describe "built in DSL methods" do
-    include_examples "dsl methods", :describe, :context, :shared_examples, :shared_examples_for, :shared_context do
-      def changing_expose_dsl_globally
-        yield
-      end
+    include_examples "dsl methods", :describe, :context, :shared_examples, :shared_examples_for, :shared_context
+
+    def changing_expose_dsl_globally
+      yield
     end
   end
 
   describe "custom example group aliases" do
     context "when adding aliases before exposing the DSL globally" do
-      include_examples "dsl methods", :detail do
-        def changing_expose_dsl_globally
-          RSpec.configuration.alias_example_group_to(:detail)
-          yield
-        end
+      include_examples "dsl methods", :detail
+
+      def changing_expose_dsl_globally
+        RSpec.configuration.alias_example_group_to(:detail)
+        yield
       end
     end
 
     context "when adding aliases after exposing the DSL globally" do
-      include_examples "dsl methods", :detail do
-        def changing_expose_dsl_globally
-          yield
-          RSpec.configuration.alias_example_group_to(:detail)
-        end
+      include_examples "dsl methods", :detail
+
+      def changing_expose_dsl_globally
+        yield
+        RSpec.configuration.alias_example_group_to(:detail)
       end
     end
 

--- a/rspec-core/spec/rspec/core/example_group_spec.rb
+++ b/rspec-core/spec/rspec/core/example_group_spec.rb
@@ -1883,6 +1883,14 @@ module RSpec::Core
           end
         }.to raise_error("boom").and avoid_changing(RSpec::Support, :thread_local_data)
       end
+
+      it "emits a deprecation warning when used" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 3, /it_should_behave_like/)
+        RSpec.describe do
+          shared_examples_for("stuff") { }
+          it_should_behave_like "stuff"
+        end
+      end
     end
 
     it 'minimizes the number of methods that users could inadvertantly overwrite' do

--- a/rspec-core/spec/rspec/core/example_group_spec.rb
+++ b/rspec-core/spec/rspec/core/example_group_spec.rb
@@ -1257,7 +1257,29 @@ module RSpec::Core
         expect(group.examples[1].description).to eq('should 2')
         expect(group.examples[2].description).to eq('should 3')
       end
+    end
 
+    describe "deprecation warnings for example" do
+      it "does not output deprecation warning when description is a string" do
+        expect_no_deprecation
+        RSpec.describe.it('hoge')
+      end
+
+      it "does not output deprecation warning when description is nil" do
+        expect_no_deprecation
+        RSpec.describe.it
+      end
+
+      it "outputs deprecation warining when description is a symbol" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /Symbol object `:symbol` as example doc string/)
+        RSpec.describe.it(:symbol)
+      end
+
+      it "outputs deprication warning when description is a hash" do
+        formatted = RUBY_VERSION > '3.4' ? '\{"foo" => "bar"\}' : '\{"foo"=>"bar"\}'
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /Hash object `#{formatted}` as example doc string/)
+        RSpec.describe.it({ "foo" => "bar" })
+      end
     end
 
     describe Object, "describing nested example_groups", :little_less_nested => 'yep' do

--- a/rspec-core/spec/rspec/core/example_group_spec.rb
+++ b/rspec-core/spec/rspec/core/example_group_spec.rb
@@ -1698,9 +1698,10 @@ module RSpec::Core
 
         it "leaves RSpec's thread metadata unchanged, even when an error occurs during evaluation" do
           expect {
-            self.group.send(name, "named this") do
+            self.group.shared_examples "explosive" do
               raise "boom"
             end
+            self.group.send(name, "explosive")
           }.to raise_error("boom").and avoid_changing(RSpec::Support, :thread_local_data)
         end
 
@@ -1739,6 +1740,8 @@ module RSpec::Core
         end
 
         it "evals the block when given" do
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 10, /Passing a block/)
+
           key = "#{__FILE__}:#{__LINE__}"
           group = RSpec.describe do
             shared_examples(key) do

--- a/rspec-core/spec/rspec/core/example_group_spec.rb
+++ b/rspec-core/spec/rspec/core/example_group_spec.rb
@@ -57,16 +57,6 @@ module RSpec::Core
       end
     end
 
-    it 'does not treat the first argument as a metadata key even if it is a symbol' do
-      group = RSpec.describe(:symbol)
-      expect(group.metadata).not_to include(:symbol)
-    end
-
-    it 'treats the first argument as part of the description when it is a symbol' do
-      group = RSpec.describe(:symbol)
-      expect(group.description).to eq("symbol")
-    end
-
     describe "constant naming" do
       around do |ex|
         before_constants = RSpec::ExampleGroups.constants
@@ -1259,7 +1249,35 @@ module RSpec::Core
       end
     end
 
-    describe "deprecation warnings for example" do
+    describe "deprecation warnings for example group doc string" do
+      it "accepts a string for an example group doc string" do
+        expect { RSpec.describe 'MyClass' }.not_to output.to_stderr
+      end
+
+      it "accepts a class for an example group doc string" do
+        expect { RSpec.describe Numeric }.not_to output.to_stderr
+      end
+
+      it "accepts a module for an example group doc string" do
+        expect { RSpec.describe RSpec }.not_to output.to_stderr
+      end
+
+      it "accepts example group without a doc string" do
+        expect { RSpec.describe }.not_to output.to_stderr
+      end
+
+      it "emits a warning when a Symbol is used as an example group doc string" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /Symbol object `:foo` as example group doc string/)
+        RSpec.describe :foo
+      end
+
+      it "emits a warning when a Hash is used as an example group doc string" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /Hash object `#{Regexp.escape({ :foo => :bar }.inspect)}` as example group doc string/)
+        RSpec.describe(:foo => :bar) { }
+      end
+    end
+
+    describe "deprecation warnings for example doc string" do
       it "does not output deprecation warning when description is a string" do
         expect_no_deprecation
         RSpec.describe.it('hoge')
@@ -1276,9 +1294,8 @@ module RSpec::Core
       end
 
       it "outputs deprication warning when description is a hash" do
-        formatted = RUBY_VERSION > '3.4' ? '\{"foo" => "bar"\}' : '\{"foo"=>"bar"\}'
-        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /Hash object `#{formatted}` as example doc string/)
-        RSpec.describe.it({ "foo" => "bar" })
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /Hash object `#{Regexp.escape({ :foo => :bar }.inspect)}` as example doc string/)
+        RSpec.describe.it({ :foo => :bar })
       end
     end
 

--- a/rspec-core/spec/rspec/core/example_spec.rb
+++ b/rspec-core/spec/rspec/core/example_spec.rb
@@ -54,6 +54,12 @@ RSpec.describe RSpec::Core::Example, :parent_metadata => 'sample' do
       expect(example).to receive(:location_rerun_argument) { :location_rerun_argument }
       expect(example.rerun_argument).to eq(:location_rerun_argument)
     end
+
+    it "emits a deprecation warning when used" do
+      example = RSpec.describe.example
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /rerun_argument/)
+      example.rerun_argument
+    end
   end
 
   describe "#update_inherited_metadata" do

--- a/rspec-core/spec/rspec/core/filter_manager_spec.rb
+++ b/rspec-core/spec/rspec/core/filter_manager_spec.rb
@@ -184,7 +184,7 @@ module RSpec::Core
       end
 
       describe "location filtering" do
-        include_examples "example identification filter preference", :location do
+        it_behaves_like "example identification filter preference", :location do
           def add_filter(options)
             filter_manager.add_location(__FILE__, [options.fetch(:line_number)])
           end
@@ -192,7 +192,7 @@ module RSpec::Core
       end
 
       describe "id filtering" do
-        include_examples "example identification filter preference", :id do
+        it_behaves_like "example identification filter preference", :id do
           def add_filter(options)
             filter_manager.add_ids(__FILE__, [options.fetch(:scoped_id)])
           end

--- a/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -831,7 +831,7 @@ module RSpec::Core
     end
   end
 
-  RSpec.shared_examples_for "a class satisfying the common multiple exception error interface" do
+  RSpec.shared_context "exception helpers" do
     def new_failure(*a)
       RSpec::Expectations::ExpectationNotMetError.new(*a)
     end
@@ -839,6 +839,10 @@ module RSpec::Core
     def new_error(*a)
       StandardError.new(*a)
     end
+  end
+
+  RSpec.shared_examples_for "a class satisfying the common multiple exception error interface" do
+    include_context "exception helpers"
 
     it 'allows you to keep track of failures and other errors in order' do
       mee = new_multiple_exception_error
@@ -878,7 +882,7 @@ module RSpec::Core
   end
 
   RSpec.describe RSpec::Expectations::ExpectationNotMetError do
-    include_examples "a class satisfying the common multiple exception error interface" do
+    it_behaves_like "a class satisfying the common multiple exception error interface" do
       def new_multiple_exception_error
         failure_aggregator = RSpec::Expectations::FailureAggregator.new(nil, {})
         RSpec::Expectations::MultipleExpectationsNotMetError.new(failure_aggregator)
@@ -887,7 +891,9 @@ module RSpec::Core
   end
 
   RSpec.describe MultipleExceptionError do
-    include_examples "a class satisfying the common multiple exception error interface" do
+    include_context "exception helpers"
+
+    it_behaves_like "a class satisfying the common multiple exception error interface" do
       def new_multiple_exception_error
         MultipleExceptionError.new
       end

--- a/rspec-core/spec/rspec/core/hooks_filtering_spec.rb
+++ b/rspec-core/spec/rspec/core/hooks_filtering_spec.rb
@@ -313,7 +313,7 @@ module RSpec::Core
           c.after(:each,  :match => false) { filters << "after each in config"}
           c.after(:all,   :match => false) { filters << "after all in config"}
         end
-        group = RSpec.describe(:match => true)
+        group = RSpec.describe("docstring", :match => true)
         group.example("example") {}
         group.run
         expect(filters).to eq([])

--- a/rspec-core/spec/rspec/core/memoized_helpers_spec.rb
+++ b/rspec-core/spec/rspec/core/memoized_helpers_spec.rb
@@ -31,36 +31,6 @@ module RSpec::Core
         end
       end
 
-      describe "with a number" do
-        it "returns the number" do
-          expect(subject_value_for(15)).to eq(15)
-        end
-      end
-
-      describe "with a hash" do
-        it "returns the hash" do
-          expect(subject_value_for(:foo => 3)).to eq(:foo => 3)
-        end
-      end
-
-      describe "with a symbol" do
-        it "returns the symbol" do
-          expect(subject_value_for(:foo)).to eq(:foo)
-        end
-      end
-
-      describe "with true" do
-        it "returns `true`" do
-          expect(subject_value_for(true)).to eq(true)
-        end
-      end
-
-      describe "with false" do
-        it "returns `false`" do
-          expect(subject_value_for(false)).to eq(false)
-        end
-      end
-
       describe "with nil" do
         it "returns `nil`" do
           expect(subject_value_for(nil)).to eq(nil)
@@ -340,7 +310,7 @@ module RSpec::Core
       end
 
       it 'supports a new expect-based syntax' do
-        group = RSpec.describe([1, 2, 3]) do
+        group = RSpec.describe(Array) do
           it { is_expected.to be_an Array }
           it { is_expected.not_to include 4 }
         end

--- a/rspec-core/spec/rspec/core/memoized_helpers_spec.rb
+++ b/rspec-core/spec/rspec/core/memoized_helpers_spec.rb
@@ -660,11 +660,13 @@ module RSpec::Core
     subject { 'value or a Proc' }
 
     it '`should` prints a deprecation warning when given a value' do
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 2, /RSpec::Core::Example#should/)
       expect_warn_deprecation(/The implicit block expectation syntax is deprecated, you should pass/)
       expect { should block_matcher }.not_to raise_error
     end
 
     it '`should_not` prints a deprecation warning when given a value' do
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 2, /RSpec::Core::Example#should_not/)
       expect_warn_deprecation(/The implicit block expectation syntax is deprecated, you should pass/)
       expect { should_not block_matcher }.to raise_error(Exception)
     end
@@ -681,13 +683,13 @@ module RSpec::Core
 
     before { expect(value_matcher).not_to respond_to(:supports_value_expectations?) }
 
-    it '`should` does not print a deprecation warning when given a value' do
-      expect_no_deprecations
+    it '`should` prints a deprecation warning but not for being given a value' do
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /RSpec::Core::Example#should/)
       expect { should value_matcher }.not_to raise_error
     end
 
-    it '`should_not` does not print a deprecation warning when given a value' do
-      expect_no_deprecations
+    it '`should_not` prints a deprecation warning but not for being when given a value' do
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /RSpec::Core::Example#should_not/)
       expect { should_not value_matcher }.to raise_error(Exception)
     end
   end

--- a/rspec-core/spec/rspec/core/metadata_spec.rb
+++ b/rspec-core/spec/rspec/core/metadata_spec.rb
@@ -403,12 +403,6 @@ module RSpec
             end
           end
 
-          context "with a Symbol" do
-            it "returns the symbol" do
-              expect(value_for :group).to be(:group)
-            end
-          end
-
           context "with a class" do
             it "returns the class" do
               expect(value_for String).to be(String)
@@ -654,7 +648,7 @@ module RSpec
         it "finds the first non-rspec lib file in the caller array" do
           value = nil
 
-          RSpec.describe(:caller => ["./lib/rspec/core/foo.rb", "#{__FILE__}:#{__LINE__}"]) do
+          RSpec.describe("docstring", :caller => ["./lib/rspec/core/foo.rb", "#{__FILE__}:#{__LINE__}"]) do
             value = metadata[:file_path]
           end
 

--- a/rspec-core/spec/rspec/core/runner_spec.rb
+++ b/rspec-core/spec/rspec/core/runner_spec.rb
@@ -234,7 +234,7 @@ module RSpec::Core
 
     describe '#exit_code' do
       let(:world) { World.new }
-      let(:config) { Configuration.new }
+      let(:config) { Configuration.new.tap { |c| c.order = :defined } }
       let(:runner) { Runner.new({}, config, world) }
 
       it 'defaults to 1' do

--- a/rspec-core/spec/spec_helper.rb
+++ b/rspec-core/spec/spec_helper.rb
@@ -78,7 +78,9 @@ RSpec.configure do |c|
   # structural
   c.alias_it_behaves_like_to 'it_has_behavior'
   c.include(RSpecHelpers)
-  c.disable_monkey_patching!
+  c.suppress_deprecations do
+    c.disable_monkey_patching!
+  end
 
   # runtime options
   c.raise_errors_for_deprecations!

--- a/rspec-core/spec/spec_helper.rb
+++ b/rspec-core/spec/spec_helper.rb
@@ -75,6 +75,8 @@ RSpec.configure do |c|
     handle_current_dir_change(&ex)
   end
 
+  c.order = :random
+
   # structural
   c.alias_it_behaves_like_to 'it_has_behavior'
   c.include(RSpecHelpers)

--- a/rspec-expectations/.rubocop_rspec_base.yml
+++ b/rspec-expectations/.rubocop_rspec_base.yml
@@ -20,7 +20,7 @@ Style/CaseEquality:
 
 # Warns when the class is excessively long.
 Metrics/ClassLength:
-  Max: 100
+  Max: 130
 
 Style/CollectionMethods:
   PreferredMethods:

--- a/rspec-expectations/Changelog.md
+++ b/rspec-expectations/Changelog.md
@@ -1,5 +1,5 @@
 ### Development
-[Full Changelog](https://github.com/rspec/rspec/compare/rspec-expectations-v3.13.4...3-13-maintenance)
+[Full Changelog](https://github.com/rspec/rspec/compare/rspec-expectations-v3.13.4...3-99-maintenance)
 
 ### 3.13.5 / 2025-05-27
 [Full Changelog](https://github.com/rspec/rspec/compare/rspec-expectations-v3.13.4...rspec-expectations-v3.13.5)

--- a/rspec-expectations/Changelog.md
+++ b/rspec-expectations/Changelog.md
@@ -1,6 +1,10 @@
 ### Development
 [Full Changelog](https://github.com/rspec/rspec/compare/rspec-expectations-v3.13.4...3-99-maintenance)
 
+Deprecations:
+
+* Add RSpec 4 deprecation warnings. (Benoit Tigeot, Jon Rowe, Phil Pirozhkov, rspec/rspec-expectations#1301, rspec/rspec#124)
+
 ### 3.13.5 / 2025-05-27
 [Full Changelog](https://github.com/rspec/rspec/compare/rspec-expectations-v3.13.4...rspec-expectations-v3.13.5)
 

--- a/rspec-expectations/features/built_in_matchers/all.feature
+++ b/rspec-expectations/features/built_in_matchers/all.feature
@@ -21,7 +21,9 @@ Feature: `all` matcher
   Scenario: Array usage
     Given a file named "array_all_matcher_spec.rb" with:
       """ruby
-      RSpec.describe [1, 3, 5] do
+      RSpec.describe "Array" do
+        subject(:array) { [1, 3, 5] }
+
         it { is_expected.to all( be_odd ) }
         it { is_expected.to all( be_an(Integer) ) }
         it { is_expected.to all( be < 10 ) }
@@ -42,7 +44,9 @@ Feature: `all` matcher
   Scenario: Compound matcher usage
     Given a file named "compound_all_matcher_spec.rb" with:
       """ruby
-      RSpec.describe ['anything', 'everything', 'something'] do
+      RSpec.describe "Array" do
+        subject(:array) { ['anything', 'everything', 'something'] }
+
         it { is_expected.to all( be_a(String).and include("thing") ) }
         it { is_expected.to all( be_a(String).and end_with("g") ) }
         it { is_expected.to all( start_with("s").or include("y") ) }

--- a/rspec-expectations/features/built_in_matchers/be_within.feature
+++ b/rspec-expectations/features/built_in_matchers/be_within.feature
@@ -25,7 +25,9 @@ Feature: `be_within` matcher
   Scenario: Basic usage
     Given a file named "be_within_matcher_spec.rb" with:
       """ruby
-      RSpec.describe 27.5 do
+      RSpec.describe "Float" do
+        subject(:number) { 27.5 }
+
         it { is_expected.to be_within(0.5).of(27.9) }
         it { is_expected.to be_within(0.5).of(28.0) }
         it { is_expected.to be_within(0.5).of(27.1) }

--- a/rspec-expectations/features/built_in_matchers/comparisons.feature
+++ b/rspec-expectations/features/built_in_matchers/comparisons.feature
@@ -13,7 +13,9 @@ Feature: Comparison matchers
   Scenario: Numeric operator matchers
     Given a file named "numeric_operator_matchers_spec.rb" with:
       """ruby
-      RSpec.describe 18 do
+      RSpec.describe "Numeric" do
+        subject(:number) { 18 }
+
         it { is_expected.to be < 20 }
         it { is_expected.to be > 15 }
         it { is_expected.to be <= 19 }

--- a/rspec-expectations/features/built_in_matchers/contain_exactly.feature
+++ b/rspec-expectations/features/built_in_matchers/contain_exactly.feature
@@ -21,7 +21,9 @@ Feature: `contain_exactly` matcher
   Scenario: Array is expected to contain every value
     Given a file named "contain_exactly_matcher_spec.rb" with:
       """ruby
-      RSpec.describe [1, 2, 3] do
+      RSpec.describe "Array" do
+        subject(:array) { [1, 2, 3] }
+
         it { is_expected.to contain_exactly(1, 2, 3) }
         it { is_expected.to contain_exactly(1, 3, 2) }
         it { is_expected.to contain_exactly(2, 1, 3) }
@@ -48,7 +50,9 @@ Feature: `contain_exactly` matcher
   Scenario: Array is not expected to contain every value
     Given a file named "contain_exactly_matcher_spec.rb" with:
       """ruby
-      RSpec.describe [1, 2, 3] do
+      RSpec.describe "Array" do
+        subject(:array) { [1, 2, 3] }
+
         it { is_expected.to_not contain_exactly(1, 2, 3, 4) }
         it { is_expected.to_not contain_exactly(1, 2) }
 

--- a/rspec-expectations/features/built_in_matchers/cover.feature
+++ b/rspec-expectations/features/built_in_matchers/cover.feature
@@ -14,7 +14,9 @@ Feature: `cover` matcher
   Scenario: Range usage
     Given a file named "range_cover_matcher_spec.rb" with:
       """ruby
-      RSpec.describe (1..10) do
+      RSpec.describe "Range" do
+        subject(:range) { (1..10) }
+
         it { is_expected.to cover(4) }
         it { is_expected.to cover(6) }
         it { is_expected.to cover(8) }

--- a/rspec-expectations/features/built_in_matchers/end_with.feature
+++ b/rspec-expectations/features/built_in_matchers/end_with.feature
@@ -30,7 +30,9 @@ Feature: `end_with` matcher
   Scenario: Array usage
     Given a file named "example_spec.rb" with:
       """ruby
-      RSpec.describe [0, 1, 2, 3, 4] do
+      RSpec.describe "Array" do
+        subject(:array) { [0, 1, 2, 3, 4] }
+
         it { is_expected.to end_with 4 }
         it { is_expected.to end_with 3, 4 }
         it { is_expected.not_to end_with 3 }

--- a/rspec-expectations/features/built_in_matchers/have_attributes.feature
+++ b/rspec-expectations/features/built_in_matchers/have_attributes.feature
@@ -21,7 +21,9 @@ Feature: `have_attributes` matcher
       """ruby
       Person = Struct.new(:name, :age)
 
-      RSpec.describe Person.new("Jim", 32) do
+      RSpec.describe "Person" do
+        subject(:person) { Person.new("Jim", 32) }
+
         it { is_expected.to have_attributes(:name => "Jim") }
         it { is_expected.to have_attributes(:name => a_string_starting_with("J") ) }
         it { is_expected.to have_attributes(:age => 32) }

--- a/rspec-expectations/features/built_in_matchers/include.feature
+++ b/rspec-expectations/features/built_in_matchers/include.feature
@@ -35,7 +35,9 @@ Feature: `include` matcher
   Scenario: Array usage
     Given a file named "array_include_matcher_spec.rb" with:
       """ruby
-      RSpec.describe [1, 3, 7] do
+      RSpec.describe "Array" do
+        subject(:array) { [1, 3, 7] }
+
         it { is_expected.to include(1) }
         it { is_expected.to include(3) }
         it { is_expected.to include(7) }
@@ -108,7 +110,9 @@ Feature: `include` matcher
   Scenario: Hash usage
     Given a file named "hash_include_matcher_spec.rb" with:
       """ruby
-      RSpec.describe :a => 7, :b => 5 do
+      RSpec.describe "Hash" do
+        subject(:hash) { {:a => 7, :b => 5} }
+
         it { is_expected.to include(:a) }
         it { is_expected.to include(:b, :a) }
         it { is_expected.to include(:a => 7) }
@@ -158,7 +162,9 @@ Feature: `include` matcher
   Scenario: Counts usage
     Given a file named "include_matcher_with_counts_spec.rb" with:
       """ruby
-        RSpec.describe [{:c => 7}, {:a => 1}, {:b => 2}, {:c => 1}, {:a => 3}, {:c => 7}] do
+        RSpec.describe "Array of Hashes" do
+          subject(:array) { [{:c => 7}, {:a => 1}, {:b => 2}, {:c => 1}, {:a => 3}, {:c => 7}] }
+
           it { is_expected.to include(:b => 2).exactly(1).times }
           it { is_expected.to include(:b => 2).once }
           it { is_expected.to include(have_key(:a)).twice }

--- a/rspec-expectations/features/built_in_matchers/match.feature
+++ b/rspec-expectations/features/built_in_matchers/match.feature
@@ -33,7 +33,9 @@ Feature: `match` matcher
   Scenario: Regular expression usage
     Given a file named "regexp_match_spec.rb" with:
       """ruby
-      RSpec.describe /foo/ do
+      RSpec.describe "Regexp" do
+        subject(:regexp) { /foo/ }
+
         it { is_expected.to match("food") }
         it { is_expected.not_to match("drinks") }
 

--- a/rspec-expectations/features/built_in_matchers/predicates.feature
+++ b/rspec-expectations/features/built_in_matchers/predicates.feature
@@ -50,12 +50,12 @@ Feature: Predicate matchers
   Scenario: Expecting `subject` to `be_zero` (based on Integer#zero?)
     Given a file named "should_be_zero_spec.rb" with:
       """ruby
-      RSpec.describe 0 do
-        it { is_expected.to be_zero }
+      RSpec.describe "Integer" do
+        it { expect(0).to be_zero }
       end
 
-      RSpec.describe 7 do
-        it { is_expected.to be_zero } # deliberate failure
+      RSpec.describe "Integer" do
+        it { expect(7).to be_zero } # deliberate failure
       end
       """
     When I run `rspec should_be_zero_spec.rb`
@@ -65,12 +65,12 @@ Feature: Predicate matchers
   Scenario: Expecting `subject` to not `be_empty` (based on Array#empty?)
     Given a file named "should_not_be_empty_spec.rb" with:
       """ruby
-      RSpec.describe [1, 2, 3] do
-        it { is_expected.not_to be_empty }
+      RSpec.describe "Array" do
+        it { expect([1, 2, 3]).not_to be_empty }
       end
 
-      RSpec.describe [] do
-        it { is_expected.not_to be_empty } # deliberate failure
+      RSpec.describe "Array" do
+        it { expect([]).not_to be_empty } # deliberate failure
       end
       """
     When I run `rspec should_not_be_empty_spec.rb`
@@ -125,7 +125,9 @@ Feature: Predicate matchers
          end
        end
 
-       RSpec.describe 12 do
+       RSpec.describe "Integer" do
+         subject(:number) { 12 }
+
          it { is_expected.to be_multiple_of(3) }
          it { is_expected.not_to be_multiple_of(7) }
 

--- a/rspec-expectations/features/built_in_matchers/respond_to.feature
+++ b/rspec-expectations/features/built_in_matchers/respond_to.feature
@@ -70,7 +70,9 @@ Feature: `respond_to` matcher
   Scenario: Specify arguments
     Given a file named "respond_to_matcher_argument_checking_spec.rb" with:
       """ruby
-      RSpec.describe 7 do
+      RSpec.describe "Integer" do
+        subject(:number) { 7 }
+
         it { is_expected.to respond_to(:zero?).with(0).arguments }
         it { is_expected.not_to respond_to(:zero?).with(1).argument }
 

--- a/rspec-expectations/features/built_in_matchers/satisfy.feature
+++ b/rspec-expectations/features/built_in_matchers/satisfy.feature
@@ -21,7 +21,9 @@ Feature: `satisfy` matcher
   Scenario: Basic usage
     Given a file named "satisfy_matcher_spec.rb" with:
       """ruby
-      RSpec.describe 10 do
+      RSpec.describe "Integer" do
+        subject(:number) { 10 }
+
         it { is_expected.to satisfy { |v| v > 5 } }
         it { is_expected.not_to satisfy { |v| v > 15 } }
 

--- a/rspec-expectations/features/built_in_matchers/start_with.feature
+++ b/rspec-expectations/features/built_in_matchers/start_with.feature
@@ -30,7 +30,9 @@ Feature: `start_with` matcher
   Scenario: With an array
     Given a file named "example_spec.rb" with:
       """ruby
-      RSpec.describe [0, 1, 2, 3, 4] do
+      RSpec.describe "Array" do
+        subject(:array) { [0, 1, 2, 3, 4] }
+
         it { is_expected.to start_with 0 }
         it { is_expected.to start_with(0, 1)}
         it { is_expected.not_to start_with(2) }

--- a/rspec-expectations/features/built_in_matchers/types.feature
+++ b/rspec-expectations/features/built_in_matchers/types.feature
@@ -26,7 +26,9 @@ Feature: Type matchers
         include MyModule
       end
 
-      RSpec.describe 17.0 do
+      RSpec.describe "Float" do
+        subject(:float_number) { 17.0 }
+
         # the actual class
         it { is_expected.to be_kind_of(Float) }
         it { is_expected.to be_a_kind_of(Float) }
@@ -79,7 +81,9 @@ Feature: Type matchers
         include MyModule
       end
 
-      RSpec.describe 17.0 do
+      RSpec.describe "Float" do
+        subject(:float_number) { 17.0 }
+
         # the actual class
         it { is_expected.to be_instance_of(Float) }
         it { is_expected.to be_an_instance_of(Float) }

--- a/rspec-expectations/features/custom_matchers/define_matcher.feature
+++ b/rspec-expectations/features/custom_matchers/define_matcher.feature
@@ -15,21 +15,25 @@ Feature: Defining a custom matcher
         end
       end
 
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject { 9 }
         it { is_expected.to be_a_multiple_of(3) }
       end
 
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject { 9 }
         it { is_expected.not_to be_a_multiple_of(4) }
       end
 
       # fail intentionally to generate expected output
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject { 9 }
         it { is_expected.to be_a_multiple_of(4) }
       end
 
       # fail intentionally to generate expected output
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject { 9 }
         it { is_expected.not_to be_a_multiple_of(3) }
       end
       """
@@ -60,8 +64,8 @@ Feature: Defining a custom matcher
       end
 
       # fail intentionally to generate expected output
-      RSpec.describe 9 do
-        it { is_expected.to be_a_multiple_of(4) }
+      RSpec.describe "Integer" do
+        it { expect(9).to be_a_multiple_of(4) }
       end
       """
     When I run `rspec ./matcher_with_failure_message_spec.rb`
@@ -84,8 +88,8 @@ Feature: Defining a custom matcher
       end
 
       # fail intentionally to generate expected output
-      RSpec.describe 9 do
-        it { is_expected.not_to be_a_multiple_of(3) }
+      RSpec.describe "Integer" do
+        it { expect(9).not_to be_a_multiple_of(3) }
       end
       """
     When I run `rspec ./matcher_with_failure_for_message_spec.rb`
@@ -107,12 +111,12 @@ Feature: Defining a custom matcher
         end
       end
 
-      RSpec.describe 9 do
-        it { is_expected.to be_a_multiple_of(3) }
+      RSpec.describe "Integer" do
+        it { expect(9).to be_a_multiple_of(3) }
       end
 
-      RSpec.describe 9 do
-        it { is_expected.not_to be_a_multiple_of(4) }
+      RSpec.describe "Integer" do
+        it { expect(9).not_to be_a_multiple_of(4) }
       end
       """
     When I run `rspec ./matcher_overriding_description_spec.rb --format documentation`
@@ -156,8 +160,8 @@ Feature: Defining a custom matcher
         end
       end
 
-      RSpec.describe 10 do
-        it { is_expected.to be_the_sum_of(1,2,3,4) }
+      RSpec.describe "Integer" do
+        it { expect(10).to be_the_sum_of(1,2,3,4) }
       end
       """
     When I run `rspec ./matcher_with_multiple_args_spec.rb --format documentation`
@@ -178,8 +182,8 @@ Feature: Defining a custom matcher
         description { "be lazily equal to #{block_arg.call}" }
       end
 
-      RSpec.describe 10 do
-        it { is_expected.to be_lazily_equal_to { 10 } }
+      RSpec.describe "Integer" do
+        it { expect(10).to be_lazily_equal_to { 10 } }
       end
       """
     When I run `rspec ./matcher_with_block_arg_spec.rb --format documentation`
@@ -290,7 +294,9 @@ Feature: Defining a custom matcher
         end
       end
 
-      RSpec.describe [1, 2, 3] do
+      RSpec.describe "Array" do
+        subject(:array) { [1, 2, 3] }
+
         it { is_expected.to contain(1, 2) }
         it { is_expected.not_to contain(4, 5, 6) }
 
@@ -315,7 +321,9 @@ Feature: Defining a custom matcher
         match { |actual| is_multiple?(actual) }
       end
 
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject(:number) { 9 }
+
         it { is_expected.to be_a_multiple_of(3) }
         it { is_expected.not_to be_a_multiple_of(4) }
 
@@ -344,7 +352,9 @@ Feature: Defining a custom matcher
         match { |actual| is_multiple?(actual, expected) }
       end
 
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject(:number) { 9 }
+
         it { is_expected.to be_a_multiple_of(3) }
         it { is_expected.not_to be_a_multiple_of(4) }
 
@@ -418,11 +428,15 @@ Feature: Defining a custom matcher
         end
       end
 
-      RSpec.describe 1 do
+      RSpec.describe "Integer" do
+        subject(:number) { 1 }
+
         it { is_expected.to is_lower_than 2 }
       end
 
-      RSpec.describe 1 do
+      RSpec.describe "Integer" do
+        subject(:number) { 1 }
+
         it { is_expected.not_to is_lower_than 'a' }
       end
 
@@ -448,7 +462,9 @@ Feature: Defining a custom matcher
 
       RSpec::Matchers.alias_matcher :be_n_of , :be_a_multiple_of
 
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject(:number) { 9 }
+
         it { is_expected.to be_n_of(3) }
       end
       """

--- a/rspec-expectations/features/custom_matchers/define_matcher_with_fluent_interface.feature
+++ b/rspec-expectations/features/custom_matchers/define_matcher_with_fluent_interface.feature
@@ -15,7 +15,9 @@ Feature: Defining a matcher with fluent interface
         end
       end
 
-      RSpec.describe 5 do
+      RSpec.describe "Integer" do
+        subject(:number) { 5 }
+
         it { is_expected.to be_bigger_than(4).and_smaller_than(6) }
       end
       """
@@ -34,7 +36,9 @@ Feature: Defining a matcher with fluent interface
         chain :and_smaller_than, :second
       end
 
-      RSpec.describe 5 do
+      RSpec.describe "Integer" do
+        subject(:number) { 5 }
+
         it { is_expected.to be_bigger_than(4).and_smaller_than(6) }
       end
       """
@@ -61,7 +65,9 @@ Feature: Defining a matcher with fluent interface
           end
         end
 
-        RSpec.describe 5 do
+        RSpec.describe "Integer" do
+        subject(:number) { 5 }
+
           it { is_expected.to be_bigger_than(4).and_smaller_than(6) }
         end
         """

--- a/rspec-expectations/features/syntax_configuration.feature
+++ b/rspec-expectations/features/syntax_configuration.feature
@@ -81,6 +81,7 @@ Feature: Syntax Configuration
     Given a file named "spec/spec_helper.rb" with:
       """ruby
       RSpec.configure do |config|
+        config.order = :random
         config.expect_with :rspec do |expectations|
           expectations.syntax = [:should, :expect]
         end

--- a/rspec-expectations/features/syntax_configuration.feature
+++ b/rspec-expectations/features/syntax_configuration.feature
@@ -44,7 +44,7 @@ Feature: Syntax Configuration
       """
     When I run `rspec`
     Then the examples should all pass
-    And the output should contain "Using `should` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax is deprecated"
+    And the output should contain "Using `should` from rspec-expectations' old `:should` syntax is deprecated"
 
   Scenario: Disable should syntax
     Given a file named "spec/spec_helper.rb" with:
@@ -89,5 +89,5 @@ Feature: Syntax Configuration
       """
     When I run `rspec`
     Then the examples should all pass
-     And the output should not contain "deprecated"
-
+    And the output should contain "syntax= is deprecated"
+    And the output should not contain "`should` syntax is deprecated"

--- a/rspec-expectations/features/test_frameworks/minitest.feature
+++ b/rspec-expectations/features/test_frameworks/minitest.feature
@@ -109,3 +109,27 @@ Feature: Minitest integration
       And the output should contain "expected ZeroDivisionError but nothing was raised"
       And the output should contain "Got 2 failures from failure aggregation block"
       And the output should contain "Expected [1, 2] to be empty?"
+
+  Scenario: Use rspec/expectations with minitest/spec and the deprecated should syntax
+    Given a file named "rspec_expectations_spec.rb" with:
+      """ruby
+      require 'minitest/autorun'
+      require 'minitest/spec'
+      require 'rspec/expectations/minitest_integration'
+
+      RSpec::Matchers.configuration.syntax = [:should]
+
+      describe "Using RSpec::Expectations with Minitest::Spec" do
+        it 'passes an expectation' do
+          (1 + 3).should eq 4
+        end
+
+        it 'fails an expectation' do
+          [1, 2].should be_empty
+        end
+      end
+      """
+     When I run `ruby rspec_expectations_spec.rb`
+     Then the output should contain "2 runs, 0 assertions, 1 failures, 0 errors"
+      And the output should contain "expected `[1, 2].empty?` to be truthy, got false"
+      And the output should contain "syntax= is deprecated"

--- a/rspec-expectations/lib/rspec/expectations/syntax.rb
+++ b/rspec-expectations/lib/rspec/expectations/syntax.rb
@@ -25,10 +25,7 @@ module RSpec
       def warn_about_should_unless_configured(method_name)
         return unless @warn_about_should
 
-        RSpec.deprecate(
-          "Using `#{method_name}` from rspec-expectations' old `:should` syntax without explicitly enabling the syntax",
-          :replacement => "the new `:expect` syntax or explicitly enable `:should` with `config.expect_with(:rspec) { |c| c.syntax = :should }`"
-        )
+        RSpec.deprecate("Using `#{method_name}` from rspec-expectations' old `:should` syntax", :replacement => "the `:expect` syntax")
 
         @warn_about_should = false
       end

--- a/rspec-expectations/lib/rspec/expectations/version.rb
+++ b/rspec-expectations/lib/rspec/expectations/version.rb
@@ -2,7 +2,7 @@ module RSpec
   module Expectations
     # @private
     module Version
-      STRING = '3.13.5'
+      STRING = '3.99.0'
     end
   end
 end

--- a/rspec-expectations/lib/rspec/matchers.rb
+++ b/rspec-expectations/lib/rspec/matchers.rb
@@ -697,7 +697,8 @@ module RSpec
     def match(expected)
       BuiltIn::Match.new(expected)
     end
-    alias_matcher :match_regex, :match
+    # @deprecated
+    alias_matcher :match_regex, :match, :deprecated => "`RSpec::Expectations::Matchers#match_regex`"
     alias_matcher :an_object_matching, :match
     alias_matcher :a_string_matching, :match
     alias_matcher :matching, :match

--- a/rspec-expectations/lib/rspec/matchers/built_in/contain_exactly.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/contain_exactly.rb
@@ -1,7 +1,6 @@
 module RSpec
   module Matchers
     module BuiltIn
-      # rubocop:disable Metrics/ClassLength
       # @api private
       # Provides the implementation for `contain_exactly` and `match_array`.
       # Not intended to be instantiated directly.
@@ -306,7 +305,6 @@ module RSpec
           end
         end
       end
-      # rubocop:enable Metrics/ClassLength
     end
   end
 end

--- a/rspec-expectations/lib/rspec/matchers/built_in/start_or_end_with.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/start_or_end_with.rb
@@ -58,7 +58,15 @@ module RSpec
       # we still provide this constant until 4.0.
       # @deprecated Use StartOrEndWith instead.
       # @private
-      StartAndEndWith = StartOrEndWith
+      class StartAndEndWith < StartOrEndWith
+        def initialize(*args)
+          RSpec.deprecate(
+            "RSpec::Matchers::BuiltIn::StartAndEndWith",
+            :replacement => "RSpec::Matchers::BuiltIn::StartOrEndWith"
+          )
+          super
+        end
+      end
 
       # @api private
       # Provides the implementation for `start_with`.

--- a/rspec-expectations/lib/rspec/matchers/dsl.rb
+++ b/rspec-expectations/lib/rspec/matchers/dsl.rb
@@ -36,6 +36,10 @@ module RSpec
         klass = options.fetch(:klass) { AliasedMatcher }
 
         define_method(new_name) do |*args, &block|
+          if options[:deprecated]
+            RSpec.deprecate(options[:deprecated], :replacement => "`#{old_name}`")
+          end
+
           matcher = __send__(old_name, *args, &block)
           matcher.matcher_name = new_name if matcher.respond_to?(:matcher_name=)
           klass.new(matcher, description_override)

--- a/rspec-expectations/spec/rspec/matchers/aliases_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/aliases_spec.rb
@@ -276,7 +276,8 @@ module RSpec
       ).with_description('an object matching /foo/')
     end
 
-    specify do
+    it 'prints a deprecation warning for `match_regex`', :skip => RSpec::Support::Ruby.jruby? do
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 2, /match_regex/)
       expect(
         match_regex(/foo/)
       ).to be_aliased_to(

--- a/rspec-expectations/spec/rspec/matchers/built_in/base_matcher_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/base_matcher_spec.rb
@@ -104,23 +104,23 @@ module RSpec::Matchers::BuiltIn
       end
 
       context "for a DSL-defined custom matcher" do
-        include_examples "detecting default failure message" do
-          def build_matcher(&block)
-            definition = Proc.new do
-              match {}
-              module_exec(&block) if block
-            end
+        include_examples "detecting default failure message"
 
-            RSpec::Matchers::DSL::Matcher.new(:matcher_name, definition, self)
+        def build_matcher(&block)
+          definition = Proc.new do
+            match {}
+            module_exec(&block) if block
           end
+
+          RSpec::Matchers::DSL::Matcher.new(:matcher_name, definition, self)
         end
       end
 
       context "for a matcher that subclasses `BaseMatcher`" do
-        include_examples "detecting default failure message" do
-          def build_matcher(&block)
-            Class.new(RSpec::Matchers::BuiltIn::BaseMatcher, &block).new
-          end
+        include_examples "detecting default failure message"
+
+        def build_matcher(&block)
+          Class.new(RSpec::Matchers::BuiltIn::BaseMatcher, &block).new
         end
       end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/has_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/has_spec.rb
@@ -4,6 +4,42 @@ RSpec.describe "expect(...).to have_sym(*args)" do
     let(:matcher) { have_key(:a) }
   end
 
+  context "when strict_predicate_matchers is not set it behaves like it was set to false" do
+    # rubocop:disable Style/RedundantBegin
+    around do |example|
+      begin
+        orig_config  = RSpec::Expectations.configuration
+
+        RSpec::Expectations.configuration = RSpec::Expectations::Configuration.new
+
+        example.run
+      ensure
+        RSpec::Expectations.configuration = orig_config
+      end
+    end
+    # rubocop:enable Style/RedundantBegin
+
+    it "passes if #has_sym?(*args) returns truthy" do
+      actual = double("actual", :has_foo? => 42)
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /did not return a boolean result/)
+      expect(actual).to have_foo
+    end
+
+    it "allows dynamic matchers to pass for supplied methods on spies" do
+      thing = spy("thing", :has_furg? => 42)
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /did not return a boolean result/)
+      expect(thing).to have_furg(:furg)
+    end
+
+    it "does not allow dynamic matchers to pass for inferred methods on spies" do
+      thing = spy("thing")
+      expect {
+        expect(thing).to have_furg(:foo)
+      }.to fail
+      expect(thing).not_to have_received(:furg?)
+    end
+  end
+
   it "passes if #has_sym?(*args) returns true" do
     expect({ :a => "A" }).to have_key(:a)
   end
@@ -157,6 +193,42 @@ RSpec.describe "expect(...).not_to have_sym(*args)" do
 
     it "passes if #has_sym?(*args) returns nil" do
       actual = double("actual", :has_foo? => nil)
+      expect(actual).not_to have_foo
+    end
+
+    it "allows dynamic matchers to pass for supplied methods on spies" do
+      thing = spy("thing", :furg? => true)
+      expect(thing).to be_furg(:foo)
+      expect(thing).to have_received(:furg?).with(:foo)
+    end
+
+    it "does not allow dynamic matchers to pass for inferred methods on spies" do
+      thing = spy("thing")
+      expect {
+        expect(thing).to be_furg(:foo)
+      }.to fail
+      expect(thing).not_to have_received(:furg?)
+    end
+  end
+
+  context "when strict_predicate_matchers is not set it behaves like it was set to false" do
+    # rubocop:disable Style/RedundantBegin
+    around do |example|
+      begin
+        orig_config  = RSpec::Expectations.configuration
+
+        RSpec::Expectations.configuration = RSpec::Expectations::Configuration.new
+
+        example.run
+      ensure
+        RSpec::Expectations.configuration = orig_config
+      end
+    end
+    # rubocop:enable Style/RedundantBegin
+
+    it "passes if #has_sym?(*args) returns nil" do
+      actual = double("actual", :has_foo? => nil)
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /did not return a boolean result/)
       expect(actual).not_to have_foo
     end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/output_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/output_spec.rb
@@ -4,9 +4,11 @@ RSpec.shared_examples "output_to_stream" do |stream_name, matcher_method, helper
 
   it_behaves_like "an RSpec block-only matcher" do
     let(:matcher) { output(/fo/).send(matcher_method) }
+
     def valid_block
       print_to_stream('foo')
     end
+
     def invalid_block
     end
   end

--- a/rspec-expectations/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe "expect { ... }.to raise_error" do
   end
 
   it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /warn_about_potential_false_positives/)
     RSpec::Expectations.configuration.warn_about_potential_false_positives = false
     expect_no_warnings
     expect { raise }.to raise_error
@@ -183,6 +184,7 @@ RSpec.describe "expect { ... }.not_to raise_error" do
     end
 
     it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /warn_about_potential_false_positives/)
       RSpec::Expectations.configuration.warn_about_potential_false_positives = false
       expect_no_warnings
       expect { "bees" }.not_to raise_error(RuntimeError)
@@ -292,12 +294,14 @@ end
 
 RSpec.describe "expect { ... }.not_to raise_error('message')" do
   it "issues a warning when configured to do so", :warn_about_potential_false_positives do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /warn_about_potential_false_positives/)
     RSpec::Expectations.configuration.warn_about_potential_false_positives = true
     expect_warning_with_call_site __FILE__, __LINE__+1, /not_to raise_error\(message\)` risks false positives/
     expect { raise 'blarg' }.not_to raise_error('blah')
   end
 
   it "supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /warn_about_potential_false_positives/)
     RSpec::Expectations.configuration.warn_about_potential_false_positives = false
     expect_no_warnings
     expect { raise 'blarg' }.not_to raise_error('blah')
@@ -306,12 +310,14 @@ end
 
 RSpec.describe "expect { ... }.not_to raise_error(/message/)" do
   it "issues a warning when configured to do so", :warn_about_potential_false_positives do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /warn_about_potential_false_positives/)
     RSpec::Expectations.configuration.warn_about_potential_false_positives = true
     expect_warning_with_call_site __FILE__, __LINE__+1, /not_to raise_error\(message\)` risks false positives/
     expect { raise 'blarg' }.not_to raise_error(/blah/)
   end
 
   it "supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /warn_about_potential_false_positives/)
     RSpec::Expectations.configuration.warn_about_potential_false_positives = false
     expect_no_warnings
     expect { raise 'blarg' }.not_to raise_error(/blah/)
@@ -349,6 +355,7 @@ RSpec.describe "expect { ... }.not_to raise_error(NamedError)" do
   end
 
   it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /warn_about_potential_false_positives/)
     RSpec::Expectations.configuration.warn_about_potential_false_positives = false
     expect_no_warnings
     expect {}.not_to raise_error(NameError)
@@ -386,6 +393,7 @@ RSpec.describe "expect { ... }.not_to raise_error(NamedError, error_message) wit
   end
 
   it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /warn_about_potential_false_positives/)
     RSpec::Expectations.configuration.warn_about_potential_false_positives = false
     expect_no_warnings
     expect {}.not_to raise_error(RuntimeError, "example message")
@@ -424,6 +432,7 @@ RSpec.describe "expect { ... }.not_to raise_error(NamedError, error_message) wit
   end
 
   it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /warn_about_potential_false_positives/)
     RSpec::Expectations.configuration.warn_about_potential_false_positives = false
     expect_no_warnings
     expect {}.not_to raise_error(RuntimeError, /ample mess/)
@@ -510,6 +519,7 @@ RSpec.describe "expect { ... }.not_to raise_error(NamedError, error_message) { |
   end
 
   it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /warn_about_potential_false_positives/)
     RSpec::Expectations.configuration.warn_about_potential_false_positives = false
     expect_no_warnings
     expect {}.not_to raise_error(RuntimeError, "example message") { |err| }

--- a/rspec-expectations/spec/rspec/matchers/built_in/start_and_end_with_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/start_and_end_with_spec.rb
@@ -1,4 +1,22 @@
 RSpec.describe "expect(...).to start_with" do
+  it "has a deprecated old constant" do
+    require 'rspec/matchers/built_in/start_or_end_with'
+
+    deprecated_matcher =
+      Class.new(RSpec::Matchers::BuiltIn::StartAndEndWith) do
+        def subset_matches?
+          values_match?(expected, actual[0, expected.length])
+        end
+
+        def element_matches?
+          values_match?(expected, actual[0])
+        end
+      end
+
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /StartAndEndWith/)
+    expect("abd").to deprecated_matcher.new("ab")
+  end
+
   it_behaves_like "an RSpec value matcher", :valid_value => "ab", :invalid_value => "bc" do
     let(:matcher) { start_with("a") }
   end

--- a/rspec-expectations/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/yield_spec.rb
@@ -37,13 +37,13 @@ end
 # and lambdas that take the expectation target in a way that they accept
 # a probe.
 RSpec.shared_examples "an RSpec probe-yielding block-only matcher" do |*options|
-  include_examples "an RSpec block-only matcher", { :expects_lambda => true }.merge(options.first || {}) do
-    let(:valid_expectation) { expect { |block| valid_block(&block) } }
-    let(:invalid_expectation) { expect { |block| invalid_block(&block) } }
+  include_examples "an RSpec block-only matcher", { :expects_lambda => true }.merge(options.first || {})
 
-    let(:valid_block_lambda) { lambda { |block| valid_block(&block) } }
-    let(:invalid_block_lambda) { lambda { |block| invalid_block(&block) } }
-  end
+  let(:valid_expectation) { expect { |block| valid_block(&block) } }
+  let(:invalid_expectation) { expect { |block| invalid_block(&block) } }
+
+  let(:valid_block_lambda) { lambda { |block| valid_block(&block) } }
+  let(:invalid_block_lambda) { lambda { |block| invalid_block(&block) } }
 end
 
 RSpec.describe "yield_control matcher" do

--- a/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
@@ -394,19 +394,23 @@ module RSpec::Matchers::DSL
         include_context "isolate include_chain_clauses_in_custom_matcher_descriptions"
 
         context "without include_chain_clauses_in_custom_matcher_descriptions configured" do
-          before { RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = false }
-          let(:match) { matcher.and_smaller_than(10).and_divisible_by(3) }
+          before do
+            expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /include_chain_clauses_in_custom_matcher_descriptions/)
+            RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = false
+          end
+
+          let(:chained_matcher) { matcher.and_smaller_than(10).and_divisible_by(3) }
 
           it "provides a default description that does not include any of the chained matchers' descriptions" do
-            expect(match.description).to eq 'be bigger than 5'
+            expect(chained_matcher.description).to eq 'be bigger than 5'
           end
 
           it "provides a default positive expectation failure message that does not include any of the chained matchers' descriptions" do
-            expect { expect(8).to match }.to fail_with 'expected 8 to be bigger than 5'
+            expect { expect(8).to chained_matcher }.to fail_with 'expected 8 to be bigger than 5'
           end
 
           it "provides a default negative expectation failure message that does not include the any of the chained matchers's descriptions" do
-            expect { expect(9).to_not match }.to fail_with 'expected 9 not to be bigger than 5'
+            expect { expect(9).to_not chained_matcher }.to fail_with 'expected 9 not to be bigger than 5'
           end
         end
 
@@ -434,6 +438,7 @@ module RSpec::Matchers::DSL
         it 'only decides if to include the chained clauses at the time description is invoked' do
           matcher.and_divisible_by(3)
 
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 2, /include_chain_clauses_in_custom_matcher_descriptions/)
           expect {
             RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = false
           }.to change { matcher.description }.
@@ -926,7 +931,10 @@ module RSpec::Matchers::DSL
 
         context "with include_chain_clauses_in_custom_matcher_descriptions configured to false" do
           include_context "isolate include_chain_clauses_in_custom_matcher_descriptions"
-          before { RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = false }
+          before do
+            expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /include_chain_clauses_in_custom_matcher_descriptions/)
+            RSpec::Expectations.configuration.include_chain_clauses_in_custom_matcher_descriptions = false
+          end
 
           it "provides a default description that does not include any of the chained matchers' descriptions" do
             expect(matcher.and_divisible_by(10).description).to eq 'be even and divisible by 10'

--- a/rspec-expectations/spec/spec_helper.rb
+++ b/rspec-expectations/spec/spec_helper.rb
@@ -81,7 +81,9 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |expectations|
     $default_expectation_syntax = expectations.syntax # rubocop:disable Style/GlobalVars
-    expectations.syntax = :expect
+    config.suppress_deprecations do
+      expectations.syntax = :expect
+    end
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
     expectations.strict_predicate_matchers = true
   end
@@ -107,11 +109,15 @@ RSpec.shared_context "with #should enabled", :uses_should do
 
   before(:all) do
     orig_syntax = RSpec::Matchers.configuration.syntax
-    RSpec::Matchers.configuration.syntax = [:expect, :should]
+    RSpec.configuration.suppress_deprecations do
+      RSpec::Matchers.configuration.syntax = [:expect, :should]
+    end
   end
 
   after(:context) do
-    RSpec::Matchers.configuration.syntax = orig_syntax
+    RSpec.configuration.suppress_deprecations do
+      RSpec::Matchers.configuration.syntax = orig_syntax
+    end
   end
 end
 
@@ -124,9 +130,10 @@ RSpec.shared_context "with the default expectation syntax" do
   end
 
   after(:context) do
-    RSpec::Matchers.configuration.syntax = orig_syntax
+    RSpec.configuration.suppress_deprecations do
+      RSpec::Matchers.configuration.syntax = orig_syntax
+    end
   end
-
 end
 
 RSpec.shared_context "with #should exclusively enabled", :uses_only_should do
@@ -134,11 +141,15 @@ RSpec.shared_context "with #should exclusively enabled", :uses_only_should do
 
   before(:context) do
     orig_syntax = RSpec::Matchers.configuration.syntax
-    RSpec::Matchers.configuration.syntax = :should
+    RSpec.configuration.suppress_deprecations do
+      RSpec::Matchers.configuration.syntax = :should
+    end
   end
 
   after(:context) do
-    RSpec::Matchers.configuration.syntax = orig_syntax
+    RSpec.configuration.suppress_deprecations do
+      RSpec::Matchers.configuration.syntax = orig_syntax
+    end
   end
 end
 
@@ -151,9 +162,16 @@ RSpec.shared_context "isolate include_chain_clauses_in_custom_matcher_descriptio
 end
 
 RSpec.shared_context "with warn_about_potential_false_positives set to false", :warn_about_potential_false_positives do
-  original_value = RSpec::Expectations.configuration.warn_about_potential_false_positives?
+  original_value =
+    RSpec.configuration.suppress_deprecations do
+      RSpec::Expectations.configuration.warn_about_potential_false_positives?
+    end
 
-  after(:context)  { RSpec::Expectations.configuration.warn_about_potential_false_positives = original_value }
+  after(:context)  do
+    RSpec.configuration.suppress_deprecations do
+      RSpec::Expectations.configuration.warn_about_potential_false_positives = original_value
+    end
+  end
 end
 
 module MinitestIntegration

--- a/rspec-expectations/spec/spec_helper.rb
+++ b/rspec-expectations/spec/spec_helper.rb
@@ -73,7 +73,7 @@ module CommonHelperMethods
 end
 
 RSpec.configure do |config|
-  config.color = true
+  config.color_mode = :automatic
   config.order = :random
 
   config.include CommonHelperMethods
@@ -90,7 +90,9 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
-  config.disable_monkey_patching!
+  config.suppress_deprecations do
+    config.disable_monkey_patching!
+  end
 
   # We don't want rspec-core to look in our `lib` for failure snippets.
   # When it does that, it inevitably finds this line:

--- a/rspec-expectations/spec/support/shared_examples/block_matcher.rb
+++ b/rspec-expectations/spec/support/shared_examples/block_matcher.rb
@@ -68,12 +68,16 @@ RSpec.shared_examples "an RSpec block-only matcher" do |*options|
 
   it 'fails gracefully when given a value' do
     expect {
-      expect(3).to matcher
+      RSpec.configuration.suppress_deprecations do
+        expect(3).to matcher
+      end
     }.to fail_with(/was not( given)? a block/)
 
     unless options[:disallows_negation]
       expect {
-        expect(3).not_to matcher
+        RSpec.configuration.suppress_deprecations do
+          expect(3).not_to matcher
+        end
       }.to fail_with(/was not( given)? a block/)
     end
   end

--- a/rspec-mocks/Changelog.md
+++ b/rspec-mocks/Changelog.md
@@ -1,5 +1,5 @@
 ### Development
-[Full Changelog](https://github.com/rspec/rspec/compare/rspec-mocks-v3.13.6...3-13-maintenance)
+[Full Changelog](https://github.com/rspec/rspec/compare/rspec-mocks-v3.13.6...3-99-maintenance)
 
 ### 3.13.6 / 2025-10-14
 [Full Changelog](https://github.com/rspec/rspec/compare/rspec-mocks-v3.13.5...rspec-mocks-v3.13.6)

--- a/rspec-mocks/lib/rspec/mocks/configuration.rb
+++ b/rspec-mocks/lib/rspec/mocks/configuration.rb
@@ -10,6 +10,9 @@ module RSpec
         @verify_partial_doubles = false
         @temporarily_suppress_partial_double_verification = false
         @color = false
+
+        # Temporary config for 3.99
+        @warn_about_verify_partial_doubles = true
       end
 
       # Sets whether RSpec will warn, ignore, or fail a test when
@@ -79,6 +82,10 @@ module RSpec
       #  end
       #
       def syntax=(*values)
+        RSpec.deprecate(
+          "RSpec::Mocks::Configuration#syntax=",
+          :replacement => "the expect syntax, which is the only option in RSpec 4"
+        )
         syntaxes = values.flatten
         if syntaxes.include?(:expect)
           Syntax.enable_expect
@@ -148,10 +155,19 @@ module RSpec
       # doubles. Any stubs will have their arguments checked against the original
       # method, and methods that do not exist cannot be stubbed.
       def verify_partial_doubles=(val)
+        @warn_about_verify_partial_doubles = false
         @verify_partial_doubles = !!val
       end
 
       def verify_partial_doubles?
+        if @warn_about_verify_partial_doubles
+          RSpec.deprecate(
+            "Default setting of `false` for `RSpec::Mocks::Configuration#verify_partial_doubles`",
+            :replacement => "`verify_partial_doubles = false` explicitly, or set to `true` and remove in RSpec 4"
+          )
+          @warn_about_verify_partial_doubles = false
+        end
+
         @verify_partial_doubles
       end
 
@@ -196,7 +212,8 @@ module RSpec
       # @api private
       # Resets the configured syntax to the default.
       def reset_syntaxes_to_default
-        self.syntax = [:should, :expect]
+        Syntax.enable_should
+        Syntax.enable_expect
         RSpec::Mocks::Syntax.warn_about_should!
       end
     end

--- a/rspec-mocks/lib/rspec/mocks/example_methods.rb
+++ b/rspec-mocks/lib/rspec/mocks/example_methods.rb
@@ -199,6 +199,10 @@ module RSpec
       # early on.
       # @deprecated Use {RSpec::Mocks::Configuration#allow_message_expectations_on_nil} instead.
       def allow_message_expectations_on_nil
+        RSpec.deprecate(
+          "RSpec::Core::Example#allow_message_expectations_on_nil",
+          :replacement => "RSpec::Mocks::Configuration#allow_message_expectations_on_nil"
+        )
         RSpec::Mocks.space.proxy_for(nil).warn_about_expectations = false
       end
 

--- a/rspec-mocks/lib/rspec/mocks/syntax.rb
+++ b/rspec-mocks/lib/rspec/mocks/syntax.rb
@@ -10,12 +10,9 @@ module RSpec
       end
 
       # @private
-      def self.warn_unless_should_configured(method_name , replacement="the new `:expect` syntax or explicitly enable `:should`")
+      def self.warn_unless_should_configured(method_name , replacement="the `:expect` syntax")
         if @warn_about_should
-          RSpec.deprecate(
-            "Using `#{method_name}` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax",
-            :replacement => replacement
-          )
+          RSpec.deprecate("Using `#{method_name}` from rspec-mocks' old `:should` syntax", :replacement => replacement)
 
           @warn_about_should = false
         end

--- a/rspec-mocks/lib/rspec/mocks/version.rb
+++ b/rspec-mocks/lib/rspec/mocks/version.rb
@@ -3,7 +3,7 @@ module RSpec
     # Version information for RSpec mocks.
     module Version
       # Version of RSpec mocks currently in use in SemVer format.
-      STRING = '3.13.6'
+      STRING = '3.99.0'
     end
   end
 end

--- a/rspec-mocks/spec/rspec/mocks/before_all_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/before_all_spec.rb
@@ -2,74 +2,74 @@ require 'support/before_all_shared_example_group'
 
 RSpec.describe "Using rspec-mocks features in before(:all) blocks" do
   describe "#stub_const" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        stub_const("SomeNewConst", Class.new)
-      end
+    include_examples "fails in a before(:all) block"
 
-      it 'does not stub the const' do
-        expect(defined?(SomeNewConst)).to be_falsey
-      end
+    def use_rspec_mocks
+      stub_const("SomeNewConst", Class.new)
+    end
+
+    it 'does not stub the const' do
+      expect(defined?(SomeNewConst)).to be_falsey
     end
   end
 
   describe "#hide_const(for an undefined const)" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        hide_const("Foo")
-      end
+    include_examples "fails in a before(:all) block"
+
+    def use_rspec_mocks
+      hide_const("Foo")
     end
   end
 
   describe "#hide_const(for a defined const)" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        hide_const("Float")
-      end
+    include_examples "fails in a before(:all) block"
 
-      it 'does not hide the const' do
-        expect(defined?(Float)).to be_truthy
-      end
+    def use_rspec_mocks
+      hide_const("Float")
+    end
+
+    it 'does not hide the const' do
+      expect(defined?(Float)).to be_truthy
     end
   end
 
   describe "allow(...).to receive_message_chain" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        allow(Object).to receive_message_chain(:foo, :bar)
-      end
+    include_examples "fails in a before(:all) block"
+
+    def use_rspec_mocks
+      allow(Object).to receive_message_chain(:foo, :bar)
     end
   end
 
   describe "#expect(...).to receive" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        expect(Object).to receive(:foo)
-      end
+    include_examples "fails in a before(:all) block"
+
+    def use_rspec_mocks
+      expect(Object).to receive(:foo)
     end
   end
 
   describe "#allow(...).to receive" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        allow(Object).to receive(:foo)
-      end
+    include_examples "fails in a before(:all) block"
+
+    def use_rspec_mocks
+      allow(Object).to receive(:foo)
     end
   end
 
   describe "#expect_any_instance_of(...).to receive" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        expect_any_instance_of(Object).to receive(:foo)
-      end
+    include_examples "fails in a before(:all) block"
+
+    def use_rspec_mocks
+      expect_any_instance_of(Object).to receive(:foo)
     end
   end
 
   describe "#allow_any_instance_of(...).to receive" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        allow_any_instance_of(Object).to receive(:foo)
-      end
+    include_examples "fails in a before(:all) block"
+
+    def use_rspec_mocks
+      allow_any_instance_of(Object).to receive(:foo)
     end
   end
 end

--- a/rspec-mocks/spec/rspec/mocks/configuration_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/configuration_spec.rb
@@ -39,6 +39,7 @@ module RSpec
           # config setting, which makes it hard to get at the original
           # default value. in spec_helper.rb we store the default value
           # in $default_rspec_mocks_syntax so we can use it here.
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /syntax=/)
           RSpec::Mocks.configuration.syntax = $default_rspec_mocks_syntax
           expect(dbl).to respond_to(*should_methods)
           expect(self).to respond_to(*expect_methods)
@@ -130,7 +131,9 @@ module RSpec
       describe "configuring rspec-mocks directly" do
         it_behaves_like "configuring the syntax" do
           def configure_syntax(syntax)
-            RSpec::Mocks.configuration.syntax = syntax
+            RSpec.configuration.suppress_deprecations do
+              RSpec::Mocks.configuration.syntax = syntax
+            end
           end
 
           def configured_syntax
@@ -148,7 +151,9 @@ module RSpec
           def configure_syntax(syntax)
             RSpec.configure do |rspec|
               rspec.mock_with :rspec do |c|
-                c.syntax = syntax
+                rspec.suppress_deprecations do
+                  c.syntax = syntax
+                end
               end
             end
           end
@@ -182,6 +187,14 @@ module RSpec
             config.when_declaring_verifying_double(&block2)
             expect(config.verifying_double_callbacks).to eq [block, block2]
           end
+        end
+      end
+
+      describe "#verify_partial_doubles?" do
+        it "will issue a deprecation if config value hasn't been explicitly set" do
+          config = RSpec::Mocks::Configuration.new
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /Default.*verify_partial_doubles/)
+          config.verify_partial_doubles?
         end
       end
     end

--- a/rspec-mocks/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -677,12 +677,12 @@ module RSpec
     end
 
     RSpec.describe Matchers::HaveReceived, "when used in a context that has rspec-mocks and rspec-expectations available" do
-      include_examples Matchers::HaveReceived do
-        # Override `fail_including` for this context, since `have_received` is a normal
-        # rspec-expectations matcher, the error class is different.
-        def fail_including(*snippets)
-          raise_error(RSpec::Expectations::ExpectationNotMetError, a_string_including(*snippets))
-        end
+      include_examples Matchers::HaveReceived
+
+      # Override `fail_including` for this context, since `have_received` is a normal
+      # rspec-expectations matcher, the error class is different.
+      def fail_including(*snippets)
+        raise_error(RSpec::Expectations::ExpectationNotMetError, a_string_including(*snippets))
       end
     end
 

--- a/rspec-mocks/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/matchers/receive_spec.rb
@@ -780,6 +780,9 @@ module RSpec
         end
 
         it 'can toggle the available syntax' do
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 4, /syntax=/)
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 5, /syntax=/)
+
           expect(framework.new).to respond_to(:expect)
           RSpec::Mocks.configuration.syntax = :should
           expect(framework.new).not_to respond_to(:expect)
@@ -787,7 +790,11 @@ module RSpec
           expect(framework.new).to respond_to(:expect)
         end
 
-        after { RSpec::Mocks.configuration.syntax = :expect }
+        after do
+          RSpec.configuration.suppress_deprecations do
+            RSpec::Mocks.configuration.syntax = :expect
+          end
+        end
       end
 
       context "when rspec-expectations is included in the test framework first" do

--- a/rspec-mocks/spec/rspec/mocks/nil_expectation_warning_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/nil_expectation_warning_spec.rb
@@ -22,6 +22,7 @@ module RSpec
       end
 
       it 'does not issue a warning when expectations are set to be allowed' do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /allow_message_expectations_on_nil/)
         allow_message_expectations_on_nil
 
         expect {
@@ -68,6 +69,7 @@ module RSpec
       include_context "with monkey-patched marshal"
 
       it "does not affect subsequent examples" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /allow_message_expectations_on_nil/)
         allow_message_expectations_on_nil
         RSpec::Mocks.teardown
         RSpec::Mocks.setup
@@ -83,6 +85,7 @@ module RSpec
       end
 
       it 'doesnt error when marshalled' do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /allow_message_expectations_on_nil/)
         allow_message_expectations_on_nil
         expect(Marshal.dump(nil)).to eq Marshal.dump_without_rspec_mocks(nil)
       end

--- a/rspec-mocks/spec/rspec/mocks/partial_double_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/partial_double_spec.rb
@@ -143,6 +143,7 @@ module RSpec
       end
 
       it "uses reports nil in the error message" do
+        expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /allow_message_expectations_on_nil/)
         allow_message_expectations_on_nil
 
         nil_var = nil

--- a/rspec-mocks/spec/rspec/mocks/should_syntax_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/should_syntax_spec.rb
@@ -460,23 +460,20 @@ RSpec.context "with default syntax configuration" do
   orig_syntax = nil
 
   before(:all) { orig_syntax = RSpec::Mocks.configuration.syntax }
-  after(:all)  { RSpec::Mocks.configuration.syntax = orig_syntax }
   before       { RSpec::Mocks.configuration.reset_syntaxes_to_default }
 
+  after(:all) do
+    RSpec.configuration.suppress_deprecations do
+      RSpec::Mocks.configuration.syntax = orig_syntax
+    end
+  end
+
   if RSpec::Support::RubyFeatures.required_kw_args_supported?
-    let(:expected_arguments) {
-      [
-        /Using.*without explicitly enabling/,
-      ]
-    }
-    let(:expected_keywords) {
-      {:replacement => "the new `:expect` syntax or explicitly enable `:should`"}
-    }
     it "it warns about should once, regardless of how many times it is called" do
-      # Use eval to avoid syntax error on 1.8 and 1.9
-      eval("expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)")
       o = Object.new
       o2 = Object.new
+
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /should_receive` from rspec-mocks/)
       o.should_receive(:bees)
       o2.should_receive(:bees)
 
@@ -485,34 +482,28 @@ RSpec.context "with default syntax configuration" do
     end
 
     it "warns about should not once, regardless of how many times it is called" do
-      # Use eval to avoid syntax error on 1.8 and 1.9
-      eval("expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)")
       o = Object.new
       o2 = Object.new
+
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /should_not_receive` from rspec-mocks/)
       o.should_not_receive(:bees)
       o2.should_not_receive(:bees)
     end
 
     it "warns about stubbing once, regardless of how many times it is called" do
-      # Use eval to avoid syntax error on 1.8 and 1.9
-      eval("expect(RSpec).to receive(:deprecate).with(*expected_arguments, **expected_keywords)")
       o = Object.new
       o2 = Object.new
 
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /stub` from rspec-mocks/)
       o.stub(:faces)
       o2.stub(:faces)
     end
   else
-    let(:expected_arguments) {
-      [
-        /Using.*without explicitly enabling/,
-        {:replacement => "the new `:expect` syntax or explicitly enable `:should`"}
-      ]
-    }
     it "it warns about should once, regardless of how many times it is called" do
-      expect(RSpec).to receive(:deprecate).with(*expected_arguments)
       o = Object.new
       o2 = Object.new
+
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /should_receive` from rspec-mocks/)
       o.should_receive(:bees)
       o2.should_receive(:bees)
 
@@ -521,26 +512,26 @@ RSpec.context "with default syntax configuration" do
     end
 
     it "warns about should not once, regardless of how many times it is called" do
-      expect(RSpec).to receive(:deprecate).with(*expected_arguments)
       o = Object.new
       o2 = Object.new
+
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /should_not_receive` from rspec-mocks/)
       o.should_not_receive(:bees)
       o2.should_not_receive(:bees)
     end
 
     it "warns about stubbing once, regardless of how many times it is called" do
-      expect(RSpec).to receive(:deprecate).with(*expected_arguments)
       o = Object.new
       o2 = Object.new
 
+      expect_deprecation_with_call_site(__FILE__, __LINE__ + 1, /stub` from rspec-mocks/)
       o.stub(:faces)
       o2.stub(:faces)
     end
   end
 
   it "warns about unstubbing once, regardless of how many times it is called" do
-    expect(RSpec).to receive(:deprecate).with(/Using.*without explicitly enabling/,
-      :replacement => "`allow(...).to receive(...).and_call_original` or explicitly enable `:should`")
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 7, /unstub` from rspec-mocks/)
     o = Object.new
     o2 = Object.new
 
@@ -552,7 +543,7 @@ RSpec.context "with default syntax configuration" do
   end
 
   it "doesn't warn about stubbing after a reset and setting should" do
-    expect(RSpec).not_to receive(:deprecate)
+    expect_deprecation_with_call_site(__FILE__, __LINE__ + 2, /syntax=/)
     RSpec::Mocks.configuration.reset_syntaxes_to_default
     RSpec::Mocks.configuration.syntax = :should
     o = Object.new

--- a/rspec-mocks/spec/spec_helper.rb
+++ b/rspec-mocks/spec/spec_helper.rb
@@ -78,9 +78,11 @@ end
 require 'rspec/support/spec'
 
 RSpec.configure do |config|
-  config.expose_dsl_globally = false
+  config.suppress_deprecations do
+    config.expose_dsl_globally = false
+  end
   config.mock_with :rspec
-  config.color = true
+  config.color_mode = :automatic
   config.order = :random
 
   config.expect_with :rspec do |expectations|

--- a/rspec-mocks/spec/spec_helper.rb
+++ b/rspec-mocks/spec/spec_helper.rb
@@ -81,17 +81,23 @@ RSpec.configure do |config|
   config.suppress_deprecations do
     config.expose_dsl_globally = false
   end
-  config.mock_with :rspec
+
   config.color_mode = :automatic
   config.order = :random
 
   config.expect_with :rspec do |expectations|
-    expectations.syntax = :expect
+    config.suppress_deprecations do
+      expectations.syntax = :expect
+    end
   end
 
   config.mock_with :rspec do |mocks|
     $default_rspec_mocks_syntax = mocks.syntax
-    mocks.syntax = :expect
+    config.suppress_deprecations do
+      mocks.syntax = :expect
+    end
+    # This is being explictly set to silence the warning
+    mocks.verify_partial_doubles = false
   end
 
   old_verbose = nil
@@ -134,11 +140,15 @@ RSpec.shared_context "with syntax" do |syntax|
 
   before(:all) do
     orig_syntax = RSpec::Mocks.configuration.syntax
-    RSpec::Mocks.configuration.syntax = syntax
+    RSpec.configuration.suppress_deprecations do
+      RSpec::Mocks.configuration.syntax = syntax
+    end
   end
 
   after(:all) do
-    RSpec::Mocks.configuration.syntax = orig_syntax
+    RSpec.configuration.suppress_deprecations do
+      RSpec::Mocks.configuration.syntax = orig_syntax
+    end
   end
 end
 
@@ -146,7 +156,9 @@ RSpec.shared_context "with isolated configuration" do
   orig_configuration = nil
   before do
     orig_configuration = RSpec::Mocks.configuration
-    RSpec::Mocks.instance_variable_set(:@configuration, RSpec::Mocks::Configuration.new)
+    isolated_config = RSpec::Mocks::Configuration.new
+    isolated_config.verify_partial_doubles = false
+    RSpec::Mocks.instance_variable_set(:@configuration, isolated_config)
   end
 
   after do
@@ -173,6 +185,8 @@ RSpec.shared_context "with the default mocks syntax" do
   end
 
   after(:all) do
-    RSpec::Mocks.configuration.syntax = orig_syntax
+    RSpec.configuration.suppress_deprecations do
+      RSpec::Mocks.configuration.syntax = orig_syntax
+    end
   end
 end

--- a/rspec-support/.rspec
+++ b/rspec-support/.rspec
@@ -1,4 +1,4 @@
 --order random
---color
+--force-color
 --warnings
 -r spec_helper

--- a/rspec-support/Changelog.md
+++ b/rspec-support/Changelog.md
@@ -1,5 +1,5 @@
 ### Development
-[Full Changelog](https://github.com/rspec/rspec/compare/rspec-support-v3.13.6...3-13-maintenance)
+[Full Changelog](https://github.com/rspec/rspec/compare/rspec-support-v3.13.6...3-99-maintenance)
 
 ### 3.13.6
 [Full Changelog](http://github.com/rspec/rspec/compare/rspec-support-v3.13.5...rspec-support-v3.13.6)

--- a/rspec-support/lib/rspec/support/ruby_features.rb
+++ b/rspec-support/lib/rspec/support/ruby_features.rb
@@ -39,7 +39,7 @@ module RSpec
       end
 
       def rbx?
-        defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
+        !!defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
       end
 
       def non_mri?
@@ -51,7 +51,7 @@ module RSpec
       end
 
       def truffleruby?
-        defined?(RUBY_ENGINE) && RUBY_ENGINE == 'truffleruby'
+        !!defined?(RUBY_ENGINE) && RUBY_ENGINE == 'truffleruby'
       end
     end
 

--- a/rspec-support/lib/rspec/support/version.rb
+++ b/rspec-support/lib/rspec/support/version.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Support
     module Version
-      STRING = '3.13.6'
+      STRING = '3.99.0'
     end
   end
 end

--- a/rspec-support/spec/rspec/support/recursive_const_methods_spec.rb
+++ b/rspec-support/spec/rspec/support/recursive_const_methods_spec.rb
@@ -33,7 +33,9 @@ module RSpec
         end
 
         it 'does not blow up on buggy classes that raise weird errors on `to_str`' do
-          allow(Foo::Bar).to receive(:to_str).and_raise("boom!")
+          without_partial_double_verification do
+            allow(Foo::Bar).to receive(:to_str).and_raise("boom!")
+          end
           const, _ = recursive_const_defined?('::RSpec::Support::Foo::Bar::VAL')
 
           expect(const).to eq(10)

--- a/rspec-support/spec/rspec/support/warnings_spec.rb
+++ b/rspec-support/spec/rspec/support/warnings_spec.rb
@@ -57,10 +57,10 @@ RSpec.describe "rspec warnings and deprecations" do
       warning_object.warning 'Message'
     end
 
-    it_should_behave_like 'warning helper', :warning
+    it_behaves_like 'warning helper', :warning
   end
 
   describe "#warn_with message, options" do
-    it_should_behave_like 'warning helper', :warn_with
+    it_behaves_like 'warning helper', :warn_with
   end
 end

--- a/rspec-support/spec/spec_helper.rb
+++ b/rspec-support/spec/spec_helper.rb
@@ -3,3 +3,13 @@ RSpec::Support::Spec.setup_simplecov
 
 RSpec::Matchers.define_negated_matcher :avoid_raising_errors, :raise_error
 RSpec::Matchers.define_negated_matcher :avoid_changing, :change
+
+RSpec.configure do |c|
+  c.suppress_deprecations do
+    c.disable_monkey_patching!
+  end
+
+  c.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+end

--- a/rspec/lib/rspec/version.rb
+++ b/rspec/lib/rspec/version.rb
@@ -1,5 +1,5 @@
 module RSpec # :nodoc:
   module Version # :nodoc:
-    STRING = '3.13.1'
+    STRING = '3.99.0'
   end
 end


### PR DESCRIPTION
Preparing for upcoming new specification mentioned rspec/rspec#40 , added deprecated warning when example doc string is not a string object

4.0 counterpart https://github.com/rspec/rspec/pull/252 (or #339)

### What is changed

When execute rspec below

```ruby
context do
  it :pending do
    # Only pending option without reason
    expect(true).to eq false
  end

  it pending: 'only pending option' do
    expect(true).to eq false   
  end  

  it 'description with option', pending: 'some reason' do
    expect(true).to eq false
  end
end
```

Output deprecate warning like

```
Deprecation Warnings:

Hash object `{:pending=>"only pending option"}` as example doc string is deprecated. Use a string instead. Called from /home/username/test.rb:7:in `block in <top (required)>'.

Symbol object `:pending` as example doc string is deprecated. Use a string instead. Called from /home/username/test.rb:2:in `block in <top (required)>'.
```

<details>
<summary>Entire output is here</summary>

```
$ bundle exec rspec test.rb --format documentation


  pending (FAILED - 1)
  {:pending=>"only pending option"} (FAILED - 2)
  description with option (PENDING: some reason)

Pending: (Failures listed here are expected and do not affect your suite's status)

  1) description with option
     # some reason
     Failure/Error: expect(true).to eq false
     
       expected: false
            got: true
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -false
       +true
       
     # ./test.rb:12:in `block (2 levels) in <top (required)>'

Failures:

  1) pending
     Failure/Error: expect(true).to eq false
     
       expected: false
            got: true
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -false
       +true
       
     # ./test.rb:4:in `block (2 levels) in <top (required)>'

  2) {:pending=>"only pending option"}
     Failure/Error: expect(true).to eq false
     
       expected: false
            got: true
     
       (compared using ==)
     
       Diff:
       @@ -1 +1 @@
       -false
       +true
       
     # ./test.rb:8:in `block (2 levels) in <top (required)>'

Deprecation Warnings:

Hash object `{:pending=>"only pending option"}` as example doc string is deprecated. Use a string instead. Called from /home/username/test.rb:7:in `block in <top (required)>'.

Symbol object `:pending` as example doc string is deprecated. Use a string instead. Called from /home/username/test.rb:2:in `block in <top (required)>'.


If you need more of the backtrace for any of these deprecations to
identify where to make the necessary changes, you can configure
`config.raise_errors_for_deprecations!`, and it will turn the
deprecation warnings into errors, giving you the full backtrace.

2 deprecation warnings total

Finished in 0.01384 seconds (files took 0.08949 seconds to load)
3 examples, 2 failures, 1 pending

Failed examples:

rspec ./test.rb:2 # pending
rspec ./test.rb:7 # {:pending=>"only pending option"}

```

</details>
