### PR TITLE
[rspec-support] [bugfix] Properly detect kwargs hashes vs optional positional args

### DIFF
--- a/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
@@ -60,6 +60,14 @@ RSpec.describe "a matcher defined using the matcher DSL" do
       expect(1).to match_optional_kw(bar: 1)
     end
 
+    # This is a regression test for rspec/rspec#145
+    it 'supports the use of optional keyword arguments in definition block when passed a hash' do
+      RSpec::Matchers.define(:match_optional_kw_hash) do |hash, bar: nil|
+        match { expect(hash["1"]).to eq 1 }
+      end
+      expect(1).to match_optional_kw_hash({"1" => 1})
+    end
+
     def optional_kw(a: nil)
       a
     end

--- a/rspec-support/lib/rspec/support/method_signature_verifier.rb
+++ b/rspec-support/lib/rspec/support/method_signature_verifier.rb
@@ -80,7 +80,7 @@ module RSpec
         end
 
         # Considering the arg types, are there kw_args?
-        def has_kw_args_in?(args)
+        def has_kw_args_in?(args) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           if RubyFeatures.kw_arg_separation?
             # If the last arg is a hash, depending on the signature it could be kw_args or a positional parameter.
             return false unless Hash === args.last && could_contain_kw_args?(args)

--- a/rspec-support/lib/rspec/support/method_signature_verifier.rb
+++ b/rspec-support/lib/rspec/support/method_signature_verifier.rb
@@ -79,12 +79,35 @@ module RSpec
           given_kw_args - @allowed_kw_args
         end
 
-        # If the last argument is Hash, Ruby will treat only symbol keys as keyword arguments
-        # the rest will be grouped in another Hash and passed as positional argument.
+        # Considering the arg types, are there kw_args?
         def has_kw_args_in?(args)
-          Hash === args.last &&
-            could_contain_kw_args?(args) &&
-            (RubyFeatures.kw_arg_separation? || args.last.empty? || args.last.keys.any? { |x| x.is_a?(Symbol) })
+          if RubyFeatures.kw_arg_separation?
+            # If the last arg is a hash, depending on the signature it could be kw_args or a positional parameter.
+            return false unless Hash === args.last && could_contain_kw_args?(args)
+
+            # If the position of the hash is beyond the count of required and optional positional
+            # args then it is the kwargs hash
+            return true if args.count > @max_non_kw_args
+
+            # This is the proper way to disambiguate between positional args and keywords hash
+            # but relies on beginning of the call chain annotating the method with
+            # ruby2_keywords, so only use it for positive feedback as without the annotation
+            # this is always false
+            return true if Hash.ruby2_keywords_hash?(args[-1])
+
+            # Otherwise, the hash could be defined kw_args or an optional positional parameter
+            # inspect the keys against known kwargs to determine what it is
+            # Note: the problem with this is that if a user passes only invalid keyword args,
+            #       rspec no longer detects is and will assign this to a positional argument
+            return arbitrary_kw_args? || args.last.keys.all? { |x| @allowed_kw_args.include?(x) }
+          else
+            # Version <= Ruby 2.7
+            # If the last argument is Hash, Ruby will treat only symbol keys as keyword arguments
+            # the rest will be grouped in another Hash and passed as positional argument.
+            Hash === args.last &&
+              could_contain_kw_args?(args) &&
+              (args.last.empty? || args.last.keys.any? { |x| x.is_a?(Symbol) })
+          end
         end
 
         # Without considering what the last arg is, could it

--- a/rspec-support/lib/rspec/support/method_signature_verifier.rb
+++ b/rspec-support/lib/rspec/support/method_signature_verifier.rb
@@ -308,7 +308,7 @@ module RSpec
 
       def initialize(signature, args=[])
         @signature = signature
-        @non_kw_args, @kw_args = split_args(*args)
+        @non_kw_args, @kw_args = split_args(args.clone)
         @min_non_kw_args = @max_non_kw_args = @non_kw_args
         @arbitrary_kw_args = @unlimited_args = false
       end
@@ -388,7 +388,7 @@ module RSpec
         !@unlimited_args || @signature.unlimited_args?
       end
 
-      def split_args(*args)
+      def split_args(args)
         kw_args = if @signature.has_kw_args_in?(args) && !RubyFeatures.kw_arg_separation?
                     last = args.pop
                     non_kw_args = last.reject { |k, _| k.is_a?(Symbol) }
@@ -421,13 +421,13 @@ module RSpec
     class LooseSignatureVerifier < MethodSignatureVerifier
     private
 
-      def split_args(*args)
+      def split_args(args)
         if RSpec::Support.is_a_matcher?(args.last) && @signature.could_contain_kw_args?(args)
           args.pop
           @signature = SignatureWithKeywordArgumentsMatcher.new(@signature)
         end
 
-        super(*args)
+        super(args)
       end
 
       # If a matcher is used in a signature in place of keyword arguments, all

--- a/rspec-support/lib/rspec/support/method_signature_verifier.rb
+++ b/rspec-support/lib/rspec/support/method_signature_verifier.rb
@@ -80,8 +80,8 @@ module RSpec
         end
 
         # Considering the arg types, are there kw_args?
-        def has_kw_args_in?(args) # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
-          if RubyFeatures.kw_arg_separation?
+        if RubyFeatures.kw_arg_separation?
+          def has_kw_args_in?(args)
             # If the last arg is a hash, depending on the signature it could be kw_args or a positional parameter.
             return false unless Hash === args.last && could_contain_kw_args?(args)
 
@@ -100,7 +100,9 @@ module RSpec
             # Note: the problem with this is that if a user passes only invalid keyword args,
             #       rspec no longer detects is and will assign this to a positional argument
             return arbitrary_kw_args? || args.last.keys.all? { |x| @allowed_kw_args.include?(x) }
-          else
+          end
+        else
+          def has_kw_args_in?(args)
             # Version <= Ruby 2.7
             # If the last argument is Hash, Ruby will treat only symbol keys as keyword arguments
             # the rest will be grouped in another Hash and passed as positional argument.

--- a/rspec-support/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/rspec-support/spec/rspec/support/method_signature_verifier_spec.rb
@@ -12,7 +12,7 @@ module RSpec
         described_class.new(signature, [nil] * arity).valid?
       end
 
-      def valid?(*args)
+      ruby2_keywords def valid?(*args)
         described_class.new(signature, args).valid?
       end
 
@@ -20,7 +20,7 @@ module RSpec
         described_class.new(signature).error_message[/Expected (.*),/, 1]
       end
 
-      def error_for(*args)
+      ruby2_keywords def error_for(*args)
         described_class.new(signature, args).error_message
       end
 

--- a/rspec-support/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/rspec-support/spec/rspec/support/method_signature_verifier_spec.rb
@@ -3,8 +3,6 @@
 require 'rspec/support'
 require 'rspec/support/method_signature_verifier'
 
-def ruby2_keywords(*); end unless respond_to?(:ruby2_keywords, true)
-
 module RSpec
   module Support
     RSpec.describe 'verifying methods' do
@@ -14,17 +12,19 @@ module RSpec
         described_class.new(signature, [nil] * arity).valid?
       end
 
-      ruby2_keywords def valid?(*args)
+      def valid?(*args)
         described_class.new(signature, args).valid?
       end
+      ruby2_keywords(:valid?) if respond_to?(:ruby2_keywords, true)
 
       def error_description
         described_class.new(signature).error_message[/Expected (.*),/, 1]
       end
 
-      ruby2_keywords def error_for(*args)
+      def error_for(*args)
         described_class.new(signature, args).error_message
       end
+      ruby2_keywords(:error_for) if respond_to?(:ruby2_keywords, true)
 
       def signature_description
         signature.description

--- a/rspec-support/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/rspec-support/spec/rspec/support/method_signature_verifier_spec.rb
@@ -3,6 +3,8 @@
 require 'rspec/support'
 require 'rspec/support/method_signature_verifier'
 
+def ruby2_keywords(*); end unless respond_to?(:ruby2_keywords, true)
+
 module RSpec
   module Support
     RSpec.describe 'verifying methods' do


### PR DESCRIPTION
This is rspec/rspec-support#594

> Attempting to fix https://github.com/rspec/rspec/issues/145
>
> Refactor has_kw_args_in?:
>
>     try to use positional parameter information to determine whether a hash is kw_args
>     try to leverage information passed by the ruby2_keywords annotation
>     fallback to inspection of keyword args to determine if they look valid or not
>
> Added backwards compatible ruby2_keywords wrapping to the necessary methods (valid? and error_for) in the spec files like so:
> ruby2_keywords(:valid?) if respond_to?(:ruby2_keywords, true)
> 
> Also needed to modify how args are passed to the MSV split_args so that the special kwargs markings are not lost.