### PR TITLE
Include webrick gem for ruby > 3, necessary for yard docs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ end
 group :documentation do
   gem 'github-markup', :platform => :mri
   gem 'redcarpet', :platform => :mri
+  # Webrick extracted from Ruby 3.0.0, required by Yard
+  gem 'webrick', '~> 1.9.1', :require => false if RUBY_VERSION >= '3.0.0'
   gem 'yard', '~> 0.9.24', :require => false
 end
 


### PR DESCRIPTION
When running `bundle exec yard server --reload` before:
```
.../3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require': cannot load such file -- webrick (LoadError)
```

Webrick is [no longer bundled as of Ruby 3](https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/#:~:text=sdbm-,webrick,-net%2Dtelnet), and yard needs it (or another server). 