### PR TITLE
Status badge report wrong branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# rspec [![Build Status](https://github.com/rspec/rspec/workflows/RSpec%20CI/badge.svg)](https://github.com/rspec/rspec/actions) [![Code Climate](https://codeclimate.com/github/rspec/rspec.svg)](https://codeclimate.com/github/rspec/rspec)
+# rspec [![Build Status](https://github.com/rspec/rspec/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/rspec/rspec/actions) [![Code Climate](https://codeclimate.com/github/rspec/rspec.svg)](https://codeclimate.com/github/rspec/rspec)
 
 This is the RSpec mono repo, it contains the core gems we think of as "rspec", they are:
 


### PR DESCRIPTION
Hello

Congrats for the monorepo. Happy to see it. <3

I noticed that the badge report was in failing state even if the CI on main was green. I think we should scope to `ci.yml` and main branch.