### PR TITLE
Add windows back to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,25 +20,25 @@ jobs:
     uses: rspec/rspec/.github/workflows/rubocop.yml@main
 
   core:
-    uses: rspec/rspec/.github/workflows/rspec.yml@main
+    uses: rspec/rspec/.github/workflows/rspec.yml@add-windows
     with:
       library: 'rspec-core'
       rspec_version: '= 3.14.0.pre'
 
   mocks:
-    uses: rspec/rspec/.github/workflows/rspec.yml@main
+    uses: rspec/rspec/.github/workflows/rspec.yml@add-windows
     with:
       library: 'rspec-mocks'
       rspec_version: '= 3.14.0.pre'
 
   expectations:
-    uses: rspec/rspec/.github/workflows/rspec.yml@main
+    uses: rspec/rspec/.github/workflows/rspec.yml@add-windows
     with:
       library: 'rspec-expectations'
       rspec_version: '= 3.14.0.pre'
 
   support:
-    uses: rspec/rspec/.github/workflows/rspec.yml@main
+    uses: rspec/rspec/.github/workflows/rspec.yml@add-windows
     with:
       library: 'rspec-support'
       rspec_version: '= 3.14.0.pre'

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -50,3 +50,22 @@ jobs:
       - run: ../script/run_rspec
       - run: ../script/run_rspec_one_by_one
       - run: ../script/run_cucumber
+
+  windows:
+    name: Ruby ${{ matrix.ruby }} (Windows)
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        ruby:
+          - '3.3'
+          - 2.7
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler: '2.2.22'
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: choco install ansicon
+      - run: bundle exec rspec --backtrace


### PR DESCRIPTION
We should run at least one windows build, theres two here only because of my uncertainty of 3.3 support where as I know 2.7 worked.