### PR TITLE
Cancel outdated builds to reduce queueing

### DIFF
--- a/.github/workflows/documentation_coverage.yml
+++ b/.github/workflows/documentation_coverage.yml
@@ -4,6 +4,10 @@ on: workflow_call
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   RSPEC_CI: true
 

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -16,6 +16,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   DIFF_LCS_VERSION: "> 1.4.3"
   RSPEC_CI: true

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -4,6 +4,10 @@ on: workflow_call
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   rubocop:
     name: RuboCop

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,6 +1,5 @@
 name: Run RuboCop
-on:
-  workflow_call:
+on: workflow_call
 
 permissions:
   contents: read

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,4 +1,4 @@
-name: Run Rubocop
+name: Run RuboCop
 on:
   workflow_call:
 
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   rubocop:
-    name: Rubocop
+    name: RuboCop
     runs-on: 'ubuntu-20.04'
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Run CI only for the last push on each branch.

Prevents branch builds from stacking on multiple subsequent pushes by canceling older builds.

https://docs.github.com/en/actions/using-jobs/using-concurrency
https://github.blog/changelog/2021-04-19-github-actions-limit-workflow-run-or-job-concurrency/

Scavenged from https://github.com/rubocop/rubocop-rspec/pull/1539

Problem:
<img width="1090" alt="image" src="https://github.com/user-attachments/assets/9292c0e9-1430-4465-87e8-b4d60a34e10a" />
