### PR TITLE
Use a thread based invoking check

### DIFF
--- a/rspec-mocks/lib/rspec/mocks/message_expectation.rb
+++ b/rspec-mocks/lib/rspec/mocks/message_expectation.rb
@@ -438,7 +438,8 @@ module RSpec
           @expectation_type = type
           @ordered = false
           @at_least = @at_most = @exactly = nil
-          @invoking = false
+
+          self.invoking = false
 
           # Initialized to nil so that we don't allocate an array for every
           # mock or stub. See also comment in `and_yield`.
@@ -475,7 +476,7 @@ module RSpec
         ruby2_keywords :safe_invoke if respond_to?(:ruby2_keywords, true)
 
         def invoke(parent_stub, *args, &block)
-          if @invoking
+          if invoking
             safe_invoke_without_incrementing_received_count(parent_stub, *args, &block)
           else
             invoke_incrementing_actual_calls_by(1, true, parent_stub, *args, &block)
@@ -613,10 +614,18 @@ module RSpec
           @exception_source_id ||= "#{self.class.name} #{__id__}"
         end
 
+        def invoking
+          RSpec::Support.thread_local_data[:"__rspec_#{object_id}_invoking"]
+        end
+
+        def invoking=(value)
+          RSpec::Support.thread_local_data[:"__rspec_#{object_id}_invoking"] = value
+        end
+
         def invoke_incrementing_actual_calls_by(increment, allowed_to_fail, parent_stub, *args, &block)
           args.unshift(orig_object) if yield_receiver_to_implementation_block?
 
-          @invoking = true
+          self.invoking = true
 
           if negative? || (allowed_to_fail && (@exactly || @at_most) && (@actual_received_count == @expected_received_count))
             # args are the args we actually received, @argument_list_matcher is the
@@ -637,7 +646,7 @@ module RSpec
             parent_stub.invoke(nil, *args, &block)
           end
         ensure
-          @invoking = false
+          self.invoking = false
           @actual_received_count_write_mutex.synchronize do
             @actual_received_count += increment
           end


### PR DESCRIPTION
This is a follow up to #116 which introduced a threaded race condition for JRuby, this changes the invoking check to being thread local based on the object id 