### PR TITLE
Fix gemspec links and other doc links that point to old repos

### DIFF
--- a/rspec-core/README.md
+++ b/rspec-core/README.md
@@ -2,10 +2,10 @@
 
 This is the detailed readme for `rspec-core`, see also:
 
-* [The combined readme][../README.md]
-* [rspec-expectations][../rspec-expectations/README.md]
-* [rspec-mocks][../rspec-mocks/README.md]
-* [rspec-support][../rspec-support/README.md]
+* [The combined readme](../README.md)
+* [rspec-expectations](../rspec-expectations/README.md)
+* [rspec-mocks](../rspec-mocks/README.md)
+* [rspec-support](../rspec-support/README.md)
 
 ## Basic Structure
 

--- a/rspec-core/features/README.md
+++ b/rspec-core/features/README.md
@@ -14,4 +14,4 @@ end
 
 ## Issues
 
-This documentation is [open source](https://github.com/rspec/rspec-core/tree/main/features), and a work in progress.  If you find it incomplete or confusing, please [submit an issue](http://github.com/rspec/rspec-core/issues), or, better yet, [a pull request](http://github.com/rspec/rspec-core).
+This documentation is [open source](https://github.com/rspec/rspec/tree/main/rspec-core/features), and a work in progress.  If you find it incomplete or confusing, please [submit an issue](http://github.com/rspec/rspec/issues), or, better yet, [a pull request](http://github.com/rspec/rspec).

--- a/rspec-core/rspec-core.gemspec
+++ b/rspec-core/rspec-core.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-core-v#{s.version}/rspec-core/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/tree/rspec-core-v#{s.version}/rspec-core/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-core-v#{s.version}/rspec-core",
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/rspec-core-v#{s.version}/rspec-core",
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-core/rspec-core.gemspec
+++ b/rspec-core/rspec-core.gemspec
@@ -2,47 +2,47 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "rspec/core/version"
 
-Gem::Specification.new do |spec|
-  spec.name        = "rspec-core"
-  spec.version     = RSpec::Core::Version::STRING
-  spec.platform    = Gem::Platform::RUBY
-  spec.license     = "MIT"
-  spec.authors     = ["Steven Baker", "David Chelimsky", "Chad Humphries", "Myron Marston"]
-  spec.email       = "rspec@googlegroups.com"
-  spec.homepage    = "https://github.com/rspec/rspec-core"
-  spec.summary     = "rspec-core-#{RSpec::Core::Version::STRING}"
-  spec.description = "BDD for Ruby. RSpec runner and example groups."
+Gem::Specification.new do |s|
+  s.name        = "rspec-core"
+  s.version     = RSpec::Core::Version::STRING
+  s.platform    = Gem::Platform::RUBY
+  s.license     = "MIT"
+  s.authors     = ["Steven Baker", "David Chelimsky", "Chad Humphries", "Myron Marston"]
+  s.email       = "rspec@googlegroups.com"
+  s.homepage    = "https://github.com/rspec/rspec-core"
+  s.summary     = "rspec-core-#{RSpec::Core::Version::STRING}"
+  s.description = "BDD for Ruby. RSpec runner and example groups."
 
-  spec.metadata = {
+  s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-core-v#{spec.version}/rspec-core/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-core-v#{s.version}/rspec-core/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-core-v#{spec.version}/rspec-core",
+    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-core-v#{s.version}/rspec-core",
     'rubygems_mfa_required' => 'true',
   }
 
-  spec.files            = `git ls-files -- lib/*`.split("\n")
-  spec.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
-  spec.test_files       = []
-  spec.bindir           = 'exe'
-  spec.executables      = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
-  spec.rdoc_options     = ["--charset=UTF-8"]
-  spec.require_path     = "lib"
+  s.files            = `git ls-files -- lib/*`.split("\n")
+  s.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
+  s.test_files       = []
+  s.bindir           = 'exe'
+  s.executables      = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
+  s.rdoc_options     = ["--charset=UTF-8"]
+  s.require_path     = "lib"
 
-  spec.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 1.8.7'
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
   if File.exist?(private_key)
-    spec.signing_key = private_key
-    spec.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
+    s.signing_key = private_key
+    s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
   if RSpec::Core::Version::STRING =~ /[a-zA-Z]+/
     # rspec-support is locked to our version when running pre,rc etc
-    spec.add_runtime_dependency "rspec-support", "= #{RSpec::Core::Version::STRING}"
+    s.add_runtime_dependency "rspec-support", "= #{RSpec::Core::Version::STRING}"
   else
     # rspec-support must otherwise match our major/minor version
-    spec.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
+    s.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
   end
 end

--- a/rspec-core/rspec-core.gemspec
+++ b/rspec-core/rspec-core.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.authors     = ["Steven Baker", "David Chelimsky", "Chad Humphries", "Myron Marston"]
   s.email       = "rspec@googlegroups.com"
-  s.homepage    = "https://github.com/rspec/rspec/tree/main/rspec-core"
+  s.homepage    = "https://rspec.info"
   s.summary     = "rspec-core-#{RSpec::Core::Version::STRING}"
   s.description = "BDD for Ruby. RSpec runner and example groups."
 

--- a/rspec-core/rspec-core.gemspec
+++ b/rspec-core/rspec-core.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
   s.description = "BDD for Ruby. RSpec runner and example groups."
 
   s.metadata = {
-    'bug_tracker_uri' => 'https://github.com/rspec/rspec-core/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec-core/blob/v#{s.version}/Changelog.md",
+    'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
+    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-core-v#{s.version}/rspec-core/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => 'https://github.com/rspec/rspec',
+    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-core-v#{s.version}/rspec-core",
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-core/rspec-core.gemspec
+++ b/rspec-core/rspec-core.gemspec
@@ -2,47 +2,47 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "rspec/core/version"
 
-Gem::Specification.new do |s|
-  s.name        = "rspec-core"
-  s.version     = RSpec::Core::Version::STRING
-  s.platform    = Gem::Platform::RUBY
-  s.license     = "MIT"
-  s.authors     = ["Steven Baker", "David Chelimsky", "Chad Humphries", "Myron Marston"]
-  s.email       = "rspec@googlegroups.com"
-  s.homepage    = "https://github.com/rspec/rspec-core"
-  s.summary     = "rspec-core-#{RSpec::Core::Version::STRING}"
-  s.description = "BDD for Ruby. RSpec runner and example groups."
+Gem::Specification.new do |spec|
+  spec.name        = "rspec-core"
+  spec.version     = RSpec::Core::Version::STRING
+  spec.platform    = Gem::Platform::RUBY
+  spec.license     = "MIT"
+  spec.authors     = ["Steven Baker", "David Chelimsky", "Chad Humphries", "Myron Marston"]
+  spec.email       = "rspec@googlegroups.com"
+  spec.homepage    = "https://github.com/rspec/rspec-core"
+  spec.summary     = "rspec-core-#{RSpec::Core::Version::STRING}"
+  spec.description = "BDD for Ruby. RSpec runner and example groups."
 
-  s.metadata = {
+  spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-core-v#{s.version}/rspec-core/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-core-v#{spec.version}/rspec-core/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-core-v#{s.version}/rspec-core",
+    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-core-v#{spec.version}/rspec-core",
     'rubygems_mfa_required' => 'true',
   }
 
-  s.files            = `git ls-files -- lib/*`.split("\n")
-  s.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
-  s.test_files       = []
-  s.bindir           = 'exe'
-  s.executables      = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
-  s.rdoc_options     = ["--charset=UTF-8"]
-  s.require_path     = "lib"
+  spec.files            = `git ls-files -- lib/*`.split("\n")
+  spec.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
+  spec.test_files       = []
+  spec.bindir           = 'exe'
+  spec.executables      = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
+  spec.rdoc_options     = ["--charset=UTF-8"]
+  spec.require_path     = "lib"
 
-  s.required_ruby_version = '>= 1.8.7'
+  spec.required_ruby_version = '>= 1.8.7'
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
   if File.exist?(private_key)
-    s.signing_key = private_key
-    s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
+    spec.signing_key = private_key
+    spec.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
   if RSpec::Core::Version::STRING =~ /[a-zA-Z]+/
     # rspec-support is locked to our version when running pre,rc etc
-    s.add_runtime_dependency "rspec-support", "= #{RSpec::Core::Version::STRING}"
+    spec.add_runtime_dependency "rspec-support", "= #{RSpec::Core::Version::STRING}"
   else
     # rspec-support must otherwise match our major/minor version
-    s.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
+    spec.add_runtime_dependency "rspec-support", "~> #{RSpec::Core::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
   end
 end

--- a/rspec-core/rspec-core.gemspec
+++ b/rspec-core/rspec-core.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.authors     = ["Steven Baker", "David Chelimsky", "Chad Humphries", "Myron Marston"]
   s.email       = "rspec@googlegroups.com"
-  s.homepage    = "https://github.com/rspec/rspec-core"
+  s.homepage    = "https://github.com/rspec/rspec/tree/main/rspec-core"
   s.summary     = "rspec-core-#{RSpec::Core::Version::STRING}"
   s.description = "BDD for Ruby. RSpec runner and example groups."
 

--- a/rspec-expectations/README.md
+++ b/rspec-expectations/README.md
@@ -2,10 +2,10 @@
 
 This is the detailed readme for `rspec-expectations`, see also:
 
-* [The combined readme][../README.md]
-* [rspec-core][../rspec-core/README.md]
-* [rspec-mocks][../rspec-mocks/README.md]
-* [rspec-support][../rspec-support/README.md]
+* [The combined readme](../README.md)
+* [rspec-core](../rspec-core/README.md)
+* [rspec-mocks](../rspec-mocks/README.md)
+* [rspec-support](../rspec-support/README.md)
 
 ## Basic usage
 

--- a/rspec-expectations/README.md
+++ b/rspec-expectations/README.md
@@ -193,7 +193,7 @@ actual.should be > 3
 [1, 2, 3].should_not include 4
 ```
 
-See [detailed information on the `should` syntax and its usage.](https://github.com/rspec/rspec-expectations/blob/main/Should.md)
+See [detailed information on the `should` syntax and its usage.](https://github.com/rspec/rspec/blob/main/rspec-expectations/Should.md)
 
 ## Compound Matcher Expressions
 

--- a/rspec-expectations/features/built_in_matchers/README.md
+++ b/rspec-expectations/features/built_in_matchers/README.md
@@ -3,7 +3,7 @@
 `rspec-expectations` ships with a number of built-in matchers. Each matcher can be used
 with `expect(..).to` or `expect(..).not_to` to define positive and negative expectations
 respectively on an object. Most matchers can also be accessed using the `(...).should` and
-`(...).should_not` syntax; see [using should syntax](https://github.com/rspec/rspec-expectations/blob/main/Should.md) for why we recommend using `expect`.
+`(...).should_not` syntax; see [using should syntax](https://github.com/rspec/rspec/blob/main/rspec-expectations/Should.md) for why we recommend using `expect`.
 
 e.g.
 

--- a/rspec-expectations/rspec-expectations.gemspec
+++ b/rspec-expectations/rspec-expectations.gemspec
@@ -3,47 +3,47 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "rspec/expectations/version"
 
-Gem::Specification.new do |spec|
-  spec.name        = "rspec-expectations"
-  spec.version     = RSpec::Expectations::Version::STRING
-  spec.platform    = Gem::Platform::RUBY
-  spec.license     = "MIT"
-  spec.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
-  spec.email       = "rspec@googlegroups.com"
-  spec.homepage    = "https://github.com/rspec/rspec-expectations"
-  spec.summary     = "rspec-expectations-#{RSpec::Expectations::Version::STRING}"
-  spec.description = "rspec-expectations provides a simple, readable API to express expected outcomes of a code example."
+Gem::Specification.new do |s|
+  s.name        = "rspec-expectations"
+  s.version     = RSpec::Expectations::Version::STRING
+  s.platform    = Gem::Platform::RUBY
+  s.license     = "MIT"
+  s.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
+  s.email       = "rspec@googlegroups.com"
+  s.homepage    = "https://github.com/rspec/rspec-expectations"
+  s.summary     = "rspec-expectations-#{RSpec::Expectations::Version::STRING}"
+  s.description = "rspec-expectations provides a simple, readable API to express expected outcomes of a code example."
 
-  spec.metadata = {
+  s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-expectations-v#{spec.version}/rspec-expectations/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-expectations-v#{s.version}/rspec-expectations/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-expectations-v#{spec.version}/rspec-expectations",
+    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-expectations-v#{s.version}/rspec-expectations",
     'rubygems_mfa_required' => 'true',
   }
 
-  spec.files            = `git ls-files -- lib/*`.split("\n")
-  spec.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
-  spec.test_files       = []
-  spec.rdoc_options     = ["--charset=UTF-8"]
-  spec.require_path     = "lib"
+  s.files            = `git ls-files -- lib/*`.split("\n")
+  s.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
+  s.test_files       = []
+  s.rdoc_options     = ["--charset=UTF-8"]
+  s.require_path     = "lib"
 
-  spec.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 1.8.7'
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
   if File.exist?(private_key)
-    spec.signing_key = private_key
-    spec.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
+    s.signing_key = private_key
+    s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
   if RSpec::Expectations::Version::STRING =~ /[a-zA-Z]+/
     # pin to exact version for rc's and betas
-    spec.add_runtime_dependency "rspec-support", "= #{RSpec::Expectations::Version::STRING}"
+    s.add_runtime_dependency "rspec-support", "= #{RSpec::Expectations::Version::STRING}"
   else
     # pin to major/minor ignoring patch
-    spec.add_runtime_dependency "rspec-support", "~> #{RSpec::Expectations::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
+    s.add_runtime_dependency "rspec-support", "~> #{RSpec::Expectations::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
   end
 
-  spec.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
+  s.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
 end

--- a/rspec-expectations/rspec-expectations.gemspec
+++ b/rspec-expectations/rspec-expectations.gemspec
@@ -3,47 +3,47 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "rspec/expectations/version"
 
-Gem::Specification.new do |s|
-  s.name        = "rspec-expectations"
-  s.version     = RSpec::Expectations::Version::STRING
-  s.platform    = Gem::Platform::RUBY
-  s.license     = "MIT"
-  s.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
-  s.email       = "rspec@googlegroups.com"
-  s.homepage    = "https://github.com/rspec/rspec-expectations"
-  s.summary     = "rspec-expectations-#{RSpec::Expectations::Version::STRING}"
-  s.description = "rspec-expectations provides a simple, readable API to express expected outcomes of a code example."
+Gem::Specification.new do |spec|
+  spec.name        = "rspec-expectations"
+  spec.version     = RSpec::Expectations::Version::STRING
+  spec.platform    = Gem::Platform::RUBY
+  spec.license     = "MIT"
+  spec.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
+  spec.email       = "rspec@googlegroups.com"
+  spec.homepage    = "https://github.com/rspec/rspec-expectations"
+  spec.summary     = "rspec-expectations-#{RSpec::Expectations::Version::STRING}"
+  spec.description = "rspec-expectations provides a simple, readable API to express expected outcomes of a code example."
 
-  s.metadata = {
+  spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-expectations-v#{s.version}/rspec-expectations/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-expectations-v#{spec.version}/rspec-expectations/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-expectations-v#{s.version}/rspec-expectations",
+    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-expectations-v#{spec.version}/rspec-expectations",
     'rubygems_mfa_required' => 'true',
   }
 
-  s.files            = `git ls-files -- lib/*`.split("\n")
-  s.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
-  s.test_files       = []
-  s.rdoc_options     = ["--charset=UTF-8"]
-  s.require_path     = "lib"
+  spec.files            = `git ls-files -- lib/*`.split("\n")
+  spec.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
+  spec.test_files       = []
+  spec.rdoc_options     = ["--charset=UTF-8"]
+  spec.require_path     = "lib"
 
-  s.required_ruby_version = '>= 1.8.7'
+  spec.required_ruby_version = '>= 1.8.7'
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
   if File.exist?(private_key)
-    s.signing_key = private_key
-    s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
+    spec.signing_key = private_key
+    spec.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
   if RSpec::Expectations::Version::STRING =~ /[a-zA-Z]+/
     # pin to exact version for rc's and betas
-    s.add_runtime_dependency "rspec-support", "= #{RSpec::Expectations::Version::STRING}"
+    spec.add_runtime_dependency "rspec-support", "= #{RSpec::Expectations::Version::STRING}"
   else
     # pin to major/minor ignoring patch
-    s.add_runtime_dependency "rspec-support", "~> #{RSpec::Expectations::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
+    spec.add_runtime_dependency "rspec-support", "~> #{RSpec::Expectations::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
   end
 
-  s.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
+  spec.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
 end

--- a/rspec-expectations/rspec-expectations.gemspec
+++ b/rspec-expectations/rspec-expectations.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
   s.email       = "rspec@googlegroups.com"
-  s.homepage    = "https://github.com/rspec/rspec-expectations"
+  s.homepage    = "https://github.com/rspec/rspec/tree/main/rspec-expectations"
   s.summary     = "rspec-expectations-#{RSpec::Expectations::Version::STRING}"
   s.description = "rspec-expectations provides a simple, readable API to express expected outcomes of a code example."
 

--- a/rspec-expectations/rspec-expectations.gemspec
+++ b/rspec-expectations/rspec-expectations.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-expectations-v#{s.version}/rspec-expectations/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/tree/rspec-expectations-v#{s.version}/rspec-expectations/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-expectations-v#{s.version}/rspec-expectations",
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/rspec-expectations-v#{s.version}/rspec-expectations",
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-expectations/rspec-expectations.gemspec
+++ b/rspec-expectations/rspec-expectations.gemspec
@@ -15,11 +15,11 @@ Gem::Specification.new do |s|
   s.description = "rspec-expectations provides a simple, readable API to express expected outcomes of a code example."
 
   s.metadata = {
-    'bug_tracker_uri' => 'https://github.com/rspec/rspec-expectations/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec-expectations/blob/v#{s.version}/Changelog.md",
+    'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
+    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-expectations-v#{s.version}/rspec-expectations/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => 'https://github.com/rspec/rspec',
+    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-expectations-v#{s.version}/rspec-expectations",
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-expectations/rspec-expectations.gemspec
+++ b/rspec-expectations/rspec-expectations.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
   s.email       = "rspec@googlegroups.com"
-  s.homepage    = "https://github.com/rspec/rspec/tree/main/rspec-expectations"
+  s.homepage    = "https://rspec.info"
   s.summary     = "rspec-expectations-#{RSpec::Expectations::Version::STRING}"
   s.description = "rspec-expectations provides a simple, readable API to express expected outcomes of a code example."
 

--- a/rspec-mocks/README.md
+++ b/rspec-mocks/README.md
@@ -29,7 +29,7 @@ book = instance_double("Book", :pages => 250)
 Verifying doubles have some clever tricks to enable you to both test in
 isolation without your dependencies loaded while still being able to validate
 them against real objects. More detail is available in [their
-documentation](https://github.com/rspec/rspec-mocks/blob/main/features/verifying_doubles).
+documentation](https://github.com/rspec/rspec/tree/main/rspec-mocks/features/verifying_doubles#readme).
 
 Verifying doubles can also accept custom identifiers, just like double(), e.g.:
 
@@ -381,7 +381,7 @@ your code.
 ## Stubbing and Hiding Constants
 
 See the [mutating constants
-README](https://github.com/rspec/rspec-mocks/blob/main/features/mutating_constants/README.md)
+README](https://github.com/rspec/rspec/tree/rspec-metagem-v3.13.0/rspec-mocks/features/mutating_constants#readme)
 for info on this feature.
 
 ## Use `before(:example)`, not `before(:context)`

--- a/rspec-mocks/README.md
+++ b/rspec-mocks/README.md
@@ -381,7 +381,7 @@ your code.
 ## Stubbing and Hiding Constants
 
 See the [mutating constants
-README](https://github.com/rspec/rspec/tree/rspec-metagem-v3.13.0/rspec-mocks/features/mutating_constants#readme)
+README](https://github.com/rspec/rspec/tree/main/rspec-mocks/features/mutating_constants)
 for info on this feature.
 
 ## Use `before(:example)`, not `before(:context)`

--- a/rspec-mocks/README.md
+++ b/rspec-mocks/README.md
@@ -2,10 +2,10 @@
 
 This is the detailed readme for `rspec-mocks`, see also:
 
-* [The combined readme][../README.md]
-* [rspec-core][../rspec-core/README.md]
-* [rspec-expectations][../rspec-expectations/README.md]
-* [rspec-support][../rspec-support/README.md]
+* [The combined readme](../README.md)
+* [rspec-core](../rspec-core/README.md)
+* [rspec-expectations](../rspec-expectations/README.md)
+* [rspec-support](../rspec-support/README.md)
 
 ## Test Doubles
 

--- a/rspec-mocks/rspec-mocks.gemspec
+++ b/rspec-mocks/rspec-mocks.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{s.version}/rspec-mocks/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/tree/rspec-mocks-v#{s.version}/rspec-mocks/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{s.version}/rspec-mocks",
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/rspec-mocks-v#{s.version}/rspec-mocks",
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-mocks/rspec-mocks.gemspec
+++ b/rspec-mocks/rspec-mocks.gemspec
@@ -14,11 +14,11 @@ Gem::Specification.new do |s|
   s.description = "RSpec's 'test double' framework, with support for stubbing and mocking"
 
   s.metadata = {
-    'bug_tracker_uri' => 'https://github.com/rspec/rspec-mocks/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec-mocks/blob/v#{s.version}/Changelog.md",
+    'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
+    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{s.version}/rspec-mocks/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => 'https://github.com/rspec/rspec',
+    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{spec.version}/rspec-mocks",
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-mocks/rspec-mocks.gemspec
+++ b/rspec-mocks/rspec-mocks.gemspec
@@ -2,47 +2,47 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "rspec/mocks/version"
 
-Gem::Specification.new do |s|
-  s.name        = "rspec-mocks"
-  s.version     = RSpec::Mocks::Version::STRING
-  s.platform    = Gem::Platform::RUBY
-  s.license     = "MIT"
-  s.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
-  s.email       = "rspec@googlegroups.com"
-  s.homepage    = "https://github.com/rspec/rspec-mocks"
-  s.summary     = "rspec-mocks-#{RSpec::Mocks::Version::STRING}"
-  s.description = "RSpec's 'test double' framework, with support for stubbing and mocking"
+Gem::Specification.new do |spec|
+  spec.name        = "rspec-mocks"
+  spec.version     = RSpec::Mocks::Version::STRING
+  spec.platform    = Gem::Platform::RUBY
+  spec.license     = "MIT"
+  spec.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
+  spec.email       = "rspec@googlegroups.com"
+  spec.homepage    = "https://github.com/rspec/rspec-mocks"
+  spec.summary     = "rspec-mocks-#{RSpec::Mocks::Version::STRING}"
+  spec.description = "RSpec's 'test double' framework, with support for stubbing and mocking"
 
-  s.metadata = {
+  spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{s.version}/rspec-mocks/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{spec.version}/rspec-mocks/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
     'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{spec.version}/rspec-mocks",
     'rubygems_mfa_required' => 'true',
   }
 
-  s.files            = `git ls-files -- lib/*`.split("\n")
-  s.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
-  s.test_files       = []
-  s.rdoc_options     = ["--charset=UTF-8"]
-  s.require_path     = "lib"
+  spec.files            = `git ls-files -- lib/*`.split("\n")
+  spec.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
+  spec.test_files       = []
+  spec.rdoc_options     = ["--charset=UTF-8"]
+  spec.require_path     = "lib"
 
-  s.required_ruby_version = '>= 1.8.7'
+  spec.required_ruby_version = '>= 1.8.7'
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
   if File.exist?(private_key)
-    s.signing_key = private_key
-    s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
+    spec.signing_key = private_key
+    spec.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
   if RSpec::Mocks::Version::STRING =~ /[a-zA-Z]+/
     # pin to exact version for rc's and betas
-    s.add_runtime_dependency "rspec-support", "= #{RSpec::Mocks::Version::STRING}"
+    spec.add_runtime_dependency "rspec-support", "= #{RSpec::Mocks::Version::STRING}"
   else
     # pin to major/minor ignoring patch
-    s.add_runtime_dependency "rspec-support", "~> #{RSpec::Mocks::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
+    spec.add_runtime_dependency "rspec-support", "~> #{RSpec::Mocks::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
   end
 
-  s.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
+  spec.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
 end

--- a/rspec-mocks/rspec-mocks.gemspec
+++ b/rspec-mocks/rspec-mocks.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
   s.email       = "rspec@googlegroups.com"
-  s.homepage    = "https://github.com/rspec/rspec-mocks"
+  s.homepage    = "https://github.com/rspec/rspec/tree/main/rspec-mocks"
   s.summary     = "rspec-mocks-#{RSpec::Mocks::Version::STRING}"
   s.description = "RSpec's 'test double' framework, with support for stubbing and mocking"
 

--- a/rspec-mocks/rspec-mocks.gemspec
+++ b/rspec-mocks/rspec-mocks.gemspec
@@ -2,47 +2,47 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "rspec/mocks/version"
 
-Gem::Specification.new do |spec|
-  spec.name        = "rspec-mocks"
-  spec.version     = RSpec::Mocks::Version::STRING
-  spec.platform    = Gem::Platform::RUBY
-  spec.license     = "MIT"
-  spec.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
-  spec.email       = "rspec@googlegroups.com"
-  spec.homepage    = "https://github.com/rspec/rspec-mocks"
-  spec.summary     = "rspec-mocks-#{RSpec::Mocks::Version::STRING}"
-  spec.description = "RSpec's 'test double' framework, with support for stubbing and mocking"
+Gem::Specification.new do |s|
+  s.name        = "rspec-mocks"
+  s.version     = RSpec::Mocks::Version::STRING
+  s.platform    = Gem::Platform::RUBY
+  s.license     = "MIT"
+  s.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
+  s.email       = "rspec@googlegroups.com"
+  s.homepage    = "https://github.com/rspec/rspec-mocks"
+  s.summary     = "rspec-mocks-#{RSpec::Mocks::Version::STRING}"
+  s.description = "RSpec's 'test double' framework, with support for stubbing and mocking"
 
-  spec.metadata = {
+  s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{spec.version}/rspec-mocks/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{s.version}/rspec-mocks/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
     'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{spec.version}/rspec-mocks",
     'rubygems_mfa_required' => 'true',
   }
 
-  spec.files            = `git ls-files -- lib/*`.split("\n")
-  spec.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
-  spec.test_files       = []
-  spec.rdoc_options     = ["--charset=UTF-8"]
-  spec.require_path     = "lib"
+  s.files            = `git ls-files -- lib/*`.split("\n")
+  s.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
+  s.test_files       = []
+  s.rdoc_options     = ["--charset=UTF-8"]
+  s.require_path     = "lib"
 
-  spec.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 1.8.7'
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
   if File.exist?(private_key)
-    spec.signing_key = private_key
-    spec.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
+    s.signing_key = private_key
+    s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
   if RSpec::Mocks::Version::STRING =~ /[a-zA-Z]+/
     # pin to exact version for rc's and betas
-    spec.add_runtime_dependency "rspec-support", "= #{RSpec::Mocks::Version::STRING}"
+    s.add_runtime_dependency "rspec-support", "= #{RSpec::Mocks::Version::STRING}"
   else
     # pin to major/minor ignoring patch
-    spec.add_runtime_dependency "rspec-support", "~> #{RSpec::Mocks::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
+    s.add_runtime_dependency "rspec-support", "~> #{RSpec::Mocks::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
   end
 
-  spec.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
+  s.add_runtime_dependency "diff-lcs", ">= 1.2.0", "< 2.0"
 end

--- a/rspec-mocks/rspec-mocks.gemspec
+++ b/rspec-mocks/rspec-mocks.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
     'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{s.version}/rspec-mocks/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{spec.version}/rspec-mocks",
+    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-mocks-v#{s.version}/rspec-mocks",
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-mocks/rspec-mocks.gemspec
+++ b/rspec-mocks/rspec-mocks.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
   s.email       = "rspec@googlegroups.com"
-  s.homepage    = "https://github.com/rspec/rspec/tree/main/rspec-mocks"
+  s.homepage    = "https://rspec.info"
   s.summary     = "rspec-mocks-#{RSpec::Mocks::Version::STRING}"
   s.description = "RSpec's 'test double' framework, with support for stubbing and mocking"
 

--- a/rspec-support/README.md
+++ b/rspec-support/README.md
@@ -2,7 +2,7 @@
 
 This is the readme for `rspec-support`, there isn't anything to see here but see also:
 
-* [The combined readme][../README.md]
-* [rspec-core][../rspec-core/README.md]
-* [rspec-expectations][../rspec-expectations/README.md]
-* [rspec-mocks][../rspec-mocks/README.md]
+* [The combined readme](../README.md)
+* [rspec-core](../rspec-core/README.md)
+* [rspec-expectations](../rspec-expectations/README.md)
+* [rspec-mocks](../rspec-mocks/README.md)

--- a/rspec-support/rspec-support.gemspec
+++ b/rspec-support/rspec-support.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version       = RSpec::Support::Version::STRING
   s.authors       = ["David Chelimsky","Myron Marson","Jon Rowe","Sam Phippen","Xaviery Shay","Bradley Schaefer"]
   s.email         = "rspec-users@rubyforge.org"
-  s.homepage      = "https://github.com/rspec/rspec"
+  s.homepage      = "https://github.com/rspec/rspec/tree/main/rspec-support"
   s.summary       = "rspec-support-#{RSpec::Support::Version::STRING}"
   s.description   = "Support utilities for RSpec gems"
   s.license       = "MIT"

--- a/rspec-support/rspec-support.gemspec
+++ b/rspec-support/rspec-support.gemspec
@@ -5,36 +5,36 @@ lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'rspec/support/version'
 
-Gem::Specification.new do |spec|
-  spec.name          = "rspec-support"
-  spec.version       = RSpec::Support::Version::STRING
-  spec.authors       = ["David Chelimsky","Myron Marson","Jon Rowe","Sam Phippen","Xaviery Shay","Bradley Schaefer"]
-  spec.email         = "rspec-users@rubyforge.org"
-  spec.homepage      = "https://github.com/rspec/rspec"
-  spec.summary       = "rspec-support-#{RSpec::Support::Version::STRING}"
-  spec.description   = "Support utilities for RSpec gems"
-  spec.license       = "MIT"
+Gem::Specification.new do |s|
+  s.name          = "rspec-support"
+  s.version       = RSpec::Support::Version::STRING
+  s.authors       = ["David Chelimsky","Myron Marson","Jon Rowe","Sam Phippen","Xaviery Shay","Bradley Schaefer"]
+  s.email         = "rspec-users@rubyforge.org"
+  s.homepage      = "https://github.com/rspec/rspec"
+  s.summary       = "rspec-support-#{RSpec::Support::Version::STRING}"
+  s.description   = "Support utilities for RSpec gems"
+  s.license       = "MIT"
 
-  spec.metadata = {
+  s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-support-v#{spec.version}/rspec-support/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-support-v#{s.version}/rspec-support/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
     'rubygems_mfa_required' => 'true',
-    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-support-v#{spec.version}/rspec-support",
+    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-support-v#{s.version}/rspec-support",
   }
 
-  spec.files         = `git ls-files -- lib/*`.split("\n")
-  spec.files         += %w[README.md LICENSE.md Changelog.md]
-  spec.test_files    = []
-  spec.rdoc_options  = ["--charset=UTF-8"]
-  spec.require_paths = ["lib"]
+  s.files         = `git ls-files -- lib/*`.split("\n")
+  s.files         += %w[README.md LICENSE.md Changelog.md]
+  s.test_files    = []
+  s.rdoc_options  = ["--charset=UTF-8"]
+  s.require_paths = ["lib"]
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
   if File.exist?(private_key)
-    spec.signing_key = private_key
-    spec.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
+    s.signing_key = private_key
+    s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
-  spec.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 1.8.7'
 end

--- a/rspec-support/rspec-support.gemspec
+++ b/rspec-support/rspec-support.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/blob/rspec-support-v#{s.version}/rspec-support/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/tree/rspec-support-v#{s.version}/rspec-support/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
     'rubygems_mfa_required' => 'true',
-    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-support-v#{s.version}/rspec-support",
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/rspec-support-v#{s.version}/rspec-support",
   }
 
   s.files         = `git ls-files -- lib/*`.split("\n")

--- a/rspec-support/rspec-support.gemspec
+++ b/rspec-support/rspec-support.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.version       = RSpec::Support::Version::STRING
   s.authors       = ["David Chelimsky","Myron Marson","Jon Rowe","Sam Phippen","Xaviery Shay","Bradley Schaefer"]
   s.email         = "rspec-users@rubyforge.org"
-  s.homepage      = "https://github.com/rspec/rspec/tree/main/rspec-support"
+  s.homepage      = "https://rspec.info"
   s.summary       = "rspec-support-#{RSpec::Support::Version::STRING}"
   s.description   = "Support utilities for RSpec gems"
   s.license       = "MIT"

--- a/rspec/README.md
+++ b/rspec/README.md
@@ -9,9 +9,9 @@ for a new mono-repo approach to RSpec dev to unify issue tracking and PR managem
 ## Description
 
 rspec is a meta-gem, which depends on the
-[rspec-core](https://github.com/rspec/rspec-core),
-[rspec-expectations](https://github.com/rspec/rspec-expectations)
-and [rspec-mocks](https://github.com/rspec/rspec-mocks) gems. Each of these
+[rspec-core](https://github.com/rspec/rspec/tree/main/rspec-core),
+[rspec-expectations](https://github.com/rspec/rspec/tree/main/rspec-expectations)
+and [rspec-mocks](https://github.com/rspec/rspec/tree/main/rspec-mocks) gems. Each of these
 can be installed separately and loaded in isolation using `require`. Among
 other benefits, this allows you to use rspec-expectations, for example, in
 Test::Unit::TestCase if you happen to prefer that style.

--- a/rspec/rspec.gemspec
+++ b/rspec/rspec.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => 'https://github.com/rspec/rspec',
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}",
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec/rspec.gemspec
+++ b/rspec/rspec.gemspec
@@ -4,44 +4,44 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "rspec/version"
 
-Gem::Specification.new do |spec|
-  spec.name        = "rspec"
-  spec.version     = RSpec::Version::STRING
-  spec.platform    = Gem::Platform::RUBY
-  spec.license     = "MIT"
-  spec.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
-  spec.email       = "rspec@googlegroups.com"
-  spec.homepage    = "http://github.com/rspec"
-  spec.summary     = "rspec-#{RSpec::Version::STRING}"
-  spec.description = "BDD for Ruby"
+Gem::Specification.new do |s|
+  s.name        = "rspec"
+  s.version     = RSpec::Version::STRING
+  s.platform    = Gem::Platform::RUBY
+  s.license     = "MIT"
+  s.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
+  s.email       = "rspec@googlegroups.com"
+  s.homepage    = "http://github.com/rspec"
+  s.summary     = "rspec-#{RSpec::Version::STRING}"
+  s.description = "BDD for Ruby"
 
-  spec.metadata = {
+  s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/tree/v#{spec.version}",
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}",
     'rubygems_mfa_required' => 'true',
   }
 
-  spec.files            = `git ls-files -- lib/*`.split("\n")
-  spec.files           += ["LICENSE.md"]
-  spec.test_files       = `git ls-files -- {spec,features}/*`.split("\n")
-  spec.executables      = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
-  spec.extra_rdoc_files = ["README.md"]
-  spec.rdoc_options     = ["--charset=UTF-8"]
-  spec.require_path     = "lib"
+  s.files            = `git ls-files -- lib/*`.split("\n")
+  s.files           += ["LICENSE.md"]
+  s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")
+  s.executables      = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  s.extra_rdoc_files = ["README.md"]
+  s.rdoc_options     = ["--charset=UTF-8"]
+  s.require_path     = "lib"
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
   if File.exist?(private_key)
-    spec.signing_key = private_key
-    spec.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
+    s.signing_key = private_key
+    s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
   %w[core expectations mocks].each do |name|
     if RSpec::Version::STRING =~ /[a-zA-Z]+/
-      spec.add_runtime_dependency "rspec-#{name}", "= #{RSpec::Version::STRING}"
+      s.add_runtime_dependency "rspec-#{name}", "= #{RSpec::Version::STRING}"
     else
-      spec.add_runtime_dependency "rspec-#{name}", "~> #{RSpec::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
+      s.add_runtime_dependency "rspec-#{name}", "~> #{RSpec::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
     end
   end
 end

--- a/rspec/rspec.gemspec
+++ b/rspec/rspec.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
   s.email       = "rspec@googlegroups.com"
-  s.homepage    = "https://github.com/rspec/rspec"
+  s.homepage    = "https://rspec.info"
   s.summary     = "rspec-#{RSpec::Version::STRING}"
   s.description = "BDD for Ruby"
 

--- a/rspec/rspec.gemspec
+++ b/rspec/rspec.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.license     = "MIT"
   s.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
   s.email       = "rspec@googlegroups.com"
-  s.homepage    = "http://github.com/rspec"
+  s.homepage    = "https://github.com/rspec/rspec"
   s.summary     = "rspec-#{RSpec::Version::STRING}"
   s.description = "BDD for Ruby"
 

--- a/rspec/rspec.gemspec
+++ b/rspec/rspec.gemspec
@@ -4,44 +4,44 @@
 $LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
 require "rspec/version"
 
-Gem::Specification.new do |s|
-  s.name        = "rspec"
-  s.version     = RSpec::Version::STRING
-  s.platform    = Gem::Platform::RUBY
-  s.license     = "MIT"
-  s.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
-  s.email       = "rspec@googlegroups.com"
-  s.homepage    = "http://github.com/rspec"
-  s.summary     = "rspec-#{RSpec::Version::STRING}"
-  s.description = "BDD for Ruby"
+Gem::Specification.new do |spec|
+  spec.name        = "rspec"
+  spec.version     = RSpec::Version::STRING
+  spec.platform    = Gem::Platform::RUBY
+  spec.license     = "MIT"
+  spec.authors     = ["Steven Baker", "David Chelimsky", "Myron Marston"]
+  spec.email       = "rspec@googlegroups.com"
+  spec.homepage    = "http://github.com/rspec"
+  spec.summary     = "rspec-#{RSpec::Version::STRING}"
+  spec.description = "BDD for Ruby"
 
-  s.metadata = {
+  spec.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}",
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/v#{spec.version}",
     'rubygems_mfa_required' => 'true',
   }
 
-  s.files            = `git ls-files -- lib/*`.split("\n")
-  s.files           += ["LICENSE.md"]
-  s.test_files       = `git ls-files -- {spec,features}/*`.split("\n")
-  s.executables      = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
-  s.extra_rdoc_files = ["README.md"]
-  s.rdoc_options     = ["--charset=UTF-8"]
-  s.require_path     = "lib"
+  spec.files            = `git ls-files -- lib/*`.split("\n")
+  spec.files           += ["LICENSE.md"]
+  spec.test_files       = `git ls-files -- {spec,features}/*`.split("\n")
+  spec.executables      = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+  spec.extra_rdoc_files = ["README.md"]
+  spec.rdoc_options     = ["--charset=UTF-8"]
+  spec.require_path     = "lib"
 
   private_key = File.expand_path('~/.gem/rspec-gem-private_key.pem')
   if File.exist?(private_key)
-    s.signing_key = private_key
-    s.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
+    spec.signing_key = private_key
+    spec.cert_chain = [File.expand_path('~/.gem/rspec-gem-public_cert.pem')]
   end
 
   %w[core expectations mocks].each do |name|
     if RSpec::Version::STRING =~ /[a-zA-Z]+/
-      s.add_runtime_dependency "rspec-#{name}", "= #{RSpec::Version::STRING}"
+      spec.add_runtime_dependency "rspec-#{name}", "= #{RSpec::Version::STRING}"
     else
-      s.add_runtime_dependency "rspec-#{name}", "~> #{RSpec::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
+      spec.add_runtime_dependency "rspec-#{name}", "~> #{RSpec::Version::STRING.split('.')[0..1].concat(['0']).join('.')}"
     end
   end
 end

--- a/rspec/rspec.gemspec
+++ b/rspec/rspec.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}",
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/rspec-metagem-v#{s.version}",
     'rubygems_mfa_required' => 'true',
   }
 


### PR DESCRIPTION
Following https://github.com/rspec/rspec/pull/154#issuecomment-2516789059

I think the branch should be merged to mainteance branch then ? Also we are missing a global tag for `rspec` gem ?

@JonRowe feel free to change base branch if needed.