### PR TITLE
Fix source_code_uri

### DIFF
--- a/rspec-core/rspec-core.gemspec
+++ b/rspec-core/rspec-core.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     'changelog_uri' => "https://github.com/rspec/rspec-core/blob/v#{s.version}/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => 'https://github.com/rspec/rspec-core',
+    'source_code_uri' => 'https://github.com/rspec/rspec',
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-expectations/rspec-expectations.gemspec
+++ b/rspec-expectations/rspec-expectations.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     'changelog_uri' => "https://github.com/rspec/rspec-expectations/blob/v#{s.version}/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => 'https://github.com/rspec/rspec-expectations',
+    'source_code_uri' => 'https://github.com/rspec/rspec',
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-mocks/rspec-mocks.gemspec
+++ b/rspec-mocks/rspec-mocks.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     'changelog_uri' => "https://github.com/rspec/rspec-mocks/blob/v#{s.version}/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => 'https://github.com/rspec/rspec-mocks',
+    'source_code_uri' => 'https://github.com/rspec/rspec',
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-support/rspec-support.gemspec
+++ b/rspec-support/rspec-support.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     'changelog_uri' => "https://github.com/rspec/rspec-support/blob/v#{spec.version}/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => 'https://github.com/rspec/rspec-support',
+    'source_code_uri' => 'https://github.com/rspec/rspec',
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec/rspec.gemspec
+++ b/rspec/rspec.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rspec/rspec-metagem/issues',
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => 'https://github.com/rspec/rspec-metagem',
+    'source_code_uri' => 'https://github.com/rspec/rspec',
     'rubygems_mfa_required' => 'true',
   }
 


### PR DESCRIPTION
## Overview

The URL of the gemspecs is old.
This PR replaces them.