### PR TITLE
[rspec-core] Ensure $SHELL is correct before tests

### DIFF
--- a/rspec-core/spec/integration/location_rerun_spec.rb
+++ b/rspec-core/spec/integration/location_rerun_spec.rb
@@ -63,6 +63,8 @@ RSpec.describe 'Failed spec rerun location' do
   end
 
   context "when config.force_line_number_for_spec_rerun is set to false" do
+    around { |ex| with_env_vars('SHELL' => '/usr/local/bin/zsh', &ex) }
+ 
     it 'prints the example id of the failed assertion' do
       run_command("#{Dir.pwd}/tmp/aruba/local_shared_examples_spec.rb")
 

--- a/rspec-core/spec/integration/location_rerun_spec.rb
+++ b/rspec-core/spec/integration/location_rerun_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'Failed spec rerun location' do
 
   context "when config.force_line_number_for_spec_rerun is set to false" do
     around { |ex| with_env_vars('SHELL' => '/usr/local/bin/zsh', &ex) }
- 
+
     it 'prints the example id of the failed assertion' do
       run_command("#{Dir.pwd}/tmp/aruba/local_shared_examples_spec.rb")
 


### PR DESCRIPTION
Fixes #190 

The formatting of the example rerun command depends on $SHELL so these tests can fail depending on the user's settings unless the variable is stubbed.