### PR TITLE
Fix tests for newer version of diff-lcs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,7 +57,7 @@ end
 if ENV['DIFF_LCS_VERSION']
   gem 'diff-lcs', ENV['DIFF_LCS_VERSION']
 else
-  gem 'diff-lcs', '~> 1.4', '>= 1.4.3'
+  gem 'diff-lcs', '~> 1.6'
 end
 
 if RUBY_VERSION < '2.2.0' && !!(RbConfig::CONFIG['host_os'] =~ /cygwin|mswin|mingw|bccwin|wince|emx/)

--- a/rspec-mocks/spec/rspec/mocks/diffing_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/diffing_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
           d.foo("this other string")
         }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  " \
                        "expected: (\"some string\\nline2\")\n       got: (\"this other string\")\n" \
-                       "Diff:\n@@ -1,3 +1,2 @@\n-some string\n-line2\n+this other string\n")
+                       "Diff:\n@@ -1,2 +1 @@\n-some string\n-line2\n+this other string\n")
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe "Diffs printed when arguments don't match" do
           d.foo("this other string")
         }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  " \
                        "expected: (\"some string\\nline2\", \"some other string\")\n       " \
-                       "got: (\"this other string\")\nDiff:\n@@ -1,3 +1,2 @@\n-some string\\nline2\n-some other string\n+this other string\n")
+                       "got: (\"this other string\")\nDiff:\n@@ -1,2 +1 @@\n-some string\\nline2\n-some other string\n+this other string\n")
       end
     end
 


### PR DESCRIPTION
Version 1.6 of the diff-lcs gem slightly alters the output resulting in two tests failing. The tests have been updated and the version of diff-lcs is pinned to '-> 1.6'.