### PR TITLE
[rspec-mocks] Classes don't follow the double docs WRT #dup

### DIFF
--- a/rspec-mocks/spec/rspec/mocks/partial_double_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/partial_double_spec.rb
@@ -171,6 +171,27 @@ module RSpec
         expect { duplicate.foobar }.to raise_error(NoMethodError, /foobar/)
         expect { verify object }.to fail_with(/foobar/)
       end
+
+      describe "class" do
+        let(:object) do
+          Class.new
+        end
+
+        it "shares message expectations with clone" do
+          expect(object).to receive(:foobar)
+          twin = object.clone
+          twin.foobar
+          expect { verify twin }.not_to raise_error
+          expect { verify object }.not_to raise_error
+        end
+
+        it "clears message expectations when `dup`ed" do
+          expect(object).to receive(:foobar)
+          duplicate = object.dup
+          expect { duplicate.foobar }.to raise_error(NoMethodError, /foobar/)
+          expect { verify object }.to fail_with(/foobar/)
+        end
+      end
     end
 
     RSpec.describe "Using a reopened file object as a partial mock" do

--- a/rspec-mocks/spec/rspec/mocks/stub_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/stub_spec.rb
@@ -95,6 +95,18 @@ module RSpec
         expect { @class.existing_private_class_method }.to raise_error NoMethodError, /private method [`']existing_private_class_method/
       end
 
+      context "on a class" do
+        it "is retained when stubbed object is `clone`d" do
+          allow(@class).to receive(:foobar).and_return(1)
+          expect(@class.clone.foobar).to eq(1)
+        end
+
+        it "is cleared when stubbed object when `dup`ed" do
+          allow(@class).to receive(:foobar).and_return(1)
+          expect { @class.dup.foobar }.to raise_error NoMethodError, /foobar/
+        end
+      end
+
       context "using `with`" do
         it 'determines which value is returned' do
           allow(@stub).to receive(:foo).with(1) { :one }


### PR DESCRIPTION
This is rspec/rspec-mocks#1586
> While mocks don't get copied on an object that's dup'd, that is not true for classes.