### PR TITLE
Updates for on potential false positives

### DIFF
--- a/rspec-expectations/lib/rspec/expectations/configuration.rb
+++ b/rspec-expectations/lib/rspec/expectations/configuration.rb
@@ -181,11 +181,20 @@ module RSpec
           # no-op, handler is something else
         end
       end
-      #
-      # Configures what RSpec will do about matcher use which will
-      # potentially cause false positives in tests.
-      #
-      # @param [Symbol] behavior can be set to :warn, :raise or :nothing
+
+      # Configuration for RSpec behaviour with matcher use that might result in false positives.
+      # @overload on_potential_false_positives
+      #   Indicates how RSpec handles potential false positives in tests (default: `:warn`;
+      #   options: `:warn`, `:raise`, `:nothing`)
+      #   @return [Symbol] the behavior setting
+      # @overload on_potential_false_positives=(value)
+      #   Configures what RSpec will do about matcher use which would potentially
+      #   cause false positives in tests. Defaults to `:warn` since this is generally
+      #   the desired behavior.
+      #   @param [Symbol] behavior can be set to `:warn`, `:raise` or `:nothing`
+      #   @return [Symbol] the behavior setting
+      attr_reader :on_potential_false_positives
+
       def on_potential_false_positives=(behavior)
         unless FALSE_POSITIVE_BEHAVIOURS.key?(behavior)
           raise ArgumentError, "Supported values are: #{FALSE_POSITIVE_BEHAVIOURS.keys}"
@@ -206,11 +215,6 @@ module RSpec
       def strict_predicate_matchers?
         @strict_predicate_matchers
       end
-
-      # Indicates what RSpec will do about matcher use which will
-      # potentially cause false positives in tests, generally you want to
-      # avoid such scenarios so this defaults to `true`.
-      attr_reader :on_potential_false_positives
 
       # Indicates whether RSpec will warn about matcher use which will
       # potentially cause false positives in tests, generally you want to

--- a/rspec-expectations/lib/rspec/expectations/configuration.rb
+++ b/rspec-expectations/lib/rspec/expectations/configuration.rb
@@ -187,15 +187,13 @@ module RSpec
         end
       end
 
-      # Configuration for RSpec behaviour with matcher use that might result in false positives.
+      # Configures what RSpec will do about matcher use which would potentially cause
+      # false positives in tests. Defaults to `:warn` since this is generally the desired behavior,
+      # but can also be set to `:raise` or `:nothing`.
+      #
       # @overload on_potential_false_positives
-      #   Indicates how RSpec handles potential false positives in tests (default: `:warn`;
-      #   options: `:warn`, `:raise`, `:nothing`)
       #   @return [Symbol] the behavior setting
       # @overload on_potential_false_positives=(value)
-      #   Configures what RSpec will do about matcher use which would potentially
-      #   cause false positives in tests. Defaults to `:warn` since this is generally
-      #   the desired behavior.
       #   @param [Symbol] behavior can be set to `:warn`, `:raise` or `:nothing`
       #   @return [Symbol] the behavior setting
       attr_reader :on_potential_false_positives

--- a/rspec-expectations/lib/rspec/expectations/configuration.rb
+++ b/rspec-expectations/lib/rspec/expectations/configuration.rb
@@ -4,6 +4,8 @@ RSpec::Support.require_rspec_expectations "syntax"
 
 module RSpec
   module Expectations
+    # rubocop:disable Metrics/ClassLength
+
     # Provides configuration options for rspec-expectations.
     # If you are using rspec-core, you can access this via a
     # block passed to `RSpec::Core::Configuration#expect_with`.
@@ -252,5 +254,7 @@ module RSpec
 
     # set default syntax
     configuration.reset_syntaxes_to_default
+
+    # rubocop:enable Metrics/ClassLength
   end
 end

--- a/rspec-expectations/lib/rspec/expectations/configuration.rb
+++ b/rspec-expectations/lib/rspec/expectations/configuration.rb
@@ -172,7 +172,12 @@ module RSpec
       # potentially cause false positives in tests.
       #
       # @param [Boolean] boolean
+      # @deprecated Use {#on_potential_false_positives=} which supports :warn, :raise, and :nothing behaviors
       def warn_about_potential_false_positives=(boolean)
+        RSpec.deprecate(
+          "warn_about_potential_false_positives=",
+          :replacement => "`on_potential_false_positives=` which supports :warn, :raise, and :nothing behaviors"
+        )
         if boolean
           self.on_potential_false_positives = :warn
         elsif warn_about_potential_false_positives?
@@ -219,7 +224,12 @@ module RSpec
       # Indicates whether RSpec will warn about matcher use which will
       # potentially cause false positives in tests, generally you want to
       # avoid such scenarios so this defaults to `true`.
+      # @deprecated Use {#on_potential_false_positives} which supports :warn, :raise, and :nothing behaviors
       def warn_about_potential_false_positives?
+        RSpec.deprecate(
+          "warn_about_potential_false_positives?",
+          :replacement => "`on_potential_false_positives` which supports :warn, :raise, and :nothing behaviors"
+        )
         on_potential_false_positives == :warn
       end
 

--- a/rspec-expectations/lib/rspec/expectations/configuration.rb
+++ b/rspec-expectations/lib/rspec/expectations/configuration.rb
@@ -208,12 +208,19 @@ module RSpec
       # Configures RSpec to check predicate matchers to `be(true)` / `be(false)` (strict),
       # or `be_truthy` / `be_falsey` (not strict).
       # Historically, the default was `false`, but `true` is recommended.
-      def strict_predicate_matchers=(flag)
-        raise ArgumentError, "Pass `true` or `false`" unless flag == true || flag == false
-        @strict_predicate_matchers = flag
-      end
-
+      #
+      # @overload strict_predicate_matchers
+      #   @return [Boolean]
+      # @overload strict_predicate_matchers?
+      #   @return [Boolean]
+      # @overload strict_predicate_matchers=(value)
+      #   @param [Boolean] value
       attr_reader :strict_predicate_matchers
+
+      def strict_predicate_matchers=(value)
+        raise ArgumentError, "Pass `true` or `false`" unless value == true || value == false
+        @strict_predicate_matchers = value
+      end
 
       def strict_predicate_matchers?
         @strict_predicate_matchers

--- a/rspec-expectations/spec/rspec/expectations/configuration_spec.rb
+++ b/rspec-expectations/spec/rspec/expectations/configuration_spec.rb
@@ -112,19 +112,46 @@ module RSpec
       end
 
       describe "#warn_about_potential_false_positives?" do
-        it "is true by default" do
+        it "is deprecated" do
+          expect(RSpec).to receive(:deprecate).with(
+            "warn_about_potential_false_positives?",
+            :replacement => "`on_potential_false_positives` which supports :warn, :raise, and :nothing behaviors"
+          )
+          config.warn_about_potential_false_positives?
+        end
+
+        it "returns true when on_potential_false_positives is :warn" do
+          config.on_potential_false_positives = :warn
+          expect(RSpec).to receive(:deprecate)
           expect(config.warn_about_potential_false_positives?).to be true
         end
 
-        it "can be set to false" do
-          config.warn_about_potential_false_positives = false
+        it "returns false when on_potential_false_positives is not :warn" do
+          config.on_potential_false_positives = :nothing
+          expect(RSpec).to receive(:deprecate)
           expect(config.warn_about_potential_false_positives?).to be false
         end
+      end
 
-        it "can be set back to true" do
-          config.warn_about_potential_false_positives = false
+      describe "#warn_about_potential_false_positives=" do
+        it "is deprecated" do
+          expect(RSpec).to receive(:deprecate).with(
+            "warn_about_potential_false_positives=",
+            :replacement => "`on_potential_false_positives=` which supports :warn, :raise, and :nothing behaviors"
+          ).at_least(:once)
           config.warn_about_potential_false_positives = true
-          expect(config.warn_about_potential_false_positives?).to be true
+        end
+
+        it "sets on_potential_false_positives to :warn when true" do
+          allow(RSpec).to receive(:deprecate)
+          config.warn_about_potential_false_positives = true
+          expect(config.on_potential_false_positives).to eq(:warn)
+        end
+
+        it "sets on_potential_false_positives to :nothing when false" do
+          allow(RSpec).to receive(:deprecate)
+          config.warn_about_potential_false_positives = false
+          expect(config.on_potential_false_positives).to eq(:nothing)
         end
       end
 


### PR DESCRIPTION
(Replace https://github.com/rspec/rspec/pull/198 - adds in deprecations)

1.
Updating the docs for `on_potential_false_positives`.

Before: the setter method does not show up in the docs due to how Yard handles attribute docs, and the attr_reader docs imply a truthy value.

After: More visibility into the values being used.

![Screenshot 2025-03-11 at 9 11 32 AM](https://github.com/user-attachments/assets/4c64db1d-8aa7-41dc-8480-0679e93892ba)

2.
Deprecates `warn_about_potential_false_positives` and `warn_about_potential_false_positives?` to enable removing them in a later version to simplify the codebase a bit.