### PR TITLE
[rspec-expectations] Prevent Aliased Matchers from Overriding Expected Data

### DIFF
--- a/rspec-expectations/lib/rspec/matchers/aliased_matcher.rb
+++ b/rspec-expectations/lib/rspec/matchers/aliased_matcher.rb
@@ -36,7 +36,7 @@ module RSpec
       #
       # @api private
       def description
-        @description_block.call(super)
+        @description_block.call(super, false)
       end
 
       # Provides the failure_message of the aliased matcher. Aliased matchers
@@ -46,7 +46,7 @@ module RSpec
       #
       # @api private
       def failure_message
-        @description_block.call(super, replace_after_start: true)
+        @description_block.call(super, true)
       end
 
       # Provides the failure_message_when_negated of the aliased matcher. Aliased matchers
@@ -56,7 +56,7 @@ module RSpec
       #
       # @api private
       def failure_message_when_negated
-        @description_block.call(super, replace_after_start: true)
+        @description_block.call(super, true)
       end
     end
 
@@ -107,7 +107,7 @@ module RSpec
       def optimal_failure_message(same, inverted)
         if DefaultFailureMessages.has_default_failure_messages?(@base_matcher)
           base_message = @base_matcher.__send__(same)
-          overridden    = @description_block.call(base_message, replace_after_start: true)
+          overridden    = @description_block.call(base_message, true)
           return overridden if overridden != base_message
         end
 

--- a/rspec-expectations/lib/rspec/matchers/aliased_matcher.rb
+++ b/rspec-expectations/lib/rspec/matchers/aliased_matcher.rb
@@ -36,7 +36,7 @@ module RSpec
       #
       # @api private
       def description
-        @description_block.call(super, false)
+        @description_block.call(super)
       end
 
       # Provides the failure_message of the aliased matcher. Aliased matchers
@@ -46,7 +46,7 @@ module RSpec
       #
       # @api private
       def failure_message
-        @description_block.call(super, true)
+        @description_block.call(super, replace_after_start: true)
       end
 
       # Provides the failure_message_when_negated of the aliased matcher. Aliased matchers
@@ -56,7 +56,7 @@ module RSpec
       #
       # @api private
       def failure_message_when_negated
-        @description_block.call(super, true)
+        @description_block.call(super, replace_after_start: true)
       end
     end
 
@@ -107,11 +107,52 @@ module RSpec
       def optimal_failure_message(same, inverted)
         if DefaultFailureMessages.has_default_failure_messages?(@base_matcher)
           base_message = @base_matcher.__send__(same)
-          overridden    = @description_block.call(base_message, true)
+          overridden    = @description_block.call(base_message, replace_after_start: true)
           return overridden if overridden != base_message
         end
 
         @base_matcher.__send__(inverted)
+      end
+    end
+
+    # Wrapper around an overriden description for an aliased
+    # matcher.
+    #
+    # @api private
+    class AliasDescription
+      def initialize(new_name, old_name, override_block)
+        @new_name = new_name
+        @old_name = old_name
+        @override_block = override_block
+      end
+
+      # Creates the overriden description.
+      #
+      # @api private
+      def call(old_desc, replace_after_start: false)
+        if @override_block
+          @override_block.call(old_desc)
+        else
+          default_description(old_desc, replace_after_start)
+        end
+      end
+
+    private
+
+      # Generates a default message when no block is provided
+      # when aliasing the matcher. Replaces instances of the old
+      # matcher's name with the new matcher's name where
+      # applicable.
+      #
+      # #api private
+      def default_description(old_desc, replace_after_start)
+        old_name_split = EnglishPhrasing.split_words(@old_name)
+
+        if old_desc.start_with?(old_name_split) || replace_after_start
+          old_desc.sub(old_name_split, EnglishPhrasing.split_words(@new_name))
+        else
+          old_desc
+        end
       end
     end
   end

--- a/rspec-expectations/lib/rspec/matchers/aliased_matcher.rb
+++ b/rspec-expectations/lib/rspec/matchers/aliased_matcher.rb
@@ -46,7 +46,7 @@ module RSpec
       #
       # @api private
       def failure_message
-        @description_block.call(super, replace_after_start: true)
+        @description_block.call(super, true)
       end
 
       # Provides the failure_message_when_negated of the aliased matcher. Aliased matchers
@@ -56,7 +56,7 @@ module RSpec
       #
       # @api private
       def failure_message_when_negated
-        @description_block.call(super, replace_after_start: true)
+        @description_block.call(super, true)
       end
     end
 
@@ -107,7 +107,7 @@ module RSpec
       def optimal_failure_message(same, inverted)
         if DefaultFailureMessages.has_default_failure_messages?(@base_matcher)
           base_message = @base_matcher.__send__(same)
-          overridden    = @description_block.call(base_message, replace_after_start: true)
+          overridden    = @description_block.call(base_message, true)
           return overridden if overridden != base_message
         end
 
@@ -129,7 +129,7 @@ module RSpec
       # Creates the overriden description.
       #
       # @api private
-      def call(old_desc, replace_after_start: false)
+      def call(old_desc, replace_after_start=false)
         if @override_block
           @override_block.call(old_desc)
         else

--- a/rspec-expectations/lib/rspec/matchers/aliased_matcher.rb
+++ b/rspec-expectations/lib/rspec/matchers/aliased_matcher.rb
@@ -46,7 +46,7 @@ module RSpec
       #
       # @api private
       def failure_message
-        @description_block.call(super)
+        @description_block.call(super, replace_after_start: true)
       end
 
       # Provides the failure_message_when_negated of the aliased matcher. Aliased matchers
@@ -56,7 +56,7 @@ module RSpec
       #
       # @api private
       def failure_message_when_negated
-        @description_block.call(super)
+        @description_block.call(super, replace_after_start: true)
       end
     end
 
@@ -107,7 +107,7 @@ module RSpec
       def optimal_failure_message(same, inverted)
         if DefaultFailureMessages.has_default_failure_messages?(@base_matcher)
           base_message = @base_matcher.__send__(same)
-          overridden    = @description_block.call(base_message)
+          overridden    = @description_block.call(base_message, replace_after_start: true)
           return overridden if overridden != base_message
         end
 

--- a/rspec-expectations/lib/rspec/matchers/dsl.rb
+++ b/rspec-expectations/lib/rspec/matchers/dsl.rb
@@ -33,7 +33,7 @@ module RSpec
       # @see RSpec::Matchers
       def alias_matcher(new_name, old_name, options={}, &description_override)
         description_override ||= lambda do |old_desc|
-          old_desc.gsub(EnglishPhrasing.split_words(old_name), EnglishPhrasing.split_words(new_name))
+          old_desc.sub(EnglishPhrasing.split_words(old_name), EnglishPhrasing.split_words(new_name))
         end
         klass = options.fetch(:klass) { AliasedMatcher }
 

--- a/rspec-expectations/lib/rspec/matchers/dsl.rb
+++ b/rspec-expectations/lib/rspec/matchers/dsl.rb
@@ -87,7 +87,7 @@ module RSpec
       # @param old_name [Symbol] the name of the old (aliased) matcher
       def default_desc_override(new_name, old_name)
         old_name_split = EnglishPhrasing.split_words(old_name)
-        lambda do |old_desc, replace_after_start: false|
+        lambda do |old_desc, replace_after_start|
           if old_desc.start_with?(old_name_split) || replace_after_start
             old_desc.sub(old_name_split, EnglishPhrasing.split_words(new_name))
           else

--- a/rspec-expectations/lib/rspec/matchers/dsl.rb
+++ b/rspec-expectations/lib/rspec/matchers/dsl.rb
@@ -31,8 +31,8 @@ module RSpec
       #   logic. The yielded arg is the original description or failure message. If no
       #   block is provided, a default override is used based on the old and new names.
       # @see RSpec::Matchers
-      def alias_matcher(new_name, old_name, options={}, &description_override)
-        description_override ||= default_desc_override(new_name, old_name)
+      def alias_matcher(new_name, old_name, options={}, &description_block)
+        description_override = AliasDescription.new(new_name, old_name, description_block)
         klass = options.fetch(:klass) { AliasedMatcher }
 
         define_method(new_name) do |*args, &block|
@@ -79,22 +79,6 @@ module RSpec
       alias_method :matcher, :define
 
     private
-
-      # Defines the override for an aliased matcher description
-      # if not block is passed in.
-      #
-      # @param new_name [Symbol] the name of the new matcher
-      # @param old_name [Symbol] the name of the old (aliased) matcher
-      def default_desc_override(new_name, old_name)
-        old_name_split = EnglishPhrasing.split_words(old_name)
-        lambda do |old_desc, replace_after_start|
-          if old_desc.start_with?(old_name_split) || replace_after_start
-            old_desc.sub(old_name_split, EnglishPhrasing.split_words(new_name))
-          else
-            old_desc
-          end
-        end
-      end
 
       if Proc.method_defined?(:parameters)
         def warn_about_block_args(name, declarations)

--- a/rspec-expectations/lib/rspec/matchers/dsl.rb
+++ b/rspec-expectations/lib/rspec/matchers/dsl.rb
@@ -32,9 +32,7 @@ module RSpec
       #   block is provided, a default override is used based on the old and new names.
       # @see RSpec::Matchers
       def alias_matcher(new_name, old_name, options={}, &description_override)
-        description_override ||= lambda do |old_desc|
-          old_desc.sub(EnglishPhrasing.split_words(old_name), EnglishPhrasing.split_words(new_name))
-        end
+        description_override ||= default_desc_override(new_name, old_name)
         klass = options.fetch(:klass) { AliasedMatcher }
 
         define_method(new_name) do |*args, &block|
@@ -81,6 +79,22 @@ module RSpec
       alias_method :matcher, :define
 
     private
+
+      # Defines the override for an aliased matcher description
+      # if not block is passed in.
+      #
+      # @param new_name [Symbol] the name of the new matcher
+      # @param old_name [Symbol] the name of the old (aliased) matcher
+      def default_desc_override(new_name, old_name)
+        old_name_split = EnglishPhrasing.split_words(old_name)
+        lambda do |old_desc, replace_after_start: false|
+          if old_desc.start_with?(old_name_split) || replace_after_start
+            old_desc.sub(old_name_split, EnglishPhrasing.split_words(new_name))
+          else
+            old_desc
+          end
+        end
+      end
 
       if Proc.method_defined?(:parameters)
         def warn_about_block_args(name, declarations)

--- a/rspec-expectations/spec/rspec/matchers/aliased_matcher_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/aliased_matcher_spec.rb
@@ -3,6 +3,7 @@
 module RSpec
   module Matchers
     RSpec.describe AliasedMatcher do
+      let(:base_matcher_desc) { "my base matcher description" }
       RSpec::Matchers.define :my_base_matcher do
         match { |actual| actual == foo }
 
@@ -11,7 +12,7 @@ module RSpec
         end
 
         def description
-          "my base matcher description"
+          base_matcher_desc
         end
       end
       RSpec::Matchers.alias_matcher :alias_of_my_base_matcher, :my_base_matcher
@@ -81,17 +82,13 @@ module RSpec
         expect(matcher.description).to eq("my blockless override description")
       end
 
-      RSpec::Matchers.define :my_repeating_base_matcher do
-        def description
-          "my repeating base matcher my repeating base matcher"
+      context "when the matcher's description starts with the matcher's name" do
+        let(:base_matcher_desc) { "my base matcher my base matcher" }
+
+        it 'only overrides the first instance of the name in the description' do
+          matcher = alias_of_my_base_matcher
+          expect(matcher.description).to eq("alias of my base matcher my base matcher")
         end
-      end
-
-      RSpec::Matchers.alias_matcher :my_repeating_override, :my_repeating_base_matcher
-
-      it 'does not override data in the description with the same name as the matcher' do
-        matcher = my_repeating_override
-        expect(matcher.description).to eq("my repeating override my repeating base matcher")
       end
 
       it 'works properly with a chained method off a negated matcher' do

--- a/rspec-expectations/spec/rspec/matchers/aliased_matcher_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/aliased_matcher_spec.rb
@@ -81,6 +81,19 @@ module RSpec
         expect(matcher.description).to eq("my blockless override description")
       end
 
+      RSpec::Matchers.define :my_repeating_base_matcher do
+        def description
+          "my repeating base matcher my repeating base matcher"
+        end
+      end
+
+      RSpec::Matchers.alias_matcher :my_repeating_override, :my_repeating_base_matcher
+
+      it 'does not override data in the description with the same name as the matcher' do
+        matcher = my_repeating_override
+        expect(matcher.description).to eq("my repeating override my repeating base matcher")
+      end
+
       it 'works properly with a chained method off a negated matcher' do
         expect {}.to avoid_outputting.to_stdout
 

--- a/rspec-expectations/spec/rspec/matchers/aliases_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/aliases_spec.rb
@@ -264,7 +264,7 @@ module RSpec
 
     specify do
       expect {
-        expect({}).to match(a_hash_including({a: 'include'}))
+        expect({}).to match(a_hash_including({:a => 'include'}))
       }.to fail_including(
         'expected {} to match (a hash including {:a => "include"}'
       )

--- a/rspec-expectations/spec/rspec/matchers/aliases_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/aliases_spec.rb
@@ -239,6 +239,14 @@ module RSpec
     end
 
     specify do
+      expect {
+        expect("some random string").to match(a_string_including("include"))
+      }.to fail_including(
+        'expected "some random string" to match (a string including "include")'
+      )
+    end
+
+    specify do
       expect(
         a_collection_including("a")
       ).to be_aliased_to(
@@ -252,6 +260,14 @@ module RSpec
       ).to be_aliased_to(
         include(:a => 5)
       ).with_description('a hash including {:a => 5}')
+    end
+
+    specify do
+      expect {
+        expect({}).to match(a_hash_including({a: 'include'}))
+      }.to fail_including(
+        'expected {} to match (a hash including {:a => "include"}'
+      )
     end
 
     specify do


### PR DESCRIPTION
This is rspec/rspec-expectations#1116

> ## Previous Behavior
> 
> The aliased matcher implementation of a description currently replaces all instance of the old matcher's name in the new matcher's name. If it happens that the expected values include the old matcher's name, these also get overwritten. In the examples below, the string `"include"` is replaced in both the outputs by the new matcher's name.
> 
> ```ruby
> it 'overwrites data for a_string_including' do
>   my_string = "a string with 'include'"
>   expect("some random string").to match(a_string_including(my_string))
> end
> 
> # => expected "some random string" to match 
> #       (a string including "a string with 'a string including'")
> ```
> 
> ```ruby
> it 'overwrites data for a_hash_including' do
>   my_hash = { my_string: "a string with 'include'" }
>   expect({}).to match(a_hash_including(my_hash))
> end
> 
> # => expected {} to match 
> #       (a hash including {:my_string => "a string with 'a hash including'"})
> ```
> 
> ## New Behavior
> 
> This change makes it so it only replaces the first instance of the original name so none of the expected data is also overwritten. The two above error outputs would be the following:
> 
> `expected {} to match (a hash including {:my_string => "a string with 'include'"})`
> `expected "some random string" to match (a string including "a string with 'include'")`
> 
> I saw this in https://github.com/rspec/rspec-rails/issues/1835.
