### PR TITLE
[rspec-expectations] Allow `satisfy` to match block expectations return value

### DIFF
--- a/rspec-expectations/Changelog.md
+++ b/rspec-expectations/Changelog.md
@@ -5,6 +5,7 @@ Enhancements:
 
 * Improve the IO emulation in the output capture matchers (`output(...).to_stdout` et al)
   by adding `as_tty` and `as_not_tty` to change the `tty?` flags. (Sergio Gil Pérez de la Manga, #1459)
+* Allow `satisfy` to match block expectations return value. (Phil Pirozhkov, #1477)
 
 ### 3.13.3 / 2024-09-07
 [Full Changelog](http://github.com/rspec/rspec-expectations/compare/v3.13.2...v3.13.3)

--- a/rspec-expectations/features/built_in_matchers/satisfy.feature
+++ b/rspec-expectations/features/built_in_matchers/satisfy.feature
@@ -17,6 +17,20 @@ Feature: `satisfy` matcher
   end
   ```
 
+  The `satisfy` matcher can also be used on block expectations to match the returned value of the block:
+
+  ```ruby
+  expect { 2 + 2 }.to satisfy { |returned_value| returned_value == 4 }
+  ```
+
+  This comes handy to check both the side effects of the subject under test and its returned value:
+
+  ```ruby
+  expect { request! }
+    .to change { Log.count }.by(1)
+    .and satisfy { |response| response.success? }
+  ```
+
   @skip-when-ripper-unsupported
   Scenario: Basic usage
     Given a file named "satisfy_matcher_spec.rb" with:
@@ -39,3 +53,20 @@ Feature: `satisfy` matcher
       | expected 10 to satisfy expression `v > 15`    |
       | expected 10 not to be greater than 5          |
       | expected 10 to be greater than 15             |
+
+  @skip-when-ripper-unsupported
+  Scenario: Matching the block expectation return value
+    Given a file named "satisfy_matcher_returned_value_spec.rb" with:
+      """ruby
+      RSpec.describe "double-purpose" do
+        it "adds an entry and returns the sum" do
+          ary = [1, 2, 3]
+          expect { ary.shift }
+            .to change { ary }.to([2, 3])
+            .and satisfy { |returned_value| returned_value == 1 }
+        end
+      end
+      """
+    When I run `rspec satisfy_matcher_returned_value_spec.rb`
+    Then the output should contain all of these:
+      | 1 example, 0 failures                        |

--- a/rspec-expectations/lib/rspec/matchers.rb
+++ b/rspec-expectations/lib/rspec/matchers.rb
@@ -797,8 +797,9 @@ module RSpec
     alias_matcher :an_object_responding_to, :respond_to
     alias_matcher :responding_to, :respond_to
 
-    # Passes if the submitted block returns true. Yields target to the
-    # block.
+    # Passes if the submitted block returns true.
+    # For value expectations, yields target to the block.
+    # For block expectations, yields the expectation's returned value to the block.
     #
     # Generally speaking, this should be thought of as a last resort when
     # you can't find any other way to specify the behaviour you wish to
@@ -812,6 +813,10 @@ module RSpec
     # @example
     #   expect(5).to satisfy { |n| n > 3 }
     #   expect(5).to satisfy("be greater than 3") { |n| n > 3 }
+    #
+    #   expect { ary.shift }
+    #     .to change { ary }.to(be_empty)
+    #     .and satisfy { |returned_value| returned_value == :last_on_the_list }
     def satisfy(description=nil, &block)
       BuiltIn::Satisfy.new(description, &block)
     end

--- a/rspec-expectations/lib/rspec/matchers/built_in/compound.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/compound.rb
@@ -167,8 +167,13 @@ module RSpec
 
             inner, outer = order_block_matchers
 
+            returned = nil
             @match_results[outer] = outer.matches?(Proc.new do |*args|
-              @match_results[inner] = inner.matches?(inner_matcher_block(args))
+              p = Proc.new { |*args2|
+                returned = inner_matcher_block(args).call(*args2)
+              }
+              @match_results[inner] = inner.matches?(p)
+              returned
             end)
           end
 

--- a/rspec-expectations/lib/rspec/matchers/built_in/satisfy.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/satisfy.rb
@@ -14,9 +14,14 @@ module RSpec
 
         # @private
         def matches?(actual, &block)
-          @block = block if block
-          @actual = actual
-          @block.call(actual)
+          if Proc === actual
+            @actual = actual.call
+            @block.call(@actual)
+          else
+            @block = block if block
+            @actual = actual
+            @block.call(actual)
+          end
         end
 
         # @private
@@ -34,6 +39,13 @@ module RSpec
         # @return [String]
         def failure_message_when_negated
           "expected #{actual_formatted} not to #{description}"
+        end
+
+        # @api private
+        # Indicates this matcher matches against a block.
+        # @return [True]
+        def supports_block_expectations?
+          true
         end
 
       private

--- a/rspec-expectations/spec/rspec/matchers/aliased_matcher_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/aliased_matcher_spec.rb
@@ -16,7 +16,7 @@ module RSpec
       end
       RSpec::Matchers.alias_matcher :alias_of_my_base_matcher, :my_base_matcher
 
-      it_behaves_like "an RSpec value matcher", :valid_value => 13, :invalid_value => nil do
+      it_behaves_like "an RSpec value-only matcher", :valid_value => 13, :invalid_value => nil do
         let(:matcher) { alias_of_my_base_matcher }
       end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/all_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/all_spec.rb
@@ -3,7 +3,7 @@
 module RSpec::Matchers::BuiltIn
   RSpec.describe All do
 
-    it_behaves_like 'an RSpec value matcher', :valid_value => ['A', 'A', 'A'], :invalid_value => ['A', 'A', 'B'], :disallows_negation => true do
+    it_behaves_like 'an RSpec value-only matcher', :valid_value => ['A', 'A', 'A'], :invalid_value => ['A', 'A', 'B'], :disallows_negation => true do
       let(:matcher) { all( eq('A') ) }
     end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/be_between_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/be_between_spec.rb
@@ -82,7 +82,7 @@ module RSpec::Matchers::BuiltIn
       end
     end
 
-    it_behaves_like "an RSpec value matcher", :valid_value => (10), :invalid_value => (11) do
+    it_behaves_like "an RSpec value-only matcher", :valid_value => (10), :invalid_value => (11) do
       let(:matcher) { be_between(1, 10) }
     end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/be_instance_of_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/be_instance_of_spec.rb
@@ -4,7 +4,7 @@ module RSpec
   module Matchers
     [:be_an_instance_of, :be_instance_of].each do |method|
       RSpec.describe "expect(actual).to #{method}(expected)" do
-        it_behaves_like "an RSpec value matcher", :valid_value => "a", :invalid_value => 5 do
+        it_behaves_like "an RSpec value-only matcher", :valid_value => "a", :invalid_value => 5 do
           let(:matcher) { send(method, String) }
         end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/be_kind_of_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/be_kind_of_spec.rb
@@ -4,7 +4,7 @@ module RSpec
   module Matchers
     [:be_a_kind_of, :be_kind_of].each do |method|
       RSpec.describe "expect(actual).to #{method}(expected)" do
-        it_behaves_like "an RSpec value matcher", :valid_value => 5, :invalid_value => "a" do
+        it_behaves_like "an RSpec value-only matcher", :valid_value => 5, :invalid_value => "a" do
           let(:matcher) { send(method, Integer) }
         end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/be_within_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/be_within_spec.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Matchers
     RSpec.describe "expect(actual).to be_within(delta).of(expected)" do
-      it_behaves_like "an RSpec value matcher", :valid_value => 5, :invalid_value => -5 do
+      it_behaves_like "an RSpec value-only matcher", :valid_value => 5, :invalid_value => -5 do
         let(:matcher) { be_within(2).of(4.0) }
       end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/compound_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/compound_spec.rb
@@ -291,12 +291,12 @@ module RSpec::Matchers::BuiltIn
 
     describe "expect(...).to matcher.and(other_matcher)" do
 
-      it_behaves_like "an RSpec value matcher", :valid_value => 3, :invalid_value => 4, :disallows_negation => true do
+      it_behaves_like "an RSpec value-only matcher", :valid_value => 3, :invalid_value => 4, :disallows_negation => true do
         let(:matcher) { eq(3).and be <= 3 }
       end
 
       context 'when using boolean AND `&` alias' do
-        it_behaves_like "an RSpec value matcher", :valid_value => 3, :invalid_value => 4, :disallows_negation => true do
+        it_behaves_like "an RSpec value-only matcher", :valid_value => 3, :invalid_value => 4, :disallows_negation => true do
           let(:matcher) { eq(3) & be_a(Integer) }
         end
       end
@@ -691,12 +691,12 @@ module RSpec::Matchers::BuiltIn
     end
 
     describe "expect(...).to matcher.or(other_matcher)" do
-      it_behaves_like "an RSpec value matcher", :valid_value => 3, :invalid_value => 5, :disallows_negation => true do
+      it_behaves_like "an RSpec value-only matcher", :valid_value => 3, :invalid_value => 5, :disallows_negation => true do
         let(:matcher) { eq(3).or eq(4) }
       end
 
       context 'when using boolean OR `|` alias' do
-        it_behaves_like "an RSpec value matcher", :valid_value => 3, :invalid_value => 5, :disallows_negation => true do
+        it_behaves_like "an RSpec value-only matcher", :valid_value => 3, :invalid_value => 5, :disallows_negation => true do
           let(:matcher) { eq(3) | eq(4) }
         end
       end

--- a/rspec-expectations/spec/rspec/matchers/built_in/contain_exactly_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/contain_exactly_spec.rb
@@ -150,7 +150,7 @@ RSpec.describe "using contain_exactly with expect" do
 end
 
 RSpec.describe "expect(array).to contain_exactly(*other_array)" do
-  it_behaves_like "an RSpec value matcher", :valid_value => [1, 2], :invalid_value => [1] do
+  it_behaves_like "an RSpec value-only matcher", :valid_value => [1, 2], :invalid_value => [1] do
     let(:matcher) { contain_exactly(2, 1) }
   end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/cover_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/cover_spec.rb
@@ -2,7 +2,7 @@
 
 if (1..2).respond_to?(:cover?)
   RSpec.describe "expect(...).to cover(expected)" do
-    it_behaves_like "an RSpec value matcher", :valid_value => (1..10), :invalid_value => (20..30) do
+    it_behaves_like "an RSpec value-only matcher", :valid_value => (1..10), :invalid_value => (20..30) do
       let(:matcher) { cover(5) }
     end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/eq_spec.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Matchers
     RSpec.describe "eq" do
-      it_behaves_like "an RSpec value matcher", :valid_value => 1, :invalid_value => 2 do
+      it_behaves_like "an RSpec value-only matcher", :valid_value => 1, :invalid_value => 2 do
         let(:matcher) { eq(1) }
       end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/eql_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/eql_spec.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Matchers
     RSpec.describe "eql" do
-      it_behaves_like "an RSpec value matcher", :valid_value => 1, :invalid_value => 2 do
+      it_behaves_like "an RSpec value-only matcher", :valid_value => 1, :invalid_value => 2 do
         let(:matcher) { eql(1) }
       end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/equal_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/equal_spec.rb
@@ -3,7 +3,7 @@
 module RSpec
   module Matchers
     RSpec.describe "equal" do
-      it_behaves_like "an RSpec value matcher", :valid_value => :a, :invalid_value => :b do
+      it_behaves_like "an RSpec value-only matcher", :valid_value => :a, :invalid_value => :b do
         let(:matcher) { equal(:a) }
       end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/exist_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/exist_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "exist matcher" do
-  it_behaves_like "an RSpec value matcher", :valid_value => Class.new { def exist?; true; end }.new,
+  it_behaves_like "an RSpec value-only matcher", :valid_value => Class.new { def exist?; true; end }.new,
                                             :invalid_value => Class.new { def exist?; false; end }.new do
     let(:matcher) { exist }
   end

--- a/rspec-expectations/spec/rspec/matchers/built_in/has_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/has_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "expect(...).to have_sym(*args)" do
-  it_behaves_like "an RSpec value matcher", :valid_value => { :a => 1 },
+  it_behaves_like "an RSpec value-only matcher", :valid_value => { :a => 1 },
                                             :invalid_value => {} do
     let(:matcher) { have_key(:a) }
   end

--- a/rspec-expectations/spec/rspec/matchers/built_in/have_attributes_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/have_attributes_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe "#have_attributes matcher" do
   end
 
   describe "expect(...).to have_attributes(with_one_attribute)" do
-    it_behaves_like "an RSpec value matcher", :valid_value => Person.new("Correct name", 33), :invalid_value => Person.new("Wrong Name", 11) do
+    it_behaves_like "an RSpec value-only matcher", :valid_value => Person.new("Correct name", 33), :invalid_value => Person.new("Wrong Name", 11) do
       let(:matcher) { have_attributes(:name => "Correct name") }
     end
 
@@ -150,7 +150,7 @@ RSpec.describe "#have_attributes matcher" do
   end
 
   describe "expect(...).to have_attributes(with_multiple_attributes)" do
-    it_behaves_like "an RSpec value matcher", :valid_value => Person.new("Correct name", 33), :invalid_value => Person.new("Wrong Name", 11) do
+    it_behaves_like "an RSpec value-only matcher", :valid_value => Person.new("Correct name", 33), :invalid_value => Person.new("Wrong Name", 11) do
       let(:matcher) { have_attributes(:name => "Correct name", :age => 33) }
     end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/include_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/include_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe "#include matcher" do
   end
 
   describe "expect(...).to include(with_one_arg)" do
-    it_behaves_like "an RSpec value matcher", :valid_value => [1, 2], :invalid_value => [1] do
+    it_behaves_like "an RSpec value-only matcher", :valid_value => [1, 2], :invalid_value => [1] do
       let(:matcher) { include(2) }
     end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/match_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/match_spec.rb
@@ -3,7 +3,7 @@
 RSpec.describe "expect(...).to match(expected)" do
   include RSpec::Support::Spec::DiffHelpers
 
-  it_behaves_like "an RSpec value matcher", :valid_value => 'ab', :invalid_value => 'bc' do
+  it_behaves_like "an RSpec value-only matcher", :valid_value => 'ab', :invalid_value => 'bc' do
     let(:matcher) { match(/a/) }
   end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/respond_to_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/respond_to_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "expect(...).to respond_to(:sym)" do
-  it_behaves_like "an RSpec value matcher", :valid_value => "s", :invalid_value => 5 do
+  it_behaves_like "an RSpec value-only matcher", :valid_value => "s", :invalid_value => 5 do
     let(:matcher) { respond_to(:upcase) }
   end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/satisfy_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/satisfy_spec.rb
@@ -122,3 +122,54 @@ RSpec.describe "expect(...).not_to satisfy { block }" do
     end
   end
 end
+
+RSpec.describe "expect { ... }.to satisfy { block }" do
+  it_behaves_like "an RSpec block matcher", :disallows_negation => true, :skip_deprecation_check => true do
+    let(:matcher) { satisfy { |v| v == 1 } }
+    before { @k = 0 }
+    def valid_block
+      1
+    end
+    def invalid_block
+      2
+    end
+  end
+
+  let(:ary) { [1, 2] }
+
+  it "matches the returned value" do
+    expect { ary.shift }.to satisfy { |returned_value| returned_value == 1 }
+  end
+
+  it "provides a sensible failure message", :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+    expect {
+      expect { ary.shift }.to satisfy { |returned_value| returned_value == :other }
+    }.to fail_with("expected 1 to satisfy expression `returned_value == :other`")
+  end
+
+  context "when negated" do
+    it "passes when the returned value doesn't match" do
+      expect { ary.shift }.not_to satisfy { |returned_value| returned_value == 2 }
+    end
+
+    it "fails when the retuned value matches", :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+      expect {
+        expect { ary.shift }.not_to satisfy { |returned_value| returned_value == 1 }
+      }.to fail_with("expected 1 not to satisfy expression `returned_value == 1`")
+    end
+  end
+
+  describe "composed usage" do
+    it "works as a root matcher" do
+      expect { ary.shift }.to satisfy { |returned_value| returned_value == 1 }.and change { ary }.to([2])
+    end
+
+    it "works as a supplemental matcher" do
+      expect { ary.shift }.to change { ary }.to([2]).and satisfy { |returned_value| returned_value == 1 }
+    end
+  end
+
+  pending "allows a matcher as an argument" do
+    expect { ary.shift }.to satisfy(eq(2))
+  end
+end

--- a/rspec-expectations/spec/rspec/matchers/built_in/start_and_end_with_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/start_and_end_with_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 RSpec.describe "expect(...).to start_with" do
-  it_behaves_like "an RSpec value matcher", :valid_value => "ab", :invalid_value => "bc" do
+  it_behaves_like "an RSpec value-only matcher", :valid_value => "ab", :invalid_value => "bc" do
     let(:matcher) { start_with("a") }
   end
 
@@ -209,7 +209,7 @@ RSpec.describe "expect(...).not_to start_with" do
 end
 
 RSpec.describe "expect(...).to end_with" do
-  it_behaves_like "an RSpec value matcher", :valid_value => "ab", :invalid_value => "bc" do
+  it_behaves_like "an RSpec value-only matcher", :valid_value => "ab", :invalid_value => "bc" do
     let(:matcher) { end_with("b") }
   end
 

--- a/rspec-expectations/spec/rspec/matchers/define_negated_matcher_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/define_negated_matcher_spec.rb
@@ -47,7 +47,7 @@ module RSpec
       include_examples "making a copy", :clone
 
       RSpec::Matchers.define_negated_matcher :an_array_excluding, :include
-      it_behaves_like "an RSpec value matcher", :valid_value => [1, 3], :invalid_value => [1, 2] do
+      it_behaves_like "an RSpec value-only matcher", :valid_value => [1, 3], :invalid_value => [1, 2] do
         let(:matcher) { an_array_excluding(2) }
       end
 

--- a/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
@@ -185,7 +185,7 @@ module RSpec::Matchers::DSL
       RSpec::Matchers::DSL::Matcher.new(name, block, self, *expected)
     end
 
-    it_behaves_like "an RSpec value matcher", :valid_value => 1, :invalid_value => 2 do
+    it_behaves_like "an RSpec value-only matcher", :valid_value => 1, :invalid_value => 2 do
       let(:matcher) do
         new_matcher(:equal_to_1) do
           match { |v| v == 1 }

--- a/rspec-expectations/spec/rspec/matchers_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers_spec.rb
@@ -121,7 +121,7 @@ module RSpec
 
         # This spec is merely to make sure we don't forget to make
         # a built-in matcher implement `===`. It doesn't check the
-        # semantics of that. Use the "an RSpec value matcher" and
+        # semantics of that. Use the "an RSpec value-only matcher" and
         # "an RSpec block-only matcher" shared example groups to
         # actually check the semantics.
         expect(missing_threequals).to eq([])

--- a/rspec-expectations/spec/support/shared_examples/block_matcher.rb
+++ b/rspec-expectations/spec/support/shared_examples/block_matcher.rb
@@ -8,6 +8,40 @@ RSpec.shared_examples "an RSpec block-only matcher" do |*options|
   # if it was passed.
   options = options.first || {}
 
+  include_examples "an RSpec block matcher", options
+
+  it 'fails gracefully when given a value' do
+    expect {
+      expect(3).to matcher
+    }.to fail_with(/was not( given)? a block/)
+
+    unless options[:disallows_negation]
+      expect {
+        expect(3).not_to matcher
+      }.to fail_with(/was not( given)? a block/)
+    end
+  end
+
+  it 'prints a deprecation warning when given a value' do
+    expect_warn_deprecation(/The implicit block expectation syntax is deprecated, you should pass/)
+    expect { expect(3).to matcher }.to fail
+  end unless options[:skip_deprecation_check] || options[:expects_lambda]
+
+  it 'prints a deprecation warning when given a value and negated' do
+    expect_warn_deprecation(/The implicit block expectation syntax is deprecated, you should pass/)
+    expect { expect(3).not_to matcher }.to fail
+  end unless options[:disallows_negation] || options[:expects_lambda]
+
+  it 'allows lambda expectation target' do
+    allow_deprecation
+    expect(valid_block_lambda).to matcher
+  end
+end
+
+RSpec.shared_examples "an RSpec block matcher" do |*options|
+  # See the note above
+  options = options.first || {}
+
   # Note: do not use `matcher` in 2 expectation expressions in a single
   # example here. In some cases (such as `change { x += 2 }.to(2)`), it
   # will fail because using it a second time will apply `x += 2` twice,
@@ -67,31 +101,4 @@ RSpec.shared_examples "an RSpec block-only matcher" do |*options|
       expect(error.message).to include("detailed inspect")
     end
   end unless options[:failure_message_uses_no_inspect]
-
-  it 'fails gracefully when given a value' do
-    expect {
-      expect(3).to matcher
-    }.to fail_with(/was not( given)? a block/)
-
-    unless options[:disallows_negation]
-      expect {
-        expect(3).not_to matcher
-      }.to fail_with(/was not( given)? a block/)
-    end
-  end
-
-  it 'prints a deprecation warning when given a value' do
-    expect_warn_deprecation(/The implicit block expectation syntax is deprecated, you should pass/)
-    expect { expect(3).to matcher }.to fail
-  end unless options[:skip_deprecation_check] || options[:expects_lambda]
-
-  it 'prints a deprecation warning when given a value and negated' do
-    expect_warn_deprecation(/The implicit block expectation syntax is deprecated, you should pass/)
-    expect { expect(3).not_to matcher }.to fail
-  end unless options[:disallows_negation] || options[:expects_lambda]
-
-  it 'allows lambda expectation target' do
-    allow_deprecation
-    expect(valid_block_lambda).to matcher
-  end
 end

--- a/rspec-expectations/spec/support/shared_examples/value_matcher.rb
+++ b/rspec-expectations/spec/support/shared_examples/value_matcher.rb
@@ -1,5 +1,21 @@
 # frozen_string_literal: true
 
+RSpec.shared_examples "an RSpec value-only matcher" do |options|
+  include_examples "an RSpec value matcher", options
+
+  it 'fails when given a block' do
+    expect {
+      expect { 2 + 2 }.to matcher
+    }.to fail_with(/must pass an argument rather than a block/)
+
+    unless options[:disallows_negation]
+      expect {
+        expect { 2 + 2 }.not_to matcher
+      }.to fail_with(/must pass an argument rather than a block/)
+    end
+  end
+end
+
 RSpec.shared_examples "an RSpec value matcher" do |options|
   let(:valid_value)   { options.fetch(:valid_value) }
   let(:invalid_value) { options.fetch(:invalid_value) }
@@ -52,17 +68,5 @@ RSpec.shared_examples "an RSpec value matcher" do |options|
     # Undo our stub so it doesn't affect the `include` matcher below.
     allow(RSpec::Support::ObjectFormatter).to receive(:format).and_call_original
     expect(message).to include("detailed inspect")
-  end
-
-  it 'fails when given a block' do
-    expect {
-      expect { 2 + 2 }.to matcher
-    }.to fail_with(/must pass an argument rather than a block/)
-
-    unless options[:disallows_negation]
-      expect {
-        expect { 2 + 2 }.not_to matcher
-      }.to fail_with(/must pass an argument rather than a block/)
-    end
   end
 end


### PR DESCRIPTION
This is rspec/rspec-expectations#1477

> fixes https://github.com/rspec/rspec/issues/91
> idea https://github.com/rspec/rspec-expectations/issues/805#issuecomment-494380144
>
> ```ruby
> ary = [1, 2]
> expect { ary.shift }
>   .to change { ary }.to([2])
>   .and satisfy { |returned_value| returned_value == 1 }
> ```