### PR TITLE
Fix bug_tracker_uri

### DIFF
--- a/rspec/rspec.gemspec
+++ b/rspec/rspec.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.description = "BDD for Ruby"
 
   s.metadata = {
-    'bug_tracker_uri' => 'https://github.com/rspec/rspec-metagem/issues',
+    'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
     'source_code_uri' => 'https://github.com/rspec/rspec',


### PR DESCRIPTION
rspec-metagem has been archived, so replace it with the new rspec URL