### PR TITLE
[rspec-expectations] Delegate kwargs when defining a method with `chain`

### DIFF
--- a/rspec-expectations/Changelog.md
+++ b/rspec-expectations/Changelog.md
@@ -74,6 +74,10 @@ Bug Fixes:
 * When handling failures in an aggregated_failures block (or example) prevent
   the failure list leaking out. (Maciek Rząsa, #1392)
 
+Bug Fixes:
+
+* Fix keyword arguments delegation for `chain` in custom matchers. (Tyler Rick, #1374)
+
 ### 3.12.0 / 2022-10-26
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.11.1...v3.12.0)
 

--- a/rspec-expectations/lib/rspec/matchers/dsl.rb
+++ b/rspec-expectations/lib/rspec/matchers/dsl.rb
@@ -309,6 +309,7 @@ module RSpec
             @chained_method_clauses.push([method_name, args])
             self
           end
+          ruby2_keywords method_name if respond_to?(:ruby2_keywords, true)
         end
 
         def assign_attributes(attr_names)

--- a/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
@@ -356,9 +356,17 @@ module RSpec::Matchers::DSL
             (to_match <= five) || (greater_than_ceiling(to_match) && not_divisible_by_divisor?(to_match))
           end
 
-          chain :and_smaller_than do |ceiling, inclusive: false|
-            @ceiling = ceiling
-            @ceiling_inclusive = inclusive
+          if RSpec::Support::RubyFeatures.kw_args_supported?
+            binding.eval(<<-CODE, __FILE__, __LINE__)
+            chain :and_smaller_than do |ceiling, inclusive: false|
+              @ceiling = ceiling
+              @ceiling_inclusive = inclusive
+            end
+            CODE
+          else
+            chain :and_smaller_than do |ceiling|
+              @ceiling = ceiling
+            end
           end
 
           chain :and_divisible_by do |divisor|
@@ -367,10 +375,16 @@ module RSpec::Matchers::DSL
 
         private
 
-          def smaller_than_ceiling?(to_match)
-            if @ceiling_inclusive
-              to_match <= @ceiling
-            else
+          if RSpec::Support::RubyFeatures.kw_args_supported?
+            def smaller_than_ceiling?(to_match)
+              if @ceiling_inclusive
+                to_match <= @ceiling
+              else
+                to_match < @ceiling
+              end
+            end
+          else
+            def smaller_than_ceiling?(to_match)
               to_match < @ceiling
             end
           end
@@ -429,9 +443,13 @@ module RSpec::Matchers::DSL
               fail_with 'expected 21 not to be bigger than 5 and smaller than 29 and divisible by 3'
           end
 
-          it "allows passing keyword args to chain block" do
-            match = matcher.and_smaller_than(10, inclusive: true).and_divisible_by(1)
-            expect(10).to match
+          if RSpec::Support::RubyFeatures.kw_args_supported?
+            binding.eval(<<-CODE, __FILE__, __LINE__)
+            it "allows passing keyword args to chain block" do
+              match = matcher.and_smaller_than(10, inclusive: true).and_divisible_by(1)
+              expect(10).to match
+            end
+            CODE
           end
         end
 

--- a/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
@@ -356,8 +356,9 @@ module RSpec::Matchers::DSL
             (to_match <= five) || (greater_than_ceiling(to_match) && not_divisible_by_divisor?(to_match))
           end
 
-          chain :and_smaller_than do |ceiling|
+          chain :and_smaller_than do |ceiling, inclusive: false|
             @ceiling = ceiling
+            @ceiling_inclusive = inclusive
           end
 
           chain :and_divisible_by do |divisor|
@@ -367,7 +368,11 @@ module RSpec::Matchers::DSL
         private
 
           def smaller_than_ceiling?(to_match)
-            to_match < @ceiling
+            if @ceiling_inclusive
+              to_match <= @ceiling
+            else
+              to_match < @ceiling
+            end
           end
 
           def greater_than_ceiling(to_match)
@@ -375,11 +380,11 @@ module RSpec::Matchers::DSL
           end
 
           def divisible_by_divisor?(to_match)
-            @divisor % to_match == 0
+            to_match % @divisor == 0
           end
 
           def not_divisible_by_divisor?(to_match)
-            @divisor % to_match != 0
+            to_match % @divisor != 0
           end
         end
       end
@@ -399,7 +404,7 @@ module RSpec::Matchers::DSL
             expect { expect(8).to match }.to fail_with 'expected 8 to be bigger than 5'
           end
 
-          it "provides a default negative expectation failure message that does not include the any of the chained matchers's descriptions" do
+          it "provides a default negative expectation failure message that does not include any of the chained matchers' descriptions" do
             expect { expect(9).to_not match }.to fail_with 'expected 9 not to be bigger than 5'
           end
         end
@@ -422,6 +427,11 @@ module RSpec::Matchers::DSL
           it "provides a default negative expectation failure message that includes the chained matchers' failures" do
             expect { expect(21).to_not matcher.and_smaller_than(29).and_divisible_by(3) }.to \
               fail_with 'expected 21 not to be bigger than 5 and smaller than 29 and divisible by 3'
+          end
+
+          it "allows passing keyword args to chain block" do
+            match = matcher.and_smaller_than(10, inclusive: true).and_divisible_by(1)
+            expect(10).to match
           end
         end
 


### PR DESCRIPTION
This is rspec/rspec-expectations#1374

> Without this, it will raise:
>
>      ArgumentError:
>        wrong number of arguments (given 2, expected 1)
>
> if you try to pass a keyword arg to a chain method on Ruby 3.
>
> ~In Ruby, you _must_ explicitly delegate keyword arguments. (See https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/#delegation-ruby-3)~