### PR TITLE
[rspec-expectations] Fix message when matching array with non-array

### DIFF
--- a/rspec-expectations/lib/rspec/matchers/built_in/match.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/match.rb
@@ -35,11 +35,23 @@ module RSpec
           self
         end
 
+        # @api private
+        # @return [String]
+        def failure_message
+          if Array === expected && !(actual.respond_to?(:to_a) || actual.respond_to?(:to_ary))
+            return "expected a collection that can be converted to an array with " \
+                   "`#to_ary` or `#to_a`, but got #{actual_formatted}"
+          end
+
+          super
+        end
+
       private
 
         def match(expected, actual)
           return match_captures(expected, actual) if @expected_captures
           return true if values_match?(expected, actual)
+          return false if Array === expected
           return false unless can_safely_call_match?(expected, actual)
           actual.match(expected)
         end

--- a/rspec-expectations/lib/rspec/matchers/built_in/match.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/match.rb
@@ -51,13 +51,13 @@ module RSpec
         def match(expected, actual)
           return match_captures(expected, actual) if @expected_captures
           return true if values_match?(expected, actual)
-          return false if Array === expected
           return false unless can_safely_call_match?(expected, actual)
           actual.match(expected)
         end
 
         def can_safely_call_match?(expected, actual)
           return false unless actual.respond_to?(:match)
+          return false if Array === expected
 
           !(RSpec::Matchers.is_a_matcher?(expected) &&
             (String === actual || Regexp === actual))

--- a/rspec-expectations/spec/rspec/matchers/built_in/match_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/match_spec.rb
@@ -95,6 +95,12 @@ RSpec.describe "expect(...).to match(expected)" do
       expect(description).to eq("match [(a string matching /foo/), (a value within 0.2 of 1)]")
     end
   end
+
+  it "fails when target type (String) does not match expected (Array)" do
+    expect {
+      expect("string").to match(["c", "a", "b"])
+    }.to fail_with('expected a collection that can be converted to an array with `#to_ary` or `#to_a`, but got "string"')
+  end
 end
 
 RSpec.describe "expect(...).not_to match(expected)" do
@@ -134,5 +140,9 @@ RSpec.describe "expect(...).not_to match(expected)" do
         expect(["fod", 1.1]).not_to match([a_string_matching(/fod/), a_value_within(0.2).of(1)])
       }.to fail_with('expected ["fod", 1.1] not to match [(a string matching /fod/), (a value within 0.2 of 1)]')
     end
+  end
+
+  it "passes when target type (String) does not match expected (Array)" do
+    expect("string").not_to match(["c", "a", "b"])
   end
 end


### PR DESCRIPTION
#### Description

Update the failure message of the `match` matcher when an array is expected and the actual value is not an array.

#### Why

Currently

```ruby
  expect('string').to match([1,2,3])
```

results in an exception at `actual.match(expected)` in `RSpec::Matchers::BuiltIn::Match#match`. This is not caught correctly by `can_safely_call_match?`.

#### How

`RSpec::Matchers::BuiltIn::Match#match` returns `false` when `values_match?` fails and `expected` is an array. A `failure_message` method is added to catch this case and return a suitable message.

I am tipping my toe in the water with something simple to try to understand the internals of RSpec. I had originally started looking at #143 (which I will continue to look at) and found this in the process, which appears to be a bug.