### PR TITLE
Manually mark rspec as the executable

### DIFF
--- a/rspec-core/rspec-core.gemspec
+++ b/rspec-core/rspec-core.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.files           += %w[README.md LICENSE.md Changelog.md .yardopts .document]
   s.test_files       = []
   s.bindir           = 'exe'
-  s.executables      = `git ls-files -- exe/*`.split("\n").map{ |f| File.basename(f) }
+  s.executables      = ['rspec']
   s.rdoc_options     = ["--charset=UTF-8"]
   s.require_path     = "lib"
 


### PR DESCRIPTION
For years we've used a git glob to find our rspec exe, but it seems when using the glob option to pull rspec out of the monorepo this breaks, you can see this on [this rspec-rails build](https://github.com/rspec/rspec-rails/actions/runs/12562446236/job/35023255403) whilst later Rubies which are the only ones RSpec 4 will support seem fine with this, I think its safer to just fix this.