### PR TITLE
[rspec-core] Improve YARDocs for Core::ExampleGroup

### DIFF
--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -213,6 +213,7 @@ module RSpec
       #     @param metadata [Array<Symbol>, Hash] Metadata for the group.
       #       Symbols will be transformed into hash entries with `true` values.
       #     @param example_group_definition [Block] The definition of the example group.
+      #   @return [RSpec::Core::ExampleGroup]
       #
       #   Generates a subclass of this example group which inherits
       #   everything except the examples themselves.
@@ -317,7 +318,7 @@ module RSpec
       #     @param name [String, Symbol] The name of the shared group to include.
       #     @param args [Array] Pass parameters to a shared example group
       #     @param block [Block] Additional context to pass to the shared group.
-      #     @return [void]
+      #     @return [RSpec::Core::ExampleGroup]
       #
       #   @see SharedExampleGroup
       def self.define_nested_shared_group_method(new_name, report_label="it should behave like")

--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -204,6 +204,7 @@ module RSpec
       # @private
       # @macro [attach] define_example_group_method
       #   @!scope class
+      #   @method $1
       #   @overload $1
       #   @overload $1(&example_group_definition)
       #     @param example_group_definition [Block] The definition of the example group.
@@ -312,6 +313,11 @@ module RSpec
       # @private
       # @macro [attach] define_nested_shared_group_method
       #   @!scope class
+      #   @method $1(name, *args, &block)
+      #     @param name [String, Symbol] The name of the shared group to include.
+      #     @param args [Array] Pass parameters to a shared example group
+      #     @param block [Block] Additional context to pass to the shared group.
+      #     @return [void]
       #
       #   @see SharedExampleGroup
       def self.define_nested_shared_group_method(new_name, report_label="it should behave like")


### PR DESCRIPTION
Hi,

I was looking to improve the documentation shown to Solargraph LSP via https://github.com/lekemula/solargraph-rspec with the help of YARDoc comments, but I noticed that some `ExampleGroup` methods were not present. Here, I fixed some of those:

* "Defining Example Groups" section methods missing
* "Including Shared Example Groups" section missing documentation for `it_behaves_like` and `it_should_behave_like`

How to test:

```
cd rspec-core
yard
yard server
# open http://0.0.0.0:8808/docs/RSpec/Core/ExampleGroup in your browser
```

<details><summary>Before</summary>
<p>

<img width="1510" alt="Screenshot 2025-03-17 at 21 02 49" src="https://github.com/user-attachments/assets/2af409f0-84ec-4609-81e5-bd1058f08be2" />

<img width="863" alt="Screenshot 2025-03-17 at 21 05 59" src="https://github.com/user-attachments/assets/8c21121a-3277-400e-a451-f7ffc15440eb" />


</p>
</details> 

<details><summary>After</summary>
<p>


<img width="1512" alt="Screenshot 2025-03-17 at 21 03 35" src="https://github.com/user-attachments/assets/0d89023f-9f60-46a0-817a-7ae5995b043b" />

<img width="812" alt="image" src="https://github.com/user-attachments/assets/f89e1e4d-0797-4ebc-89e3-e5d76c0f30dc" />


</p>
</details> 