### PR TITLE
Fix hash output on Ruby 3.4

### DIFF
--- a/rspec-expectations/features/built_in_matchers/include.feature
+++ b/rspec-expectations/features/built_in_matchers/include.feature
@@ -139,7 +139,7 @@ Feature: `include` matcher
       end
       """
     When I run `rspec hash_include_matcher_spec.rb`
-    Then the output should contain all of these:
+    Then the output should contain all of these, ignoring hash syntax:
       | 22 examples, 13 failures                                      |
       | expected {:a => 7, :b => 5} not to include :a                 |
       | expected {:a => 7, :b => 5} not to include :b and :a          |
@@ -176,7 +176,7 @@ Feature: `include` matcher
         end
       """
     When I run `rspec include_matcher_with_counts_spec.rb`
-    Then the output should contain all of these:
+    Then the output should contain all of these, ignoring hash syntax:
       | 12 examples, 4 failures                                                                                                 |
       | expected [{:c => 7}, {:a => 1}, {:b => 2}, {:c => 1}, {:a => 3}, {:c => 7}] not to include (have key :b) once           |
       | expected [{:c => 7}, {:a => 1}, {:b => 2}, {:c => 1}, {:a => 3}, {:c => 7}] not to include (have key :a) twice          |

--- a/rspec-expectations/features/built_in_matchers/predicates.feature
+++ b/rspec-expectations/features/built_in_matchers/predicates.feature
@@ -88,7 +88,7 @@ Feature: Predicate matchers
       """
     When I run `rspec should_have_key_spec.rb`
     Then the output should contain "2 examples, 1 failure"
-     And the output should contain "expected `{:foo=>7}.has_key?(:bar)` to be truthy, got false"
+     And the output should contain, ignoring hash syntax, "expected `{:foo=>7}.has_key?(:bar)` to be truthy, got false"
 
    Scenario: Expecting `subject` to have all decimals (based on custom `has_decimals?` method)
      Given a file named "should_not_have_all_string_keys_spec.rb" with:

--- a/rspec-expectations/features/step_definitions/additional_cli_steps.rb
+++ b/rspec-expectations/features/step_definitions/additional_cli_steps.rb
@@ -28,3 +28,29 @@ Then(/^the example should fail$/) do
   step 'the output should contain "1 failure"'
   step 'the exit status should not be 0'
 end
+
+Then(/^the output should contain, ignoring hash syntax, "(.*)"$/) do |output|
+  if RUBY_VERSION.to_f > 3.3
+    expect(all_output).to include(output.gsub(/:(\w+)=>/, '\1: '))
+  else
+    expect(all_output).to include(output)
+  end
+end
+
+RSpec::Matchers.define :match_table do |lines|
+  match do |all_output|
+    lines.all? { |line| all_output.include?(line) }
+  end
+
+  diffable
+end
+
+Then "the output should contain all of these, ignoring hash syntax:" do |table|
+  lines = table.raw.flatten.reject(&:empty?)
+
+  if RUBY_VERSION.to_f > 3.3
+    lines = lines.map { |line| line.gsub(/:(\w+)\s+=>\s+/, '\1: ') }
+  end
+
+  expect(all_output).to match_table(lines)
+end

--- a/rspec-expectations/spec/rspec/matchers/aliases_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/aliases_spec.rb
@@ -219,7 +219,7 @@ module RSpec
           an_object_having_attributes(:age => 32)
       ).to be_aliased_to(
           have_attributes(:age => 32)
-      ).with_description("an object having attributes {:age => 32}")
+      ).with_description("an object having attributes #{hash_inspect({ :age => 32 })}")
     end
 
     specify do
@@ -227,7 +227,7 @@ module RSpec
         having_attributes(:age => 32)
       ).to be_aliased_to(
         have_attributes(:age => 32)
-      ).with_description("having attributes {:age => 32}")
+      ).with_description("having attributes #{hash_inspect({ :age => 32 })}")
     end
 
     specify do
@@ -251,7 +251,7 @@ module RSpec
         a_hash_including(:a => 5)
       ).to be_aliased_to(
         include(:a => 5)
-      ).with_description('a hash including {:a => 5}')
+      ).with_description("a hash including #{hash_inspect({ :a => 5 })}")
     end
 
     specify do

--- a/rspec-expectations/spec/rspec/matchers/built_in/captures_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/captures_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe "expect(regex).to match(string).with_captures" do
       it "has a sensible failure description with a hash including matcher" do
         expect {
           expect("a123a").not_to match(Regexp.new("(?<num>123)(asdf)?")).with_captures(a_hash_including(:num => "123"))
-        }.to fail_with(/num => "123"/)
+        }.to fail_with(/#{hash_inspect({ :num => "123" })}/)
       end
 
       it "matches named captures when not passing a hash" do
@@ -80,7 +80,7 @@ RSpec.describe "expect(regex).to match(string).with_captures" do
       it "has a sensible failure description with a hash including matcher" do
         expect {
           expect(Regexp.new("(?<num>123)(asdf)?")).not_to match("a123a").with_captures(a_hash_including(:num => "123"))
-        }.to fail_with(/num => "123"/)
+        }.to fail_with(/#{hash_inspect({ :num => "123" })}/)
       end
 
       it "matches named captures when not passing a hash" do

--- a/rspec-expectations/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/eq_spec.rb
@@ -120,7 +120,7 @@ module RSpec
             ['foo', 'eq "foo"'],
             [/regex/, 'eq /regex/'],
             [['foo'], 'eq ["foo"]'],
-            [{ :foo => :bar }, 'eq {:foo=>:bar}'],
+            [{ :foo => :bar }, "eq #{{ :foo=>:bar }.inspect}"],
             [Class, 'eq Class'],
             [RSpec, 'eq RSpec'],
             [Time.utc(2014, 1, 1), "eq 2014-01-01 00:00:00.#{expected_seconds} +0000"],

--- a/rspec-expectations/spec/rspec/matchers/built_in/has_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/has_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe "expect(...).to have_sym(*args)" do
   it "fails if #has_sym?(*args) returns false" do
     expect {
       expect({ :b => "B" }).to have_key(:a)
-    }.to fail_with('expected `{:b=>"B"}.has_key?(:a)` to return true, got false')
+    }.to fail_with("expected `#{{ :b=>"B" }.inspect}.has_key?(:a)` to return true, got false")
   end
 
   obj_with_block_method = Object.new
@@ -180,7 +180,7 @@ RSpec.describe "expect(...).not_to have_sym(*args)" do
   it "fails if #has_sym?(*args) returns true" do
     expect {
       expect({ :a => "A" }).not_to have_key(:a)
-    }.to fail_with('expected `{:a=>"A"}.has_key?(:a)` to return false, got true')
+    }.to fail_with("expected `#{{ :a=>"A" }.inspect}.has_key?(:a)` to return false, got true")
   end
 
   it "fails if target does not respond to #has_sym?" do

--- a/rspec-expectations/spec/rspec/matchers/built_in/have_attributes_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/have_attributes_spec.rb
@@ -108,13 +108,25 @@ RSpec.describe "#have_attributes matcher" do
 
       it 'provides a description' do
         description = have_attributes(:age => (a_value > 30)).description
-        expect(description).to eq("have attributes {:age => (a value > 30)}")
+        expect(description).to eq(
+          if RUBY_VERSION.to_f > 3.3
+            "have attributes {age: (a value > 30)}"
+          else
+            "have attributes {:age => (a value > 30)}"
+          end
+        )
       end
 
       it "fails with a clear message when the matcher does not match" do
         expect {
           expect(person).to have_attributes(:age => (a_value < 10))
-        }.to fail_including("expected #{object_inspect person} to have attributes {:age => (a value < 10)}")
+        }.to fail_including(
+          if RUBY_VERSION.to_f > 3.3
+            "expected #{object_inspect person} to have attributes {age: (a value < 10)}"
+          else
+            "expected #{object_inspect person} to have attributes {:age => (a value < 10)}"
+          end
+        )
       end
     end
   end

--- a/rspec-mocks/features/step_definitions/additional_cli_steps.rb
+++ b/rspec-mocks/features/step_definitions/additional_cli_steps.rb
@@ -27,7 +27,7 @@ Then /^it should fail with the following output(, ignoring hash syntax)?:$/ do |
   lines = table.raw.flatten.reject(&:empty?)
 
   if ignore_hash_syntax && RUBY_VERSION.to_f > 3.3
-    lines = lines.map { |line| line.gsub(/([^\s])=>/, '\1 => ') }
+    lines = lines.map { |line| line.gsub(/:(\w+)=>/, '\1: ') }
   end
 
   expect(all_output).to match_table(lines)

--- a/rspec-mocks/spec/rspec/mocks/argument_matchers_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/argument_matchers_spec.rb
@@ -431,7 +431,13 @@ module RSpec
             expect(a_double).to receive(:random_call).with(:a => "a", :b => "b")
             expect do
               a_double.random_call(opts)
-            end.to fail_with(/expected: \(\{(:a\s*=>\s*\"a\", :b\s*=>\s*\"b\"|:b\s*=>\s*\"b\", :a\s*=>\s*\"a\")\}\)/)
+            end.to fail_with(
+              if RUBY_VERSION.to_f > 3.3
+                /expected: \(\{a: \"a\", b: \"b\"\}\)/
+              else
+                /expected: \(\{(:a\s*=>\s*\"a\", :b\s*=>\s*\"b\"|:b\s*=>\s*\"b\", :a\s*=>\s*\"a\")\}\)/
+              end
+            )
           end
         else
           it "matches against a hash submitted as a positional argument and received as keyword arguments in Ruby 2.7 or before" do
@@ -445,14 +451,26 @@ module RSpec
           expect(a_double).to receive(:random_call).with(:a => "b", :c => "d")
           expect do
             a_double.random_call(:a => "b", :c => "e")
-          end.to fail_with(/expected: \(\{(:a\s*=>\s*\"b\", :c\s*=>\s*\"d\"|:c\s*=>\s*\"d\", :a\s*=>\s*\"b\")\}\)/)
+          end.to fail_with(
+            if RUBY_VERSION.to_f > 3.3
+              /expected: \(\{a: \"b\", c: \"d\"\}\)/
+            else
+              /expected: \(\{(:a\s*=>\s*\"b\", :c\s*=>\s*\"d\"|:c\s*=>\s*\"d\", :a\s*=>\s*\"b\")\}\)/
+            end
+          )
         end
 
         it "fails for a hash w/ wrong keys", :reset => true do
           expect(a_double).to receive(:random_call).with(:a => "b", :c => "d")
           expect do
             a_double.random_call("a" => "b", "c" => "d")
-          end.to fail_with(/expected: \(\{(:a\s*=>\s*\"b\", :c\s*=>\s*\"d\"|:c\s*=>\s*\"d\", :a\s*=>\s*\"b\")\}\)/)
+          end.to fail_with(
+            if RUBY_VERSION.to_f > 3.3
+              /expected: \(\{a: \"b\", c: \"d\"\}\)/
+            else
+              /expected: \(\{(:a\s*=>\s*\"b\", :c\s*=>\s*\"d\"|:c\s*=>\s*\"d\", :a\s*=>\s*\"b\")\}\)/
+            end
+          )
         end
 
         it "matches a class against itself" do

--- a/rspec-mocks/spec/rspec/mocks/diffing_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/diffing_spec.rb
@@ -105,7 +105,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
               "  expected: ({:baz=>:quz, :foo=>:bar}) (keyword arguments)\n" \
               "       got: ({:baz=>:quz, :foo=>:bar}) (options hash)"
 
-            message = message.gsub('=>', ' => ') if RUBY_VERSION.to_f > 3.3
+            message = message.gsub(/:(\w+)=>/, '\1: ') if RUBY_VERSION.to_f > 3.3
 
             with_unfulfilled_double do |d|
               expect(d).to receive(:foo).with(**expected_hash)
@@ -126,7 +126,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
                 "  expected: (:positional, {:keyword=>1}) (keyword arguments)\n" \
                 "       got: (:positional, {:keyword=>1}) (options hash)"
 
-              message = message.gsub('=>',' => ') if RUBY_VERSION.to_f > 3.3
+              message = message.gsub(/:(\w+)=>/, '\1: ') if RUBY_VERSION.to_f > 3.3
 
               expect {
                 options = { keyword: 1 }
@@ -155,7 +155,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
                 "-[#{expected_input.inspect}, {:one=>1}]\n" \
                 "+[#{actual_input.inspect}, {:one=>1}]\n"
 
-              message = message.gsub('=>',' => ') if RUBY_VERSION.to_f > 3.3
+              message = message.gsub(/:(\w+)=>/, '\1: ') if RUBY_VERSION.to_f > 3.3
 
               expect {
                 options = { one: 1 }
@@ -187,7 +187,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
               "  expected: (:positional, {:baz=>:quz, :foo=>:bar}) (keyword arguments)\n" \
               "       got: (:positional, {:baz=>:quz, :foo=>:bar}) (options hash)"
 
-            message.gsub!('=>',' => ') if RUBY_VERSION.to_f > 3.3
+            message = message.gsub(/:(\w+)=>/, '\1: ') if RUBY_VERSION.to_f > 3.3
 
             expect(d).to receive(:foo).with(:positional, **expected_hash)
             expect {
@@ -203,7 +203,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
               "  expected: (:positional, {:keyword=>1}) (keyword arguments)\n" \
               "       got: (:positional, {:keyword=>1}) (options hash)"
 
-            message.gsub!('=>',' => ') if RUBY_VERSION.to_f > 3.3
+            message = message.gsub(/:(\w+)=>/, '\1: ') if RUBY_VERSION.to_f > 3.3
 
             expect(d).to receive(:foo).with(:positional, keyword: 1)
             expect {
@@ -231,7 +231,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
               "-[#{expected_input.inspect}, {:one=>1}]\n" \
               "+[#{actual_input.inspect}, {:one=>1}]\n"
 
-            message = message.gsub('=>', ' => ') if RUBY_VERSION.to_f > 3.3
+            message = message.gsub(/:(\w+)=>/, '\1: ') if RUBY_VERSION.to_f > 3.3
 
             expect {
               options = { one: 1 }
@@ -250,11 +250,6 @@ RSpec.describe "Diffs printed when arguments don't match" do
       # calls to the same hash. This regex allows us to work around that.
       def hash_regex_inspect(hash)
         "\\{(#{hash.map { |key, value| "#{key.inspect}=>#{value.inspect}.*" }.join "|"}){#{hash.size}}\\}"
-      end
-    elsif RUBY_VERSION.to_f > 3.3
-      # Ruby head / 3.4 is changing the hash syntax inspect, but we use PP when diffing which just spaces out hashrockets
-      def hash_regex_inspect(hash)
-        Regexp.escape("{#{hash.map { |key, value| "#{key.inspect} => #{value.inspect}"}.join(", ")}}")
       end
     else
       def hash_regex_inspect(hash)

--- a/rspec-mocks/spec/rspec/mocks/double_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/double_spec.rb
@@ -528,7 +528,7 @@ module RSpec
         it 'fails when calling yielding method with invalid kw args' do
           message =
             if RUBY_VERSION.to_f > 3.3
-              '#<Double "test double"> yielded |{:x => 1, :y => 2}| to block with optional keyword args (:x)'
+              '#<Double "test double"> yielded |{x: 1, y: 2}| to block with optional keyword args (:x)'
             else
               '#<Double "test double"> yielded |{:x=>1, :y=>2}| to block with optional keyword args (:x)'
             end

--- a/rspec-mocks/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/matchers/receive_spec.rb
@@ -141,8 +141,8 @@ module RSpec
 
                   if RUBY_VERSION.to_f > 3.3
                     expect(failure.message)
-                      .to include('expected: ({:a => 1, :b => 2}) (keyword arguments)')
-                      .and include('got: ({:a => 1, :b => 2}) (options hash)')
+                      .to include('expected: ({a: 1, b: 2}) (keyword arguments)')
+                      .and include('got: ({a: 1, b: 2}) (options hash)')
                   else
                     expect(failure.message)
                       .to include('expected: ({:a=>1, :b=>2}) (keyword arguments)')

--- a/rspec-mocks/spec/rspec/mocks/verifying_doubles/expected_arg_verification_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/verifying_doubles/expected_arg_verification_spec.rb
@@ -134,7 +134,7 @@ module RSpec
               it "fails to match against a hash submitted as a positional argument and received as keyword arguments in Ruby 3.0 or later", :reset => true do
                 messages =
                   if RUBY_VERSION.to_f > 3.3
-                    ["expected: (1, {:optional_arg => 3, :required_arg => 2}) (keyword arguments)", "got: (1, {:optional_arg => 3, :required_arg => 2}) (options hash)"]
+                    ["expected: (1, {optional_arg: 3, required_arg: 2}) (keyword arguments)", "got: (1, {optional_arg: 3, required_arg: 2}) (options hash)"]
                   else
                     ["expected: (1, {:optional_arg=>3, :required_arg=>2}) (keyword arguments)", "got: (1, {:optional_arg=>3, :required_arg=>2}) (options hash)"]
                   end

--- a/rspec-support/lib/rspec/support/object_formatter.rb
+++ b/rspec-support/lib/rspec/support/object_formatter.rb
@@ -61,6 +61,8 @@ module RSpec
           prepare_array(object)
         when Hash
           prepare_hash(object)
+        when Symbol
+          object
         else
           inspector_class = INSPECTOR_CLASSES.find { |inspector| inspector.can_inspect?(object) }
           inspector_class.new(object, self)

--- a/rspec-support/spec/rspec/support/differ_spec.rb
+++ b/rspec-support/spec/rspec/support/differ_spec.rb
@@ -308,7 +308,7 @@ module RSpec
               |
             EOD
 
-            expected_diff.gsub!('=>',' => ') if RUBY_VERSION.to_f > 3.3
+            expected_diff.gsub!(/:(\w+)=>/,'\1: ') if RUBY_VERSION.to_f > 3.3
 
             diff = differ.diff(expected,actual)
             expect(diff).to be_diffed_as(expected_diff)


### PR DESCRIPTION
This builds off #163 but contains a fix which means Ruby 3.4 syntax will consistently use `{a: :b}` style on single lines.