### PR TITLE
[rspec-expectations] Prevent custom matcher is called twice without compound

### DIFF
--- a/rspec-expectations/lib/rspec/matchers/dsl.rb
+++ b/rspec-expectations/lib/rspec/matchers/dsl.rb
@@ -132,6 +132,7 @@ module RSpec
         # @yield [Object] actual the actual value (i.e. the value wrapped by `expect`)
         def match(options={}, &match_block)
           define_user_override(:matches?, match_block) do |actual|
+            check_method_call_count
             @actual = actual
             RSpec::Support.with_failure_notifier(RAISE_NOTIFIER) do
               begin
@@ -161,6 +162,7 @@ module RSpec
         # @yield [Object] actual the actual value (i.e. the value wrapped by `expect`)
         def match_when_negated(options={}, &match_block)
           define_user_override(:does_not_match?, match_block) do |actual|
+            check_method_call_count
             begin
               @actual = actual
               RSpec::Support.with_failure_notifier(RAISE_NOTIFIER) do
@@ -460,6 +462,9 @@ module RSpec
         # The name of the matcher.
         attr_reader :name
 
+        # Keep track of how many times a custom matcher is called
+        attr_reader :call_count
+
         # @api private
         def initialize(name, declarations, matcher_execution_context, *expected, &block_arg)
           @name     = name
@@ -468,6 +473,7 @@ module RSpec
           @matcher_execution_context = matcher_execution_context
           @chained_method_clauses = []
           @block_arg = block_arg
+          @call_count = 1
 
           klass =
             class << self
@@ -475,6 +481,9 @@ module RSpec
               include(@user_method_defs = Module.new)
               self
             end
+
+          override_custom_matcher_method(klass, name)
+
           RSpec::Support::WithKeywordsWhenNeeded.class_exec(klass, *expected, &declarations)
         end
 
@@ -521,6 +530,23 @@ module RSpec
         end
 
       private
+
+        def override_custom_matcher_method(klass, name)
+          klass.__send__(:define_method, name) do |*args, &block|
+            super(*args, &block).tap do |instance|
+              instance.instance_variable_set(:@call_count, call_count + 1)
+            end
+          end
+        end
+
+        def check_method_call_count
+          if (@call_count -= 1) > 0
+            RSpec.warning(
+              "The custom matcher `#{name}` or its negated method is called " \
+               'more than once in the test expectations without using `and` or `or`'
+            )
+          end
+        end
 
         def actual_arg_for(block)
           block.arity.zero? ? [] : [@actual]

--- a/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
@@ -83,6 +83,48 @@ RSpec.describe "a matcher defined using the matcher DSL" do
     expect(4).to be_just_like(4)
   end
 
+  describe 'check method call count' do
+    RSpec::Matchers.define :be_fine do
+      match { |actual| expect(actual).to eq('ok') }
+    end
+
+    RSpec::Matchers.define :have_keys do |attributes|
+      match { |actual| match_keys(actual, attributes) }
+
+      def match_keys(actual, attributes)
+        if attributes.is_a?(Array)
+          attributes.each do |attr|
+            expect(actual).to have_keys(attr)
+          end
+        else
+          expect(actual).to include(attributes)
+        end
+      end
+    end
+
+    it do
+      expect(RSpec).not_to receive(:warning)
+      expect(ok).to be_fine.and be_fine
+      expect(ok).to be_fine.or be_fine
+    end
+
+    context 'when custom matcher is called recursively' do
+      it 'does not raise a warning' do
+        expect(RSpec).not_to receive(:warning)
+        expect({ 'user' => 'Minh', 'id' => 1 }).to have_keys(%w[user id])
+      end
+    end
+
+    context 'when a custom matcher is called twice without using compound' do
+      it 'raises a warning' do
+        expect(RSpec).to receive(:warning).with(/The custom matcher `be_fine` or its negated method is called/)
+        expect(ok).to be_fine.and be_fine
+        expect(ok).to be_fine.or be_fine
+        expect(ok).to be_fine.be_fine
+      end
+    end
+  end
+
   describe '#block_arg' do
     before(:context) do
       RSpec::Matchers.define :be_lazily_equal_to do
@@ -1351,6 +1393,5 @@ module RSpec::Matchers::DSL
         defined?(RUBY_ENGINE) && RUBY_ENGINE == 'rbx'
       end
     end
-
   end
 end


### PR DESCRIPTION
This is rspec/rspec-expectations#1428

> Hey lovely folks :wave:, I hope you all are doing well 
>
> This PR here is to address https://github.com/rspec/rspec/issues/142 which is to prevent a custom matcher from calling twice without compound like `.and` or `.or`