### PR TITLE
Update instructions for gems installations from git repository

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,19 +51,15 @@ change for on `rspec-mocks`. We add a commit with the title:
 
 And content:
 
-```diff
-diff --git a/Gemfile b/Gemfile
-
--%w[rspec rspec-core rspec-mocks rspec-support].each do |lib|
-+%w[rspec rspec-core rspec-support].each do |lib|
-   library_path = File.expand_path("../../#{lib}", __FILE__)
-   if File.exist?(library_path) && !ENV['USE_GIT_REPOS']
-     gem lib, :path => library_path
-@@ -11,6 +11,7 @@ branch = File.read(File.expand_path("../maintenance-branch", __FILE__)).chomp
-     gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => branch
-   end
- end
-+gem 'rspec-mocks', :git => "https://github.com/rspec/rspec-mocks.git", :branch => "custom-failure-message"
+```ruby
+%w[rspec rspec-core rspec-expectations rspec-support].each do |lib|
+  if lib == 'rspec'
+    gem lib, git: "https://github.com/rspec/rspec"
+  else
+    gem lib, git: "https://github.com/rspec/rspec", glob: "#{lib}/#{lib}.gemspec"
+  end
+end
+gem 'rspec-mocks', git: "https://github.com/my_user_name/rspec", branch: 'your-custom-branch', glob: "rspec-mocks/rspec-mocks.gemspec"
 ```
 
 In general the process is:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ RSpec repos as well. Add the following to your `Gemfile`:
 
 ```ruby
 %w[rspec rspec-core rspec-expectations rspec-mocks rspec-support].each do |lib|
-  gem lib, :git => "https://github.com/rspec/#{lib}.git", :branch => 'main'
+  if lib == 'rspec'
+    gem lib, git: "https://github.com/rspec/rspec"
+  else
+    gem lib, git: "https://github.com/rspec/rspec", glob: "#{lib}/#{lib}.gemspec"
+  end
 end
 ```
 


### PR DESCRIPTION
Output:
```
Fetching https://github.com/rspec/rspec
Fetching https://github.com/rspec/rspec
Fetching https://github.com/rspec/rspec
Fetching https://github.com/rspec/rspec
Fetching https://github.com/rspec/rspec
Resolving dependencies...
Fetching gem metadata from https://rubygems.org/.
Bundle complete! 5 Gemfile dependencies, 7 gems now installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
```