### PR TITLE
Show the exception detailed message when available

### DIFF
--- a/rspec-core/lib/rspec/core/formatters/exception_presenter.rb
+++ b/rspec-core/lib/rspec/core/formatters/exception_presenter.rb
@@ -184,7 +184,13 @@ module RSpec
 
         # rubocop:disable Lint/RescueException
         # :nocov:
-        if SyntaxError.instance_methods.include?(:detailed_message)
+        if RSpec::Support::RubyFeatures.supports_exception_detailed_message?
+          def exception_message_string(exception)
+            exception.detailed_message(:highlight => false).sub(" (#{exception.class})", '')
+          rescue Exception => other
+            "A #{exception.class} for which `exception.detailed_message.to_s` raises #{other.class}."
+          end
+        elsif SyntaxError.instance_methods.include?(:detailed_message)
           def exception_message_string(exception)
             case exception
             when SyntaxError then exception.detailed_message.to_s
@@ -285,7 +291,7 @@ module RSpec
           end
         end
 
-        if  String.method_defined?(:encoding)
+        if String.method_defined?(:encoding)
           def encoded_description(description)
             return if description.nil?
             encoded_string(description)

--- a/rspec-support/lib/rspec/support/ruby_features.rb
+++ b/rspec-support/lib/rspec/support/ruby_features.rb
@@ -96,6 +96,16 @@ module RSpec
         end
       end
 
+      if Exception.method_defined?(:detailed_message)
+        def supports_exception_detailed_message?
+          true
+        end
+      else
+        def supports_exception_detailed_message?
+          false
+        end
+      end
+
       if RUBY_VERSION.to_f >= 3.2
         def supports_syntax_suggest?
           true

--- a/rspec-support/spec/rspec/support/ruby_features_spec.rb
+++ b/rspec-support/spec/rspec/support/ruby_features_spec.rb
@@ -105,6 +105,10 @@ module RSpec
         expect(RubyFeatures.supports_syntax_suggest?).to eq(RUBY_VERSION.to_f >= 3.2)
       end
 
+      specify "#supports_exception_detailed_message?" do
+        expect(RubyFeatures.supports_exception_detailed_message?).to eq(Exception.method_defined?(:detailed_message))
+      end
+
       specify "#supports_taint?" do
         RubyFeatures.supports_taint?
       end


### PR DESCRIPTION
Ruby 3.2 introduced an `Exception#detailed_message` method to allow gems such as `did_you_mean` and `error_highlight` to enrich the exception message.  `Exception#detailed_message`, by default, shows the error message, the exception class name, and optional highlighting using ANSI escape sequences. Previously, those gems modified `Exception#message`, which led to broken test suites.

The problem with this change is that, as we only show `Exception#message`, we stopped showing valuable information, such as typo corrections and error locations.

This commit reintroduces this feedback by using the `Exception#detailed_message` whenever available.

After this change, exceptions with detailed messages will be shown as:

```
     NoMethodError:
       undefined method `upcsae' for an instance of String

           "meow".upcsae
                 ^^^^^^^
       Did you mean?  upcase
```

Closes #191