### PR TITLE
Fix the build for diff-lcs errors

### DIFF
--- a/common_rubocop_config.yml
+++ b/common_rubocop_config.yml
@@ -117,6 +117,10 @@ Lint/NestedMethodDefinition:
 Lint/RescueException:
   Enabled: true
 
+# A new cop introduced but not yet fixed... please fix me.
+Lint/UselessConstantScoping:
+  Enabled: false
+
 # Warns when the class is excessively long.
 Metrics/ClassLength:
   Max: 100

--- a/rspec-expectations/features/custom_matchers/define_diffable_matcher.feature
+++ b/rspec-expectations/features/custom_matchers/define_diffable_matcher.feature
@@ -2,8 +2,33 @@ Feature: Defining a diffable matcher
 
   When a matcher is defined as diffable, the output will include a diff of the submitted objects when the objects are more than simple primitives.
 
-  @skip-when-diff-lcs-1.3
-  Scenario: Define a diffable matcher (with diff-lcs 1.4)
+  @skip-when-diff-lcs-1.3 @skip-when-diff-lcs-1.4
+  Scenario: Define a diffable matcher (with diff-lcs 1.6)
+    Given a file named "diffable_matcher_spec.rb" with:
+      """ruby
+      RSpec::Matchers.define :be_just_like do |expected|
+        match do |actual|
+          actual == expected
+        end
+
+        diffable
+      end
+
+      RSpec.describe "two\nlines" do
+        it { is_expected.to be_just_like("three\nlines") }
+      end
+      """
+    When I run `rspec ./diffable_matcher_spec.rb`
+    Then it should fail with:
+      """
+             Diff:
+             @@ -1,2 +1,2 @@
+             -three
+             +two
+      """
+
+  @skip-when-diff-lcs-1.3 @skip-when-diff-lcs-1.6
+  Scenario: Define a diffable matcher (with diff-lcs 1.4 - 1.5)
     Given a file named "diffable_matcher_spec.rb" with:
       """ruby
       RSpec::Matchers.define :be_just_like do |expected|
@@ -27,7 +52,7 @@ Feature: Defining a diffable matcher
              +two
       """
 
-  @skip-when-diff-lcs-1.4
+  @skip-when-diff-lcs-1.4 @skip-when-diff-lcs-1.6
   Scenario: Define a diffable matcher (with diff-lcs 1.3)
     Given a file named "diffable_matcher_spec.rb" with:
       """ruby
@@ -53,8 +78,54 @@ Feature: Defining a diffable matcher
               lines
       """
 
-  @skip-when-diff-lcs-1.3 @skip-when-diff-lcs-1.4.3
-  Scenario: Redefine actual (with diff-lcs 1.4.4)
+  @skip-when-diff-lcs-1.3 @skip-when-diff-lcs-1.4
+  Scenario: Redefine actual (with diff-lcs 1.6)
+
+    Sometimes is necessary to overwrite actual to make diffing work, e.g. if `actual` is a name of a file you want to read from. For this to work you need to overwrite `@actual` in your matcher.
+
+    Given a file named "redefine_actual_matcher_spec.rb" with:
+      """ruby
+      RSpec::Matchers.define :have_content do |expected|
+        match do |actual|
+          @actual = File.read(actual).chomp
+
+          values_match? expected, @actual
+        end
+
+        diffable
+      end
+
+      RSpec.describe 'Compare files' do
+        context 'when content is equal' do
+          it { expect('data.txt').to have_content 'Data' }
+        end
+
+        context 'when files are different' do
+          it { expect('data.txt').to have_content "No\nData\nhere" }
+        end
+      end
+      """
+    And a file named "data.txt" with:
+    """
+    Data
+    """
+    When I run `rspec ./redefine_actual_matcher_spec.rb --format documentation`
+    Then the exit status should not be 0
+    And the output should contain:
+    """
+    2 examples, 1 failure
+    """
+    And the output should contain:
+    """
+           @@ -1,3 +1 @@
+           -No
+            Data
+           -here
+    """
+
+
+  @skip-when-diff-lcs-1.3 @skip-when-diff-lcs-1.4.3 @skip-when-diff-lcs-1.6
+  Scenario: Redefine actual (with diff-lcs 1.4.4 - diff-lcs-1.5)
 
     Sometimes is necessary to overwrite actual to make diffing work, e.g. if `actual` is a name of a file you want to read from. For this to work you need to overwrite `@actual` in your matcher.
 
@@ -98,7 +169,7 @@ Feature: Defining a diffable matcher
            -here
     """
 
-  @skip-when-diff-lcs-1.4
+  @skip-when-diff-lcs-1.4 @skip-when-diff-lcs-1.6
   Scenario: Redefine actual (with diff-lcs 1.3)
     Given a file named "redefine_actual_matcher_spec.rb" with:
       """ruby

--- a/rspec-expectations/features/diffing.feature
+++ b/rspec-expectations/features/diffing.feature
@@ -2,6 +2,7 @@ Feature: Diffing
 
   When appropriate, failure messages will automatically include a diff.
 
+  @skip-when-diff-lcs-1.3 @skip-when-diff-lcs-1.4
   Scenario: Diff for a multiline string
     Given a file named "example_spec.rb" with:
       """ruby
@@ -25,14 +26,14 @@ Feature: Diffing
     Then the output should contain:
       """
              Diff:
-             @@ -1,4 +1,4 @@
+             @@ -1,3 +1,3 @@
               this is the
              -  expected
              +  actual
                   string
       """
 
-  @skip-when-diff-lcs-1.3
+  @skip-when-diff-lcs-1.3 @skip-when-diff-lcs-1.6
   Scenario: Diff for a multiline string and a regexp on diff-lcs 1.4
     Given a file named "example_spec.rb" with:
       """ruby
@@ -59,7 +60,7 @@ Feature: Diffing
              +    string
       """
 
-  @skip-when-diff-lcs-1.4
+  @skip-when-diff-lcs-1.4 @skip-when-diff-lcs-1.6
   Scenario: Diff for a multiline string and a regexp on diff-lcs 1.3
     Given a file named "example_spec.rb" with:
       """ruby

--- a/rspec-expectations/features/support/diff_lcs_versions.rb
+++ b/rspec-expectations/features/support/diff_lcs_versions.rb
@@ -2,8 +2,16 @@
 
 require 'diff-lcs'
 
+Around "@skip-when-diff-lcs-1.6" do |scenario, block|
+  if Diff::LCS::VERSION >= '1.6'
+    skip_this_scenario "Skipping scenario #{scenario.name} on `diff-lcs` v#{Diff::LCS::VERSION}"
+  else
+    block.call
+  end
+end
+
 Around "@skip-when-diff-lcs-1.4" do |scenario, block|
-  if Diff::LCS::VERSION >= '1.4'
+  if Diff::LCS::VERSION >= '1.4' && Diff::LCS::VERSION <= '1.6'
     skip_this_scenario "Skipping scenario #{scenario.name} on `diff-lcs` v#{Diff::LCS::VERSION}"
   else
     block.call

--- a/rspec-expectations/spec/rspec/matchers/built_in/change_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/change_spec.rb
@@ -248,7 +248,6 @@ RSpec.describe "expect { ... }.to change ..." do
   context "with an arbitrary enumerable" do
     before(:example) do
       @instance = SomethingExpected.new
-      # rubocop:disable Layout/EmptyLinesAroundArguments This is a RuboCop bug, and it's fixed in 0.65.0
       @instance.some_value = Class.new do
         include Enumerable
 
@@ -274,7 +273,6 @@ RSpec.describe "expect { ... }.to change ..." do
           elements.hash
         end
       end.new
-      # rubocop:enable Layout/EmptyLinesAroundArguments
     end
 
     it "passes when actual is modified by the block" do

--- a/rspec-expectations/spec/rspec/matchers/built_in/include_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/include_spec.rb
@@ -111,7 +111,7 @@ RSpec.describe "#include matcher" do
       failure_string = if use_string_keys_in_failure_message?
                          dedent(<<-END)
                            |Diff:
-                           |@@ -1,3 +1,3 @@
+                           |@@ #{one_line_header(3)} @@
                            |-:bar => 3,
                            |-:foo => 1,
                            |+"bar" => 2,
@@ -139,7 +139,7 @@ RSpec.describe "#include matcher" do
       failure_string = if use_string_keys_in_failure_message?
                          dedent(<<-END)
                            |Diff:
-                           |@@ -1,3 +1,3 @@
+                           |@@ #{one_line_header(3)} @@
                            |-(match /FOO/i) => 1,
                            |-:bar => 3,
                            |+"bar" => 2,
@@ -148,7 +148,7 @@ RSpec.describe "#include matcher" do
                        else
                          dedent(<<-END)
                            |Diff:
-                           |@@ -1,3 +1,3 @@
+                           |@@ #{one_line_header(3)} @@
                            |-(match /FOO/i) => 1,
                            |-:bar => 3,
                            |+:bar => 2,

--- a/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
@@ -517,8 +517,10 @@ module RSpec::Matchers::DSL
 
       if Diff::LCS::VERSION.to_f < 1.4
         expected_diff = "Diff:\n@@ -1,3 +1,3 @@\n-line1\n+LINE1\nline2\n"
-      else
+      elsif Diff::LCS::VERSION.to_f < 1.6
         expected_diff = "Diff:\n@@ -1 +1 @@\n-line1\n+LINE1\n"
+      else
+        expected_diff = "Diff:\n@@ -1,2 +1,2 @@\n-line1\n+LINE1\nline2\n"
       end
 
       expect(diff).to eq expected_diff

--- a/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/dsl_spec.rb
@@ -1337,7 +1337,7 @@ module RSpec::Matchers::DSL
       it "raises NoMethodError for methods not in the running_example" do |example|
         RSpec::Matchers.define(:__raise_no_method_error) do
           match do |_actual|
-            self.a_method_not_in_the_example == "method defined in the example" # rubocop:disable Style/RedundantSelf RuboCop bug, should disappear on version update
+            self.a_method_not_in_the_example == "method defined in the example" # rubocop:disable Style/RedundantSelf -- RuboCop bug, should disappear on version update
           end
         end
 

--- a/rspec-mocks/spec/rspec/mocks/diffing_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/diffing_spec.rb
@@ -50,7 +50,8 @@ RSpec.describe "Diffs printed when arguments don't match" do
           d.foo("this other string")
         }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  " \
                        "expected: (\"some string\\nline2\")\n       got: (\"this other string\")\n" \
-                       "Diff:\n@@ -1,3 +1,2 @@\n-some string\n-line2\n+this other string\n")
+                       "Diff:\n@@ #{::Diff::LCS::VERSION.to_f > 1.5 ? "-1,2 +1" : "-1,3 +1,2"} @@\n" \
+                       "-some string\n-line2\n+this other string\n")
       end
     end
 
@@ -61,7 +62,9 @@ RSpec.describe "Diffs printed when arguments don't match" do
           d.foo("this other string")
         }.to fail_with("#<Double \"double\"> received :foo with unexpected arguments\n  " \
                        "expected: (\"some string\\nline2\", \"some other string\")\n       " \
-                       "got: (\"this other string\")\nDiff:\n@@ -1,3 +1,2 @@\n-some string\\nline2\n-some other string\n+this other string\n")
+                       "got: (\"this other string\")\n" \
+                       "Diff:\n@@ #{::Diff::LCS::VERSION.to_f > 1.5 ? "-1,2 +1" : "-1,3 +1,2"} @@\n" \
+                       "-some string\\nline2\n-some other string\n+this other string\n")
       end
     end
 

--- a/rspec-support/lib/rspec/support/spec/diff_helpers.rb
+++ b/rspec-support/lib/rspec/support/spec/diff_helpers.rb
@@ -12,13 +12,25 @@ module RSpec
           def one_line_header(line_number=2)
             "-1,#{line_number} +1,#{line_number}"
           end
-        else
+        elsif ::Diff::LCS::VERSION.to_f < 1.6
           def one_line_header(_=2)
             "-1 +1"
           end
+        else
+          def one_line_header(line_number=2)
+            if line_number - 1 == 1
+              "-1 +1"
+            else
+              "-1,#{line_number - 1} +1,#{line_number - 1}"
+            end
+          end
         end
 
-        if Diff::LCS::VERSION.to_f < 1.4 || Diff::LCS::VERSION >= "1.4.4"
+        if ::Diff::LCS::VERSION.to_f > 1.5
+          def removing_two_line_header
+            "-1,2 +0,0"
+          end
+        elsif Diff::LCS::VERSION.to_f < 1.4 || Diff::LCS::VERSION >= "1.4.4"
           def removing_two_line_header
             "-1,3 +1"
           end

--- a/rspec-support/lib/rspec/support/spec/shell_out.rb
+++ b/rspec-support/lib/rspec/support/spec/shell_out.rb
@@ -82,6 +82,8 @@ module RSpec
           # Ignore some JRuby errors for gems
           %r{jruby/\d\.\d(\.\d)?/gems/aruba},
           %r{jruby/\d\.\d(\.\d)?/gems/ffi},
+          # Ignore errors from asdf
+          %r{\.asdf/installs},
         ]
 
       def strip_known_warnings(input)

--- a/rspec-support/spec/rspec/support/differ_spec.rb
+++ b/rspec-support/spec/rspec/support/differ_spec.rb
@@ -18,7 +18,7 @@ module RSpec
           actual   = "foo\nbar\nzap\nthis\nis\nsoo\nvery\nvery\nequal\ninsert\na\nline\n"
 
           if Diff::LCS::VERSION.to_f < 1.4 || Diff::LCS::VERSION >= "1.4.4"
-            expected_diff = dedent(<<-'EOD')
+            expected_diff = dedent(<<-"EOD")
               |
               |
               |@@ -1,6 +1,6 @@
@@ -29,7 +29,7 @@ module RSpec
               | this
               | is
               | soo
-              |@@ -9,6 +9,5 @@
+              |@@ #{::Diff::LCS::VERSION.to_f > 1.5 ? "-9,5 +9,4" : "-9,6 +9,5"} @@
               | equal
               | insert
               | a
@@ -67,7 +67,7 @@ module RSpec
           actual   = "foo\nbar\nzap\nthis\nis\nsoo\nvery\nvery\nequal\ninsert\na\nline\n"
 
           if Diff::LCS::VERSION.to_f < 1.4 || Diff::LCS::VERSION >= "1.4.4"
-            expected_diff = dedent(<<-'EOS')
+            expected_diff = dedent(<<-"EOS")
               |
               |
               |@@ -1,6 +1,6 @@
@@ -78,7 +78,7 @@ module RSpec
               | this
               | is
               | soo
-              |@@ -9,6 +9,5 @@
+              |@@ #{::Diff::LCS::VERSION.to_f > 1.5 ? "-9,5 +9,4" : "-9,6 +9,5"} @@
               | equal
               | insert
               | a
@@ -199,9 +199,9 @@ module RSpec
           expected = animal_class.new "bob", "giraffe"
           actual   = animal_class.new "bob", "tortoise"
 
-          expected_diff = dedent(<<-'EOD')
+          expected_diff = dedent(<<-"EOD")
             |
-            |@@ -1,5 +1,5 @@
+            |@@ #{one_line_header(5)} @@
             | <Animal
             |   name=bob,
             |-  species=tortoise
@@ -218,10 +218,10 @@ module RSpec
           expected = [ :foo, 'bar', :baz, 'quux', :metasyntactic, 'variable', :delta, 'charlie', :width, 'quite wide' ]
           actual   = [ :foo, 'bar', :baz, 'quux', :metasyntactic, 'variable', :delta, 'tango'  , :width, 'very wide'  ]
 
-          expected_diff = dedent(<<-'EOD')
+          expected_diff = dedent(<<-"EOD")
             |
             |
-            |@@ -5,7 +5,7 @@
+            |@@ #{::Diff::LCS::VERSION.to_f > 1.5 ? "-5,6 +5,6" : "-5,7 +5,7"} @@
             |  :metasyntactic,
             |  "variable",
             |  :delta,
@@ -426,9 +426,9 @@ module RSpec
           expected = "this is:\n  one string"
           actual   = "this is:\n  another string"
 
-          expected_diff = dedent(<<-'EOD')
+          expected_diff = dedent(<<-"EOD")
             |
-            |@@ -1,3 +1,3 @@
+            |@@ #{one_line_header(3)} @@
             | this is:
             |-  another string
             |+  one string
@@ -566,9 +566,9 @@ module RSpec
             actual = { :fixed => "fixed", :trigger => "trigger", :anything_key => "bcdd0399-1cfe-4de1-a481-ca6b17d41ed8" }
             expected = { :fixed => "fixed", :trigger => "wrong", :anything_key => anything }
             diff = differ.diff(actual, expected)
-            expected_diff = dedent(<<-'EOD')
+            expected_diff = dedent(<<-"EOD")
               |
-              |@@ -1,4 +1,4 @@
+              |@@ #{one_line_header(4)} @@
               | :anything_key => anything,
               | :fixed => "fixed",
               |-:trigger => "wrong",

--- a/script/run_rspec_monorepo
+++ b/script/run_rspec_monorepo
@@ -1,0 +1,18 @@
+set -e
+
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+SCRIPT_DIR="${ROOT_DIR}/script"
+source $SCRIPT_DIR/functions.sh
+
+function run_repos_one_by_one {
+  echo "Running each repo file, one-by-one..."
+
+  for folder in `ls -d rspec-*`; do
+    echo "Running $folder"
+    pushd $folder
+      $ROOT_DIR/bin/rspec --format progress
+    popd
+  done
+}
+
+run_repos_one_by_one


### PR DESCRIPTION
`diff-lcs` 1.6 changes the format of the diffs, so fix that, whilst we're here I've added a script to run all the monorepo suites from the parent and ignored some local warnings which are a false positive.