### PR TITLE
[rspec-mocks] RSpec 4 deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,25 +21,25 @@ jobs:
     uses: rspec/rspec/.github/workflows/rubocop.yml@main
 
   core:
-    uses: rspec/rspec/.github/workflows/rspec.yml@3-13-maintenance
+    uses: rspec/rspec/.github/workflows/rspec.yml@3-99-maintenance
     with:
       library: 'rspec-core'
-      rspec_version: '~> 3.13.0'
+      rspec_version: '~> 3.99.0'
 
   mocks:
-    uses: rspec/rspec/.github/workflows/rspec.yml@3-13-maintenance
+    uses: rspec/rspec/.github/workflows/rspec.yml@3-99-maintenance
     with:
       library: 'rspec-mocks'
-      rspec_version: '~> 3.13.0'
+      rspec_version: '~> 3.99.0'
 
   expectations:
-    uses: rspec/rspec/.github/workflows/rspec.yml@3-13-maintenance
+    uses: rspec/rspec/.github/workflows/rspec.yml@3-99-maintenance
     with:
       library: 'rspec-expectations'
-      rspec_version: '~> 3.13.0'
+      rspec_version: '~> 3.99.0'
 
   support:
-    uses: rspec/rspec/.github/workflows/rspec.yml@3-13-maintenance
+    uses: rspec/rspec/.github/workflows/rspec.yml@3-99-maintenance
     with:
       library: 'rspec-support'
-      rspec_version: '~> 3.13.0'
+      rspec_version: '~> 3.99.0'

--- a/rspec-core/lib/rspec/core/configuration.rb
+++ b/rspec-core/lib/rspec/core/configuration.rb
@@ -2311,8 +2311,11 @@ module RSpec
       def conditionally_disable_mocks_monkey_patching
         return unless disable_monkey_patching && rspec_mocks_loaded?
 
+        RSpec::Mocks::Configuration.instance_variable_set(:@warn_about_syntax, false)
+        RSpec::Mocks.configuration.syntax = :expect
+        RSpec::Mocks::Configuration.warn_about_syntax!
+
         RSpec::Mocks.configuration.tap do |config|
-          config.syntax = :expect
           config.patch_marshal_to_support_partial_doubles = false
         end
       end

--- a/rspec-core/lib/rspec/core/version.rb
+++ b/rspec-core/lib/rspec/core/version.rb
@@ -3,7 +3,7 @@ module RSpec
     # Version information for RSpec Core.
     module Version
       # Current version of RSpec Core, in semantic versioning format.
-      STRING = '3.13.5'
+      STRING = '3.99.0'
     end
   end
 end

--- a/rspec-core/spec/spec_helper.rb
+++ b/rspec-core/spec/spec_helper.rb
@@ -82,7 +82,7 @@ RSpec.configure do |c|
 
   # runtime options
   c.raise_errors_for_deprecations!
-  c.color = true
+
   c.include CommonHelpers
 
   c.expect_with :rspec do |expectations|

--- a/rspec-expectations/lib/rspec/expectations/version.rb
+++ b/rspec-expectations/lib/rspec/expectations/version.rb
@@ -2,7 +2,7 @@ module RSpec
   module Expectations
     # @private
     module Version
-      STRING = '3.13.5'
+      STRING = '3.99.0'
     end
   end
 end

--- a/rspec-expectations/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/eq_spec.rb
@@ -20,9 +20,11 @@ module RSpec
       it "compares by sending == to actual (not expected)" do
         called = false
         actual = Class.new do
+          # rubocop:disable Naming/MethodName
           define_method :== do |_other|
             called = true
           end
+          # rubocop:enable Naming/MethodName
         end.new
 
         expect(actual).to eq :anything # to trigger the matches? method

--- a/rspec-expectations/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/eq_spec.rb
@@ -20,11 +20,9 @@ module RSpec
       it "compares by sending == to actual (not expected)" do
         called = false
         actual = Class.new do
-          # rubocop:disable Naming/MethodName
           define_method :== do |_other|
             called = true
           end
-          # rubocop:enable Naming/MethodName
         end.new
 
         expect(actual).to eq :anything # to trigger the matches? method

--- a/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
@@ -58,6 +58,14 @@ RSpec.describe "a matcher defined using the matcher DSL" do
       expect(1).to match_optional_kw(bar: 1)
     end
 
+    # This is a regression test for rspec/rspec#145
+    it 'supports the use of optional keyword arguments in definition block when passed a hash' do
+      RSpec::Matchers.define(:match_optional_kw_hash) do |hash, bar: nil|
+        match { expect(hash["1"]).to eq 1 }
+      end
+      expect(1).to match_optional_kw_hash({"1" => 1})
+    end
+
     def optional_kw(a: nil)
       a
     end

--- a/rspec-mocks/Changelog.md
+++ b/rspec-mocks/Changelog.md
@@ -163,10 +163,6 @@ Bug Fixes:
 * Support keyword argument semantics when constraining argument expectations using
   `with` on Ruby 3.0+ (Yusuke Endoh, rspec/rspec-mocks#1394)
 
-Deprecations:
-
-* Add RSpec 4 deprecation warnings. (Phil Pirozhkov, #1418)
-
 ### 3.10.2 / 2021-01-27
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.10.1...v3.10.2)
 

--- a/rspec-mocks/Changelog.md
+++ b/rspec-mocks/Changelog.md
@@ -163,6 +163,10 @@ Bug Fixes:
 * Support keyword argument semantics when constraining argument expectations using
   `with` on Ruby 3.0+ (Yusuke Endoh, rspec/rspec-mocks#1394)
 
+Deprecations:
+
+* Add RSpec 4 deprecation warnings. (Phil Pirozhkov, #1418)
+
 ### 3.10.2 / 2021-01-27
 [Full Changelog](http://github.com/rspec/rspec-mocks/compare/v3.10.1...v3.10.2)
 

--- a/rspec-mocks/lib/rspec/mocks/configuration.rb
+++ b/rspec-mocks/lib/rspec/mocks/configuration.rb
@@ -80,6 +80,11 @@ module RSpec
       #
       def syntax=(*values)
         syntaxes = values.flatten
+        if self.class.warn_about_syntax?
+          RSpec.deprecate('Mocks syntax configuration',
+                          :replacement => 'the default `expect` syntax',
+                          :call_site => nil)
+        end
         if syntaxes.include?(:expect)
           Syntax.enable_expect
         else
@@ -87,6 +92,11 @@ module RSpec
         end
 
         if syntaxes.include?(:should)
+          if self.class.warn_about_syntax?
+            RSpec.deprecate('`:should` Mocks syntax',
+                            :replacement => 'the default `expect` syntax',
+                            :call_site => nil)
+          end
           Syntax.enable_should
         else
           Syntax.disable_should
@@ -199,6 +209,18 @@ module RSpec
         self.syntax = [:should, :expect]
         RSpec::Mocks::Syntax.warn_about_should!
       end
+
+      # @private
+      def self.warn_about_syntax?
+        @warn_about_syntax
+      end
+
+      # @private
+      def self.warn_about_syntax!
+        @warn_about_syntax = true
+      end
+
+      @warn_about_syntax = false
     end
 
     # Mocks specific configuration, as distinct from `RSpec.configuration`
@@ -208,5 +230,6 @@ module RSpec
     end
 
     configuration.reset_syntaxes_to_default
+    Configuration.warn_about_syntax!
   end
 end

--- a/rspec-mocks/lib/rspec/mocks/example_methods.rb
+++ b/rspec-mocks/lib/rspec/mocks/example_methods.rb
@@ -199,6 +199,8 @@ module RSpec
       # early on.
       # @deprecated Use {RSpec::Mocks::Configuration#allow_message_expectations_on_nil} instead.
       def allow_message_expectations_on_nil
+        RSpec.deprecate("`allow_message_expectations_on_nil` example method",
+                        :replacement => "`allow_message_expectations_on_nil` configuration option")
         RSpec::Mocks.space.proxy_for(nil).warn_about_expectations = false
       end
 

--- a/rspec-mocks/lib/rspec/mocks/version.rb
+++ b/rspec-mocks/lib/rspec/mocks/version.rb
@@ -3,7 +3,7 @@ module RSpec
     # Version information for RSpec mocks.
     module Version
       # Version of RSpec mocks currently in use in SemVer format.
-      STRING = '3.13.5'
+      STRING = '3.99.0'
     end
   end
 end

--- a/rspec-mocks/spec/rspec/mocks/configuration_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/configuration_spec.rb
@@ -68,6 +68,11 @@ module RSpec
             expect(::RSpec::Mocks::ExampleMethods).not_to receive(:method_added)
             configure_syntax :expect
           end
+
+          it 'emits a deprecation warning' do
+            expect_deprecation_without_call_site(/Mocks syntax configuration/)
+            configure_syntax :expect
+          end
         end
 
         context 'when configured to :should' do
@@ -89,14 +94,15 @@ module RSpec
             expect(configured_syntax).to eq([:should])
           end
 
-          it "does not warn about the should syntax" do
-            RSpec.should_not_receive(:deprecate)
-            Object.new.should_not_receive(:bees)
-          end
-
           it 'is a no-op when configured a second time' do
             Syntax.default_should_syntax_host.should_not_receive(:method_added)
             ::RSpec::Mocks::ExampleMethods.should_not_receive(:method_undefined)
+          end
+
+          it 'emits two deprecation warnings' do
+            configure_syntax :expect
+            expect_deprecation_without_call_site(/`:should` Mocks syntax/)
+            expect_deprecation_without_call_site(/Mocks syntax configuration/)
             configure_syntax :should
           end
         end
@@ -123,6 +129,12 @@ module RSpec
           it "does not warn about the should syntax" do
             expect(RSpec).not_to receive(:deprecate)
             expect(Object.new).not_to receive(:bees)
+          end
+
+          it 'emits two deprecation warnings' do
+            expect_deprecation_without_call_site(/`:should` Mocks syntax/)
+            expect_deprecation_without_call_site(/Mocks syntax configuration/)
+            configure_syntax [:should, :expect]
           end
         end
       end

--- a/rspec-mocks/spec/rspec/mocks/example_methods_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/example_methods_spec.rb
@@ -33,6 +33,17 @@ module RSpec
           expect(dbl.foo).to eq(1)
         end
       end
+
+      describe '#allow_message_expectations_on_nil' do
+        it "emits a deprecation warning on use" do
+          expect_deprecation_with_call_site(__FILE__, __LINE__ + 3, /allow_message_expectations_on_nil/)
+          RSpec.describe do
+            it do
+              allow_message_expectations_on_nil
+            end
+          end.run
+        end
+      end
     end
   end
 end

--- a/rspec-mocks/spec/rspec/mocks/should_syntax_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/should_syntax_spec.rb
@@ -551,16 +551,6 @@ RSpec.context "with default syntax configuration" do
     o2.unstub(:faces)
   end
 
-  it "doesn't warn about stubbing after a reset and setting should" do
-    expect(RSpec).not_to receive(:deprecate)
-    RSpec::Mocks.configuration.reset_syntaxes_to_default
-    RSpec::Mocks.configuration.syntax = :should
-    o = Object.new
-    o2 = Object.new
-    o.stub(:faces)
-    o2.stub(:faces)
-  end
-
   it "includes the call site in the deprecation warning" do
     obj = Object.new
     expect_deprecation_with_call_site(__FILE__, __LINE__ + 1)

--- a/rspec-mocks/spec/spec_helper.rb
+++ b/rspec-mocks/spec/spec_helper.rb
@@ -87,10 +87,7 @@ RSpec.configure do |config|
     expectations.syntax = :expect
   end
 
-  config.mock_with :rspec do |mocks|
-    $default_rspec_mocks_syntax = mocks.syntax
-    mocks.syntax = :expect
-  end
+  $default_rspec_mocks_syntax = [:should, :expect]
 
   old_verbose = nil
   config.before(:each, :silence_warnings) do

--- a/rspec-support/Changelog.md
+++ b/rspec-support/Changelog.md
@@ -1,6 +1,11 @@
 ### Development
 [Full Changelog](https://github.com/rspec/rspec/compare/rspec-support-v3.13.5...3-99-maintenance)
 
+Bug Fixes:
+
+* Change `RSpec::Support::HunkGenerator` to autoload rather than manual require, avoids
+  a load order issue. (Jon Rowe, rspec/rspec#249)
+
 ### 3.13.5
 [Full Changelog](http://github.com/rspec/rspec/compare/rspec-support-v3.13.4...rspec-support-v3.13.5)
 

--- a/rspec-support/Changelog.md
+++ b/rspec-support/Changelog.md
@@ -1,5 +1,8 @@
 ### Development
-[Full Changelog](https://github.com/rspec/rspec/compare/rspec-support-v3.13.5...3-99-maintenance)
+[Full Changelog](https://github.com/rspec/rspec/compare/rspec-support-v3.13.6...3-99-maintenance)
+
+### 3.13.6
+[Full Changelog](http://github.com/rspec/rspec/compare/rspec-support-v3.13.5...rspec-support-v3.13.6)
 
 Bug Fixes:
 

--- a/rspec-support/Changelog.md
+++ b/rspec-support/Changelog.md
@@ -1,6 +1,12 @@
 ### Development
 [Full Changelog](https://github.com/rspec/rspec/compare/rspec-support-v3.13.2...3-13-maintenance)
 
+Bug Fixes:
+
+* Fix regression in `RSpec::Support::MethodSignature` where positional argument arity confused
+  a check for keyword arguments, meaning a hash would be wrongly detected as keyword arguments
+  when it should have been a positional argument. (Malcolm O'Hare, rspec/rspec#121)
+
 ### 3.13.4
 [Full Changelog](http://github.com/rspec/rspec/compare/rspec-support-v3.13.3...rspec-support-v3.13.4)
 

--- a/rspec-support/Changelog.md
+++ b/rspec-support/Changelog.md
@@ -1,5 +1,8 @@
 ### Development
-[Full Changelog](https://github.com/rspec/rspec/compare/rspec-support-v3.13.2...3-13-maintenance)
+[Full Changelog](https://github.com/rspec/rspec/compare/rspec-support-v3.13.5...3-99-maintenance)
+
+### 3.13.5
+[Full Changelog](http://github.com/rspec/rspec/compare/rspec-support-v3.13.4...rspec-support-v3.13.5)
 
 Bug Fixes:
 

--- a/rspec-support/lib/rspec/support.rb
+++ b/rspec-support/lib/rspec/support.rb
@@ -158,5 +158,6 @@ module RSpec
     # pp, etc by avoiding an unnecessary require. Instead, autoload will take
     # care of loading the differ on first use.
     autoload :Differ, "rspec/support/differ"
+    autoload :HunkGenerator, "rspec/support/hunk_generator"
   end
 end

--- a/rspec-support/lib/rspec/support/differ.rb
+++ b/rspec-support/lib/rspec/support/differ.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec::Support.require_rspec_support 'encoded_string'
-RSpec::Support.require_rspec_support 'hunk_generator'
 RSpec::Support.require_rspec_support "object_formatter"
 
 require 'pp'

--- a/rspec-support/lib/rspec/support/method_signature_verifier.rb
+++ b/rspec-support/lib/rspec/support/method_signature_verifier.rb
@@ -79,12 +79,37 @@ module RSpec
           given_kw_args - @allowed_kw_args
         end
 
-        # If the last argument is Hash, Ruby will treat only symbol keys as keyword arguments
-        # the rest will be grouped in another Hash and passed as positional argument.
-        def has_kw_args_in?(args)
-          Hash === args.last &&
-            could_contain_kw_args?(args) &&
-            (RubyFeatures.kw_arg_separation? || args.last.empty? || args.last.keys.any? { |x| x.is_a?(Symbol) })
+        # Considering the arg types, are there kw_args?
+        if RubyFeatures.kw_arg_separation?
+          def has_kw_args_in?(args)
+            # If the last arg is a hash, depending on the signature it could be kw_args or a positional parameter.
+            return false unless Hash === args.last && could_contain_kw_args?(args)
+
+            # If the position of the hash is beyond the count of required and optional positional
+            # args then it is the kwargs hash
+            return true if args.count > @max_non_kw_args
+
+            # This is the proper way to disambiguate between positional args and keywords hash
+            # but relies on beginning of the call chain annotating the method with
+            # ruby2_keywords, so only use it for positive feedback as without the annotation
+            # this is always false
+            return true if Hash.ruby2_keywords_hash?(args[-1])
+
+            # Otherwise, the hash could be defined kw_args or an optional positional parameter
+            # inspect the keys against known kwargs to determine what it is
+            # Note: the problem with this is that if a user passes only invalid keyword args,
+            #       rspec no longer detects is and will assign this to a positional argument
+            return arbitrary_kw_args? || args.last.keys.all? { |x| @allowed_kw_args.include?(x) }
+          end
+        else
+          def has_kw_args_in?(args)
+            # Version <= Ruby 2.7
+            # If the last argument is Hash, Ruby will treat only symbol keys as keyword arguments
+            # the rest will be grouped in another Hash and passed as positional argument.
+            Hash === args.last &&
+              could_contain_kw_args?(args) &&
+              (args.last.empty? || args.last.keys.any? { |x| x.is_a?(Symbol) })
+          end
         end
 
         # Without considering what the last arg is, could it
@@ -282,7 +307,7 @@ module RSpec
 
       def initialize(signature, args=[])
         @signature = signature
-        @non_kw_args, @kw_args = split_args(*args)
+        @non_kw_args, @kw_args = split_args(args.clone)
         @min_non_kw_args = @max_non_kw_args = @non_kw_args
         @arbitrary_kw_args = @unlimited_args = false
       end
@@ -362,7 +387,7 @@ module RSpec
         !@unlimited_args || @signature.unlimited_args?
       end
 
-      def split_args(*args)
+      def split_args(args)
         kw_args = if @signature.has_kw_args_in?(args) && !RubyFeatures.kw_arg_separation?
                     last = args.pop
                     non_kw_args = last.reject { |k, _| k.is_a?(Symbol) }
@@ -395,13 +420,13 @@ module RSpec
     class LooseSignatureVerifier < MethodSignatureVerifier
     private
 
-      def split_args(*args)
+      def split_args(args)
         if RSpec::Support.is_a_matcher?(args.last) && @signature.could_contain_kw_args?(args)
           args.pop
           @signature = SignatureWithKeywordArgumentsMatcher.new(@signature)
         end
 
-        super(*args)
+        super(args)
       end
 
       # If a matcher is used in a signature in place of keyword arguments, all

--- a/rspec-support/lib/rspec/support/version.rb
+++ b/rspec-support/lib/rspec/support/version.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Support
     module Version
-      STRING = '3.13.4'
+      STRING = '3.99.0'
     end
   end
 end

--- a/rspec-support/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/rspec-support/spec/rspec/support/method_signature_verifier_spec.rb
@@ -13,6 +13,7 @@ module RSpec
       def valid?(*args)
         described_class.new(signature, args).valid?
       end
+      ruby2_keywords(:valid?) if respond_to?(:ruby2_keywords, true)
 
       def error_description
         described_class.new(signature).error_message[/Expected (.*),/, 1]
@@ -21,10 +22,17 @@ module RSpec
       def error_for(*args)
         described_class.new(signature, args).error_message
       end
+      ruby2_keywords(:error_for) if respond_to?(:ruby2_keywords, true)
 
       def signature_description
         signature.description
       end
+
+      def validate(target, *args)
+        target_signature = MethodSignature.new(target)
+        described_class.new(target_signature, args).valid?
+      end
+      ruby2_keywords(:validate) if respond_to?(:ruby2_keywords, true)
 
       def validate_expectation(*args)
         obj = MethodSignatureExpectation.new
@@ -39,6 +47,7 @@ module RSpec
 
         described_class.new(signature).with_expectation(obj).valid?
       end
+      ruby2_keywords(:validate_expectation) if respond_to?(:ruby2_keywords, true)
 
       shared_context 'a method verifier' do
         describe 'with a method with arguments' do
@@ -286,6 +295,10 @@ module RSpec
 
             it 'does not allow an invalid keyword arguments' do
               expect(valid?(nil, :a => 1)).to eq(false)
+            end
+
+            it 'does not treat a last-arg hash as kw args' do
+              expect(valid?({ "1" => 1 })).to eq(true)
             end
 
             it 'mentions the invalid keyword args in the error', :pending => RSpec::Support::Ruby.jruby? && !RSpec::Support::Ruby.jruby_9000? do
@@ -898,6 +911,61 @@ module RSpec
 
             it 'fails validation against 2 arguments' do
               expect(valid_non_kw_args?(2)).to eq false
+            end
+          end
+        end
+
+        describe 'a proc' do
+          it 'will match partial args' do
+            a_proc = proc { |_a, _b| }
+            expect(validate a_proc, 1).to be(true)
+            expect(validate a_proc, 2, 2).to be(true)
+            expect(validate a_proc, 3, 3, 3).to be(false)
+          end
+
+          if RubyFeatures.kw_args_supported?
+            it 'will not match keyword args when not defined' do
+              eval <<-RUBY
+              a_proc = proc { |_a| }
+              expect(validate a_proc, :arg, opts: []).to eq(false)
+              RUBY
+            end
+
+            it 'will match keyword args' do
+              eval <<-RUBY
+              a_proc = proc { |_a, opts: []| }
+              expect(validate a_proc, :arg, opts: [:value]).to eq(true)
+              RUBY
+            end
+
+            it 'allows a hash to be distinct from optional keyword arguments' do
+              eval <<-RUBY
+              a_proc = proc { |_a, opts: []| }
+              expect(validate a_proc, {1 => "not_opts"}).to eq(true)
+              RUBY
+            end
+          end
+
+          if RubyFeatures.required_kw_args_supported?
+            it 'will not match required keyword args when not defined' do
+              eval <<-RUBY
+              a_proc = proc { |_a| }
+              expect(validate a_proc, :arg, required: true).to eq(false)
+              RUBY
+            end
+
+            it 'will match required keyword args' do
+              eval <<-RUBY
+              a_proc = proc { |_a, required:| }
+              expect(validate a_proc, :arg, required: true).to eq(true)
+              RUBY
+            end
+
+            it 'allows a hash to be distinct from required keyword arguments' do
+              eval <<-RUBY
+              a_proc = proc { |_a, required:| }
+              expect(validate a_proc, {1 => "not_opts"}, required: true).to eq(true)
+              RUBY
             end
           end
         end

--- a/rspec-support/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/rspec-support/spec/rspec/support/method_signature_verifier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/support'
 require 'rspec/support/method_signature_verifier'
 
@@ -916,11 +918,13 @@ module RSpec
         end
 
         describe 'a proc' do
-          it 'will match partial args' do
-            a_proc = proc { |_a, _b| }
-            expect(validate a_proc, 1).to be(true)
-            expect(validate a_proc, 2, 2).to be(true)
-            expect(validate a_proc, 3, 3, 3).to be(false)
+          if RUBY_VERSION.to_f > 1.8
+            it 'will match partial args' do
+              a_proc = proc { |_a, _b| }
+              expect(validate a_proc, 1).to be(true)
+              expect(validate a_proc, 2, 2).to be(true)
+              expect(validate a_proc, 3, 3, 3).to be(false)
+            end
           end
 
           if RubyFeatures.kw_args_supported?

--- a/rspec/lib/rspec/version.rb
+++ b/rspec/lib/rspec/version.rb
@@ -1,5 +1,5 @@
 module RSpec # :nodoc:
   module Version # :nodoc:
-    STRING = '3.13.1'
+    STRING = '3.99.0'
   end
 end


### PR DESCRIPTION
This is rspec/rspec-mocks#1418

According to https://github.com/rspec/rspec-mocks/blob/4-0-dev/Changelog.md, only those two deprecation warnings are needed.
This is purposed to be released as version 3.99. Similar PRs for Expectations will follow.
Sibling PRs:
 - https://github.com/rspec/rspec/pull/106
 - https://github.com/rspec/rspec/pull/124

> Release strategy: https://github.com/rspec/rspec-core/pull/2880#issuecomment-797756681

RSpec 4 plan: https://github.com/rspec/rspec/issues/2

> Changes https://github.com/rspec/rspec-mocks/blob/4-0-dev/Changelog.md#development