### PR TITLE
Set `:all`/`:deprecation_only`/`:none` as options for `config.warnings=`

### DIFF
--- a/rspec-core/Changelog.md
+++ b/rspec-core/Changelog.md
@@ -35,12 +35,15 @@ Breaking Changes:
   (Phil Pirozhkov, rspec/rspec-core#2864)
 * Unify multi-condition filtering to use "all" semantic. (Phil Pirozhkov, rspec/rspec-core#2874)
 * Change the default order to random. (Santiago Bartesaghi, rspec/rspec-core#2929)
+* Default warning level is now `:deprecations_only`. (Jon Rowe, rspec/rspec#161)
 
 Enhancements:
 
 * Add config option (`RSpec::Core::Configuration#force_line_number_for_spec_rerun`) to
   allways print a line number rather than an example id when the line number is ambiguous.
   (Baden Ashford, rspec/rspec-core#3085)
+* Expand `RSpec::Core::Configuration#warnings=` to take `:all`, `:deprecations_only` and `:none`
+  options. (Jean Boussier, rspec/rspec#161)
 
 ### 3.13.4 / 2025-05-27
 [Full Changelog](http://github.com/rspec/rspec/compare/rspec-core-v3.13.3...rspec-core-v3.13.4)

--- a/rspec-core/lib/rspec/core/option_parser.rb
+++ b/rspec-core/lib/rspec/core/option_parser.rb
@@ -178,11 +178,7 @@ module RSpec::Core
         end
 
         parser.on('-w', '--warnings', 'Enable ruby warnings') do
-          if Object.const_defined?(:Warning) && Warning.respond_to?(:[]=)
-            # :nocov: on older Ruby without Warning
-            Warning[:deprecated] = true
-            # :nocov:
-          end
+          Warning[:deprecated] = true
           $VERBOSE = true
         end
 

--- a/rspec-core/lib/rspec/core/project_initializer/spec/spec_helper.rb
+++ b/rspec-core/lib/rspec/core/project_initializer/spec/spec_helper.rb
@@ -35,6 +35,11 @@ RSpec.configure do |config|
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin
+  # This setting turns on all Ruby warnings. It's recommended, but in some cases may
+  # be too noisy due to issues in dependencies. The default is set to `:deprecations_only`
+  # but it can also be set to `:none` to suppress them.
+  config.warnings = :all
+
   # This allows you to limit a spec run to individual examples or groups
   # you care about by tagging them with `:focus` metadata. When nothing
   # is tagged with `:focus`, all examples get run. RSpec also provides
@@ -46,10 +51,6 @@ RSpec.configure do |config|
   # the `--only-failures` and `--next-failure` CLI options. We recommend
   # you configure your source control system to ignore this file.
   config.example_status_persistence_file_path = "spec/examples.txt"
-
-  # This setting enables warnings. It's recommended, but in some cases may
-  # be too noisy due to issues in dependencies.
-  config.warnings = true
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an

--- a/rspec-support/lib/rspec/support/spec.rb
+++ b/rspec-support/lib/rspec/support/spec.rb
@@ -19,6 +19,8 @@ RSpec.configure do |c|
   c.include RSpec::Support::FormattingSupport
   c.include RSpec::Support::InSubProcess
 
+  c.warnings = :all
+
   unless defined?(Debugger) # debugger causes warnings when used
     c.before do
       warning_preventer.reset!


### PR DESCRIPTION
Fix: https://github.com/rspec/rspec/issues/37

Since Ruby 2.7.2, Ruby expect test frameworks to enable deprecation warnings so users get advance notice of future breaking changes.

I implemented it as specified in https://github.com/rspec/rspec/issues/37#issuecomment-2504702395

3.99 deprecation for boolean `config.warnings = true`/`config.warnings = false` https://github.com/rspec/rspec/pull/268