### PR TITLE
[rspec-expectations] Fix output.to_stdout_from_any_process when $stdout has been reassigned

### DIFF
--- a/rspec-expectations/lib/rspec/matchers/built_in/output.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/output.rb
@@ -48,7 +48,7 @@ module RSpec
         # Works when subprocesses print to stdout as well.
         # This is significantly (~30x) slower than `to_stdout`
         def to_stdout_from_any_process
-          @stream_capturer = CaptureStreamToTempfile.new("stdout", $stdout)
+          @stream_capturer = CaptureStreamToTempfile.new("stdout", STDOUT) # rubocop:disable Style/GlobalStdStream
           self
         end
 
@@ -57,7 +57,7 @@ module RSpec
         # Works when subprocesses print to stderr as well.
         # This is significantly (~30x) slower than `to_stderr`
         def to_stderr_from_any_process
-          @stream_capturer = CaptureStreamToTempfile.new("stderr", $stderr)
+          @stream_capturer = CaptureStreamToTempfile.new("stderr", STDERR) # rubocop:disable Style/GlobalStdStream
           self
         end
 

--- a/rspec-expectations/lib/rspec/matchers/built_in/output.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/output.rb
@@ -48,7 +48,7 @@ module RSpec
         # Works when subprocesses print to stdout as well.
         # This is significantly (~30x) slower than `to_stdout`
         def to_stdout_from_any_process
-          @stream_capturer = CaptureStreamToTempfile.new("stdout", STDOUT) # rubocop:disable Style/GlobalStdStream
+          @stream_capturer = CaptureStreamToTempfile.new("stdout")
           self
         end
 
@@ -57,7 +57,7 @@ module RSpec
         # Works when subprocesses print to stderr as well.
         # This is significantly (~30x) slower than `to_stderr`
         def to_stderr_from_any_process
-          @stream_capturer = CaptureStreamToTempfile.new("stderr", STDERR) # rubocop:disable Style/GlobalStdStream
+          @stream_capturer = CaptureStreamToTempfile.new("stderr")
           self
         end
 
@@ -215,7 +215,7 @@ module RSpec
       end
 
       # @private
-      class CaptureStreamToTempfile < Struct.new(:name, :stream)
+      class CaptureStreamToTempfile < Struct.new(:name)
         def capture(block)
           # We delay loading tempfile until it is actually needed because
           # we want to minimize stdlibs loaded so that users who use a
@@ -225,19 +225,29 @@ module RSpec
           # thread, fileutils, etc), so it's worth delaying it until this point.
           require 'tempfile'
 
-          original_stream = stream.clone
+          stream = name == 'stdout' ? STDOUT : STDERR # rubocop:ignore Style/GlobalStdStream
           captured_stream = Tempfile.new(name)
 
           begin
+            if name == 'stdout'
+              $stdout = captured_stream
+            else
+              $stderr = captured_stream
+            end
             captured_stream.sync = true
             stream.reopen(captured_stream)
             block.call
             captured_stream.rewind
             captured_stream.read
           ensure
-            stream.reopen(original_stream)
+            stream.reopen(stream)
             captured_stream.close
             captured_stream.unlink
+            if name == 'stdout'
+              $stdout = stream
+            else
+              $stderr = stream
+            end
           end
         end
       end

--- a/rspec-expectations/spec/rspec/matchers/built_in/output_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/output_spec.rb
@@ -171,6 +171,16 @@ module RSpec
           end
         end
       }
+
+      it "passes even if $stderr has previously been set to a StringIO" do
+        original_stderr = $stderr
+        begin
+          $stderr = StringIO.new
+          expect { print_to_stream("foo") }.to output("foo").to_stderr_from_any_process
+        ensure
+          $stderr = original_stderr
+        end
+      end
     end
 
     RSpec.describe "output.to_stdout_from_any_process matcher" do
@@ -183,6 +193,16 @@ module RSpec
           end
         end
       }
+
+      it "passes even if $stdout has previously been set to a StringIO" do
+        original_stdout = $stdout
+        begin
+          $stdout = StringIO.new
+          expect { print_to_stream("foo") }.to output("foo").to_stdout_from_any_process
+        ensure
+          $stdout = original_stdout
+        end
+      end
     end
 
     RSpec.describe "output (without `to_stdout` or `to_stderr`)" do


### PR DESCRIPTION
This is rspec/rspec-expectations#1486

> (An alternate fix for https://github.com/rspec/rspec-core/pull/3113)
> 
> When running under rspec bisect runner, $stdout & $stderr are reassigned to a StringIO, which would cause "can't convert Tempfile into StringIO" when trying to reopen the stream in CaptureStreamToTempfile
> 
> Since CaptureStreamToTempfile reopens the stream rather than reassigning it, I _think_ it makes sense to use STDOUT rather than whatever the current value of $stdout is.
> 
> (Please feel free to sanity-check that assumption. I've gone round in circles a few too many times on this)
