### PR TITLE
[rspec-expectations] Cache match results for compound failures 

### DIFF
--- a/rspec-expectations/lib/rspec/matchers/built_in/compound.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/compound.rb
@@ -77,6 +77,8 @@ module RSpec
         end
 
         def match(_expected, actual)
+          @matcher_1_matches = nil
+          @matcher_2_matches = nil
           evaluator_klass = if supports_block_expectations? && Proc === actual
                               NestedEvaluator
                             elsif supports_value_expectations?
@@ -102,11 +104,13 @@ module RSpec
         end
 
         def matcher_1_matches?
-          evaluator.matcher_matches?(matcher_1)
+          return @matcher_1_matches unless @matcher_1_matches.nil?
+          @matcher_1_matches = evaluator.matcher_matches?(matcher_1)
         end
 
         def matcher_2_matches?
-          evaluator.matcher_matches?(matcher_2)
+          return @matcher_2_matches unless @matcher_2_matches.nil?
+          @matcher_2_matches = evaluator.matcher_matches?(matcher_2)
         end
 
         def matcher_supports_block_expectations?(matcher)

--- a/rspec-expectations/spec/rspec/matchers/built_in/compound_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/compound_spec.rb
@@ -1003,31 +1003,39 @@ module RSpec::Matchers::BuiltIn
 
         context "with a failing first matcher" do
           it "generates a failure description quickly" do
-            compound = failing_matcher
-            15.times { compound = compound.and(passing_matcher) }
-            expect { expect([actual]).to compound }.to fail_including("expected [#{actual}] to include #{not_expected}")
+            timeout_if_not_debugging(0.2) do
+              compound = failing_matcher
+              15.times { compound = compound.and(passing_matcher) }
+              expect { expect([actual]).to compound }.to fail_including("expected [#{actual}] to include #{not_expected}")
+            end
           end
         end
 
         context "with a failing last matcher" do
           it "generates a failure description quickly" do
-            compound  = failing_matcher
-            15.times { compound = passing_matcher.and(compound) }
-            expect { expect([actual]).to compound }.to fail_including("expected [#{actual}] to include #{not_expected}")
+            timeout_if_not_debugging(0.2) do
+              compound  = failing_matcher
+              15.times { compound = passing_matcher.and(compound) }
+              expect { expect([actual]).to compound }.to fail_including("expected [#{actual}] to include #{not_expected}")
+            end
           end
         end
 
         context "with all failing matchers" do
           it "generates a failure description quickly with and" do
-            compound = failing_matcher
-            15.times { compound = compound.and(failing_matcher) }
-            expect { expect([actual]).to compound }.to fail_including("expected [#{actual}] to include #{not_expected}")
+            timeout_if_not_debugging(0.2) do
+              compound = failing_matcher
+              15.times { compound = compound.and(failing_matcher) }
+              expect { expect([actual]).to compound }.to fail_including("expected [#{actual}] to include #{not_expected}")
+            end
           end
 
           it "generates a failure description quickly with or" do
-            compound = failing_matcher
-            15.times { compound = compound.or(failing_matcher) }
-            expect { expect([actual]).to compound }.to fail_including("expected [#{actual}] to include #{not_expected}")
+            timeout_if_not_debugging(0.2) do
+              compound = failing_matcher
+              15.times { compound = compound.or(failing_matcher) }
+              expect { expect([actual]).to compound }.to fail_including("expected [#{actual}] to include #{not_expected}")
+            end
           end
         end
       end

--- a/rspec-expectations/spec/rspec/matchers/built_in/compound_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/compound_spec.rb
@@ -993,6 +993,44 @@ module RSpec::Matchers::BuiltIn
           |
         EOS
       end
+
+      context "with long chains of compound matchers" do
+        let(:failing_matcher) { include(not_expected) }
+        let(:passing_matcher) { include(expected) }
+        let(:expected) { actual }
+        let(:not_expected) { 3 }
+        let(:actual) { 4 }
+
+        context "with a failing first matcher" do
+          it "generates a failure description quickly" do
+            compound = failing_matcher
+            15.times { compound = compound.and(passing_matcher) }
+            expect { expect([actual]).to compound }.to fail_including("expected [#{actual}] to include #{not_expected}")
+          end
+        end
+
+        context "with a failing last matcher" do
+          it "generates a failure description quickly" do
+            compound  = failing_matcher
+            15.times { compound = passing_matcher.and(compound) }
+            expect { expect([actual]).to compound }.to fail_including("expected [#{actual}] to include #{not_expected}")
+          end
+        end
+
+        context "with all failing matchers" do
+          it "generates a failure description quickly with and" do
+            compound = failing_matcher
+            15.times { compound = compound.and(failing_matcher) }
+            expect { expect([actual]).to compound }.to fail_including("expected [#{actual}] to include #{not_expected}")
+          end
+
+          it "generates a failure description quickly with or" do
+            compound = failing_matcher
+            15.times { compound = compound.or(failing_matcher) }
+            expect { expect([actual]).to compound }.to fail_including("expected [#{actual}] to include #{not_expected}")
+          end
+        end
+      end
     end
 
     describe "expect(...).not_to matcher.or(other_matcher)" do

--- a/rspec-expectations/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -186,14 +186,6 @@ the missing elements were:      [1]
 MESSAGE
   end
 
-  def timeout_if_not_debugging(time)
-    in_sub_process_if_possible do
-      require 'timeout'
-      return yield if defined?(::Debugger)
-      Timeout.timeout(time) { yield }
-    end
-  end
-
   it 'fails a match of 11 items with duplicates in a reasonable amount of time' do
     timeout_if_not_debugging(0.1) do
       expected = [0, 1, 1,    3, 3, 3,    4, 4,    8, 8, 9   ]

--- a/rspec-expectations/spec/spec_helper.rb
+++ b/rspec-expectations/spec/spec_helper.rb
@@ -41,6 +41,14 @@ module CommonHelperMethods
     warnings
   end
 
+  def timeout_if_not_debugging(time)
+    in_sub_process_if_possible do
+      require 'timeout'
+      return yield if defined?(::Debugger)
+      Timeout.timeout(time) { yield }
+    end
+  end
+
   # We have to use Hash#inspect in examples that have multi-entry
   # hashes because the #inspect output on 1.8.7 is non-deterministic
   # due to the fact that hashes are not ordered. So we can't simply


### PR DESCRIPTION
This is rspec/rspec-expectations#1334

> 
> fixes rspec/rspec#87 
> 
> When a compound matcher fails, the failure message checks both sides of
> the match to determine how to display the failure match.  When multiple
> compound matchers are chained, that means the match for each side of the
> compound matcher may be called repeatedly for exponential growth.
> 
> To address this behavior, we can cache the match result for each side of
> the compound operator each time a match is executed.  We need to reset the
> cache each time the match is executed because the matcher may be re-used
> for a different expectation.
> 
> Added RSpec context timing before the patch:
> ```
> RSpec::Matchers::BuiltIn::Compound
>   when chaining many matchers together
>     with long chains of compound matchers
>       with a failing first matcher
>         generates a failure description quickly
>       with all failing matchers
>         generates a failure description quickly with or
>         generates a failure description quickly with and
>       with a failing last matcher
>         generates a failure description quickly
> 
> Finished in 2 minutes 47.7 seconds (files took 0.43342 seconds to load)
> 4 examples, 0 failures
> ```
> 
> Added RSpec context timing after the patch:
> ```
> RSpec::Matchers::BuiltIn::Compound
>   when chaining many matchers together
>     with long chains of compound matchers
>       with a failing last matcher
>         generates a failure description quickly
>       with all failing matchers
>         generates a failure description quickly with and
>         generates a failure description quickly with or
>       with a failing first matcher
>         generates a failure description quickly
> 
> Finished in 0.05168 seconds (files took 0.42805 seconds to load)
> 4 examples, 0 failures
> ```
