### PR TITLE
Fix rubocop build

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   Exclude:
     - bin/*
     - bundle/**/*
+    - rspec-*/tmp/**/*
     - rspec-support/lib/rspec/support/mutex.rb
   NewCops:
     enable

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,7 @@ AllCops:
   Exclude:
     - bin/*
     - bundle/**/*
+    - rspec-support/lib/rspec/support/mutex.rb
   NewCops:
     enable
   SuggestExtensions: false

--- a/rspec-mocks/lib/rspec/mocks/test_double.rb
+++ b/rspec-mocks/lib/rspec/mocks/test_double.rb
@@ -49,7 +49,9 @@ module RSpec
 
       # @private
       def respond_to?(message, incl_private=false)
-        __mock_proxy.null_object? ? true : super
+        return true if __mock_proxy.null_object?
+
+        super
       end
 
       # @private


### PR DESCRIPTION
Rework a method to keep the intent but avoid a rule violation, and ignore a legacy file.