### PR TITLE
Remove duplicate `exist` listing from nav

### DIFF
--- a/rspec-expectations/features/.nav
+++ b/rspec-expectations/features/.nav
@@ -6,7 +6,6 @@
   - all.feature
   - be.feature
   - be_within.feature
-  - exist.feature
   - change.feature
   - contain_exactly.feature
   - cover.feature


### PR DESCRIPTION
[rspec.info](https://rspec.info/features/3-13/rspec-expectations/built-in-matchers/) seems to show two links for the `exist` matcher feature. This change removes the first listing and keeps the one that maintains alphabetical sort.

Seems to have been introduced with reordering in dfe834a so I assume this was unintentional.

![Screenshot 2025-03-08 at 21-05-12 ](https://github.com/user-attachments/assets/65b25d5b-b73c-4c73-8176-bb70e38f3653)
