### PR TITLE
Fix memoization in #location_rerun_argument

### DIFF
--- a/rspec-core/lib/rspec/core/example.rb
+++ b/rspec-core/lib/rspec/core/example.rb
@@ -98,7 +98,7 @@ module RSpec
           loaded_spec_files = RSpec.configuration.loaded_spec_files
 
           Metadata.ascending(metadata) do |meta|
-            return meta[:location] if loaded_spec_files.include?(meta[:absolute_file_path])
+            break meta[:location] if loaded_spec_files.include?(meta[:absolute_file_path])
           end
         end
       end


### PR DESCRIPTION
The use of `return` meant that the memoization just didn't happen as control flow left the whole `#location_rerun_argument` method. Using break instead fixes that.
