### PR TITLE
[rspec-mocks] Prevent error formatting from causing recursive errors

### DIFF
--- a/rspec-mocks/.rubocop.yml
+++ b/rspec-mocks/.rubocop.yml
@@ -44,7 +44,7 @@ Metrics/MethodLength:
   Max: 49
 
 Metrics/ModuleLength:
-  Max: 220
+  Max: 140
   Exclude:
     - spec/**/*
 

--- a/rspec-mocks/lib/rspec/mocks/message_expectation.rb
+++ b/rspec-mocks/lib/rspec/mocks/message_expectation.rb
@@ -434,7 +434,7 @@ module RSpec
           @expectation_type = type
           @ordered = false
           @at_least = @at_most = @exactly = nil
-          @raised = false
+          @failed = false
 
           # Initialized to nil so that we don't allocate an array for every
           # mock or stub. See also comment in `and_yield`.
@@ -471,7 +471,7 @@ module RSpec
         ruby2_keywords :safe_invoke if respond_to?(:ruby2_keywords, true)
 
         def invoke(parent_stub, *args, &block)
-          if @raised
+          if @failed
             invoke_incrementing_actual_calls_by(0, false, parent_stub, *args, &block)
           else
             invoke_incrementing_actual_calls_by(1, true, parent_stub, *args, &block)
@@ -609,7 +609,7 @@ module RSpec
           args.unshift(orig_object) if yield_receiver_to_implementation_block?
 
           if negative? || (allowed_to_fail && (@exactly || @at_most) && (@actual_received_count == @expected_received_count))
-            @raised = true
+            @failed = true
             # args are the args we actually received, @argument_list_matcher is the
             # list of args we were expecting
             @error_generator.raise_expectation_error(

--- a/rspec-mocks/lib/rspec/mocks/message_expectation.rb
+++ b/rspec-mocks/lib/rspec/mocks/message_expectation.rb
@@ -400,6 +400,9 @@ module RSpec
       end
       alias inspect to_s
 
+      # Implementation details is a long module
+      # rubocop:disable Metrics/ModuleLength
+
       # @private
       # Contains the parts of `MessageExpectation` that aren't part of
       # rspec-mocks' public API. The class is very big and could really use
@@ -699,6 +702,7 @@ module RSpec
 
       include ImplementationDetails
     end
+    # rubocop:enable Metrics/ModuleLength
 
     # Handles the implementation of an `and_yield` declaration.
     # @private

--- a/rspec-mocks/lib/rspec/mocks/message_expectation.rb
+++ b/rspec-mocks/lib/rspec/mocks/message_expectation.rb
@@ -434,6 +434,7 @@ module RSpec
           @expectation_type = type
           @ordered = false
           @at_least = @at_most = @exactly = nil
+          @raised = false
 
           # Initialized to nil so that we don't allocate an array for every
           # mock or stub. See also comment in `and_yield`.
@@ -470,7 +471,11 @@ module RSpec
         ruby2_keywords :safe_invoke if respond_to?(:ruby2_keywords, true)
 
         def invoke(parent_stub, *args, &block)
-          invoke_incrementing_actual_calls_by(1, true, parent_stub, *args, &block)
+          if @raised
+            invoke_incrementing_actual_calls_by(0, false, parent_stub, *args, &block)
+          else
+            invoke_incrementing_actual_calls_by(1, true, parent_stub, *args, &block)
+          end
         end
         ruby2_keywords :invoke if respond_to?(:ruby2_keywords, true)
 
@@ -604,6 +609,7 @@ module RSpec
           args.unshift(orig_object) if yield_receiver_to_implementation_block?
 
           if negative? || (allowed_to_fail && (@exactly || @at_most) && (@actual_received_count == @expected_received_count))
+            @raised = true
             # args are the args we actually received, @argument_list_matcher is the
             # list of args we were expecting
             @error_generator.raise_expectation_error(

--- a/rspec-mocks/spec/rspec/mocks/partial_double_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/partial_double_spec.rb
@@ -165,22 +165,17 @@ module RSpec
         end
 
         object = klass.new('foo')
-
         expect(object).to receive(:name).once.and_return('bar')
-
         object.name
 
-        expect do
+        expect {
           object.name
-        end.to raise_error(
-          RSpec::Mocks::MockExpectationError,
+        }.to fail_with(
           %|(<Inspector(bar)>).name(no args)\n    expected: 1 time with any arguments\n    received: 2 times|
         )
-
-        expect do
+        expect {
           verify object
-        end.to raise_error(
-          RSpec::Mocks::MockExpectationError,
+        }.to fail_with(
           %|(<Inspector(bar)>).name(*(any args))\n    expected: 1 time with any arguments\n    received: 2 times with any arguments|
         )
       end

--- a/rspec-mocks/spec/rspec/mocks/partial_double_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/partial_double_spec.rb
@@ -157,6 +157,34 @@ module RSpec
         }.to fail_with(/MyClass/)
       end
 
+      it "formats an error message when inspect fails" do
+        klass = Struct.new(:name) do
+          def inspect
+            "<Inspector(#{name})>"
+          end
+        end
+
+        object = klass.new('foo')
+
+        expect(object).to receive(:name).once.and_return('bar')
+
+        object.name
+
+        expect do
+          object.name
+        end.to raise_error(
+          RSpec::Mocks::MockExpectationError,
+          %|(<Inspector(bar)>).name(no args)\n    expected: 1 time with any arguments\n    received: 2 times|
+        )
+
+        expect do
+          verify object
+        end.to raise_error(
+          RSpec::Mocks::MockExpectationError,
+          %|(<Inspector(bar)>).name(*(any args))\n    expected: 1 time with any arguments\n    received: 2 times with any arguments|
+        )
+      end
+
       it "shares message expectations with clone" do
         expect(object).to receive(:foobar)
         twin = object.clone


### PR DESCRIPTION
This is rspec/rspec-mocks#1275