### PR TITLE
[rspec-expectations] update not to invalid matcher error to be more descriptive

### DIFF
--- a/rspec-expectations/lib/rspec/matchers/built_in/change.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/change.rb
@@ -286,7 +286,7 @@ module RSpec
         # @private
         def does_not_match?(event_proc)
           if @description_suffix
-            raise NotImplementedError, "Using `expect { }.not_to change { }` " \
+            raise NotImplementedError, "Using `expect { }.not_to change { }.from()` " \
                                        "with the `to()` matcher is not supported."
           end
 

--- a/rspec-expectations/lib/rspec/matchers/built_in/change.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/change.rb
@@ -150,8 +150,8 @@ module RSpec
 
         # @private
         def does_not_match?(_event_proc)
-          raise NotImplementedError, "`expect { }.not_to change " \
-                                     "{ }.#{@relativity}()` is not supported"
+          raise NotImplementedError, "Using `expect { }.not_to change { }` " \
+                                     "with the `#{@relativity}()` matcher is not supported."
         end
 
         # @private
@@ -286,8 +286,8 @@ module RSpec
         # @private
         def does_not_match?(event_proc)
           if @description_suffix
-            raise NotImplementedError, "`expect { }.not_to change { }.to()` " \
-                                       "is not supported"
+            raise NotImplementedError, "Using `expect { }.not_to change { } ` " \
+                                       "with the `to()` matcher is not supported."
           end
 
           perform_change(event_proc) && !@change_details.changed? && @matches_before
@@ -326,8 +326,8 @@ module RSpec
 
         # @private
         def does_not_match?(_event_proc)
-          raise NotImplementedError, "`expect { }.not_to change { }.to()` " \
-                                     "is not supported"
+          raise NotImplementedError, "Using `expect { }.not_to change { }` " \
+                                     "with the `to()` matcher is not supported."
         end
 
       private

--- a/rspec-expectations/lib/rspec/matchers/built_in/change.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/change.rb
@@ -152,7 +152,6 @@ module RSpec
         def does_not_match?(_event_proc)
           raise NotImplementedError, "Using a negated form of the `change` matcher " \
                                      "with `#{@relativity}()` is not supported."
-
         end
 
         # @private

--- a/rspec-expectations/lib/rspec/matchers/built_in/change.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/change.rb
@@ -150,8 +150,9 @@ module RSpec
 
         # @private
         def does_not_match?(_event_proc)
-          raise NotImplementedError, "Using `expect { }.not_to change { }` " \
-                                     "with the `#{@relativity}()` matcher is not supported."
+          raise NotImplementedError, "Using a negated form of the `change` matcher " \
+                                     "with `#{@relativity}()` is not supported."
+
         end
 
         # @private
@@ -286,8 +287,8 @@ module RSpec
         # @private
         def does_not_match?(event_proc)
           if @description_suffix
-            raise NotImplementedError, "Using `expect { }.not_to change { }.from()` " \
-                                       "with the `to()` matcher is not supported."
+            raise NotImplementedError, "Using a negated form of the `change` matcher " \
+                                       "with `to()` is not supported."
           end
 
           perform_change(event_proc) && !@change_details.changed? && @matches_before
@@ -326,8 +327,8 @@ module RSpec
 
         # @private
         def does_not_match?(_event_proc)
-          raise NotImplementedError, "Using `expect { }.not_to change { }` " \
-                                     "with the `to()` matcher is not supported."
+          raise NotImplementedError, "Using a negated form of the `change` matcher " \
+                                     "with `to()` is not supported."
         end
 
       private

--- a/rspec-expectations/lib/rspec/matchers/built_in/change.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/change.rb
@@ -286,7 +286,7 @@ module RSpec
         # @private
         def does_not_match?(event_proc)
           if @description_suffix
-            raise NotImplementedError, "Using `expect { }.not_to change { } ` " \
+            raise NotImplementedError, "Using `expect { }.not_to change { }` " \
                                        "with the `to()` matcher is not supported."
           end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/change_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/change_spec.rb
@@ -519,7 +519,7 @@ RSpec.describe "expect { ... }.not_to change { }.to" do
   it 'is not supported' do
     expect {
       expect {}.not_to change {}.to(3)
-     }.to raise_error(
+    }.to raise_error(
       NotImplementedError,
       "Using a negated form of the `change` matcher with `to()` is not supported."
     )
@@ -528,10 +528,11 @@ RSpec.describe "expect { ... }.not_to change { }.to" do
   it 'is not supported when it comes after `from`' do
     expect {
       expect {}.not_to change {}.from(nil).to(3)
- }.to raise_error(
+    }.to raise_error(
       NotImplementedError,
       "Using a negated form of the `change` matcher with `to()` is not supported."
-    )  end
+    )
+  end
 end
 
 RSpec.describe "expect { ... }.not_to change { }.by" do

--- a/rspec-expectations/spec/rspec/matchers/built_in/change_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/change_spec.rb
@@ -519,21 +519,29 @@ RSpec.describe "expect { ... }.not_to change { }.to" do
   it 'is not supported' do
     expect {
       expect {}.not_to change {}.to(3)
-    }.to raise_error(NotImplementedError)
+     }.to raise_error(
+      NotImplementedError,
+      "Using a negated form of the `change` matcher with `to()` is not supported."
+    )
   end
 
   it 'is not supported when it comes after `from`' do
     expect {
       expect {}.not_to change {}.from(nil).to(3)
-    }.to raise_error(NotImplementedError)
-  end
+ }.to raise_error(
+      NotImplementedError,
+      "Using a negated form of the `change` matcher with `to()` is not supported."
+    )  end
 end
 
 RSpec.describe "expect { ... }.not_to change { }.by" do
   it 'is not supported' do
     expect {
       expect {}.not_to change {}.by(3)
-    }.to raise_error(NotImplementedError)
+    }.to raise_error(
+      NotImplementedError,
+      "Using a negated form of the `change` matcher with `by()` is not supported."
+    )
   end
 end
 
@@ -541,7 +549,10 @@ RSpec.describe "expect { ... }.not_to change { }.by_at_least" do
   it 'is not supported' do
     expect {
       expect {}.not_to change {}.by_at_least(3)
-    }.to raise_error(NotImplementedError)
+    }.to raise_error(
+      NotImplementedError,
+      "Using a negated form of the `change` matcher with `by_at_least()` is not supported."
+    )
   end
 end
 
@@ -549,7 +560,10 @@ RSpec.describe "expect { ... }.not_to change { }.by_at_most" do
   it 'is not supported' do
     expect {
       expect {}.not_to change {}.by_at_most(3)
-    }.to raise_error(NotImplementedError)
+    }.to raise_error(
+      NotImplementedError,
+      "Using a negated form of the `change` matcher with `by_at_most()` is not supported."
+    )
   end
 end
 


### PR DESCRIPTION
Fixes #90

update invalid matcher error for 'expect { }.not_to change { }.<matcher>' to be more descriptive

Error thrown:
| Before | After|
| ----- | -----|
| <img width="923" alt="image" src="https://github.com/user-attachments/assets/9dba34a8-7d39-4ef0-9ea2-870447c437eb" /> | <img width="934" alt="image" src="https://github.com/user-attachments/assets/b368a951-52ec-4364-8656-71acf152588c" />|

Very much a ruby noob, and ran into a similar issue as here:
https://github.com/rspec/rspec/issues/90
