### PR TITLE
Explicitly setup Aruba to prevent a failure

### DIFF
--- a/rspec-core/spec/integration/bisect_runners_spec.rb
+++ b/rspec-core/spec/integration/bisect_runners_spec.rb
@@ -6,7 +6,6 @@ require 'rspec/core/bisect/fork_runner'
 module RSpec::Core
   RSpec.shared_examples_for "a bisect runner" do
     include_context "aruba support"
-    before { setup_aruba }
 
     let(:shell_command) { Bisect::ShellCommand.new([]) }
 

--- a/rspec-core/spec/integration/fail_if_no_examples_spec.rb
+++ b/rspec-core/spec/integration/fail_if_no_examples_spec.rb
@@ -2,7 +2,6 @@ require 'support/aruba_support'
 
 RSpec.describe 'Fail if no examples' do
   include_context "aruba support"
-  before { setup_aruba }
 
   context 'when 1 passing example' do
     def passing_example(fail_if_no_examples)

--- a/rspec-core/spec/integration/failed_line_detection_spec.rb
+++ b/rspec-core/spec/integration/failed_line_detection_spec.rb
@@ -2,7 +2,6 @@ require 'support/aruba_support'
 
 RSpec.describe 'Failed line detection' do
   include_context "aruba support"
-  before { setup_aruba }
 
   it "finds the source of a failure in a spec file that is defined at the current directory instead of in the normal `spec` subdir" do
     write_file "the_spec.rb", "

--- a/rspec-core/spec/integration/filtering_spec.rb
+++ b/rspec-core/spec/integration/filtering_spec.rb
@@ -2,7 +2,6 @@ require 'support/aruba_support'
 
 RSpec.describe 'Filtering' do
   include_context "aruba support"
-  before { setup_aruba }
 
   it 'prints a rerun command for shared examples in external files that works to rerun' do
     write_file "spec/support/shared_examples.rb", "

--- a/rspec-core/spec/integration/location_rerun_spec.rb
+++ b/rspec-core/spec/integration/location_rerun_spec.rb
@@ -5,8 +5,6 @@ RSpec.describe 'Failed spec rerun location' do
   include_context "aruba support"
 
   before do
-    setup_aruba
-
     # Setup some shared examples and call them in a separate file
     # from where they are called to demonstrate how nested example ids work
     write_file_formatted "some_examples.rb", "

--- a/rspec-core/spec/integration/order_spec.rb
+++ b/rspec-core/spec/integration/order_spec.rb
@@ -1,7 +1,9 @@
 require 'support/aruba_support'
 
-RSpec.describe 'command line', :ui do
+RSpec.describe 'command line' do
   include_context "aruba support"
+
+  before(:all) { setup_aruba }
 
   before :all do
     write_file 'spec/simple_spec.rb', "

--- a/rspec-core/spec/integration/output_stream_spec.rb
+++ b/rspec-core/spec/integration/output_stream_spec.rb
@@ -2,7 +2,6 @@ require 'support/aruba_support'
 
 RSpec.describe 'Output stream' do
   include_context 'aruba support'
-  before { setup_aruba }
 
   context 'when a formatter set in a configure block' do
     it 'writes to the right output stream' do

--- a/rspec-core/spec/integration/persistence_failures_spec.rb
+++ b/rspec-core/spec/integration/persistence_failures_spec.rb
@@ -2,7 +2,6 @@ require 'support/aruba_support'
 
 RSpec.describe 'Persistence failures' do
   include_context "aruba support"
-  before { setup_aruba }
 
   context "when `config.example_status_persistence_file_path` is configured" do
     context "to an invalid file path (e.g. spec/spec_helper.rb/examples.txt)" do

--- a/rspec-core/spec/integration/spec_file_load_errors_spec.rb
+++ b/rspec-core/spec/integration/spec_file_load_errors_spec.rb
@@ -19,8 +19,6 @@ RSpec.describe 'Spec file load errors' do
   end
 
   before do
-    setup_aruba
-
     RSpec.configure do |c|
       c.filter_gems_from_backtrace "gems/aruba"
       c.filter_gems_from_backtrace "gems/bundler"

--- a/rspec-core/spec/integration/suite_hooks_errors_spec.rb
+++ b/rspec-core/spec/integration/suite_hooks_errors_spec.rb
@@ -21,8 +21,6 @@ RSpec.describe 'Suite hook errors' do
   end
 
   before do
-    setup_aruba
-
     RSpec.configure do |c|
       c.filter_gems_from_backtrace "gems/aruba"
       c.filter_gems_from_backtrace "gems/bundler"

--- a/rspec-core/spec/support/aruba_support.rb
+++ b/rspec-core/spec/support/aruba_support.rb
@@ -35,6 +35,8 @@ RSpec.shared_context "aruba support" do
   let(:stderr) { StringIO.new }
   let(:stdout) { StringIO.new }
 
+  before { setup_aruba }
+
   attr_reader :last_cmd_stdout, :last_cmd_stderr, :last_cmd_exit_status
 
   def run_command(cmd)


### PR DESCRIPTION
This was flaky, and order-dependent. If the spec that didn't set up Aruba ran first:

    2246 examples, 7 failures, 5 pending

    Failed examples:

    rspec ./spec/integration/order_spec.rb:83 (and some others, but all in the same file)

     RuntimeError:
       Aruba's working directory does not exist. Maybe you forgot to run `setup_aruba` before using its API.
     # /home/runner/work/rspec/rspec/bundle/ruby/3.0.0/gems/aruba-2.2.0/lib/aruba/api/core.rb:156:in `expand_path'

Only this one was "using the Aruba API" before `before`, in a `before(:all)`.

Extracted from #161
