### PR TITLE
Mute Style/ComparableBetween offence

### DIFF
--- a/rspec-expectations/features/support/diff_lcs_versions.rb
+++ b/rspec-expectations/features/support/diff_lcs_versions.rb
@@ -11,7 +11,7 @@ Around "@skip-when-diff-lcs-1.6" do |scenario, block|
 end
 
 Around "@skip-when-diff-lcs-1.4" do |scenario, block|
-  if Diff::LCS::VERSION >= '1.4' && Diff::LCS::VERSION <= '1.6'
+  if Diff::LCS::VERSION >= '1.4' && Diff::LCS::VERSION <= '1.6' # rubocop:disable Style/ComparableBetween
     skip_this_scenario "Skipping scenario #{scenario.name} on `diff-lcs` v#{Diff::LCS::VERSION}"
   else
     block.call

--- a/rspec-expectations/lib/rspec/matchers/built_in/count_expectation.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/count_expectation.rb
@@ -65,7 +65,7 @@ module RSpec
         else
           # :nocov:
           def cover?(count, number)
-            number >= count.first && number <= count.last
+            number >= count.first && number <= count.last # rubocop:disable Style/ComparableBetween
           end
           # :nocov:
         end


### PR DESCRIPTION
Broken e.g. [here](https://github.com/rspec/rspec/actions/runs/13877410125/job/38831433255?pr=199)
```
 rspec-expectations/features/support/diff_lcs_versions.rb:14:6: C: [Correctable] Style/ComparableBetween: Prefer Diff::LCS::VERSION.between?('1.4', '1.6') over logical comparison.
  if Diff::LCS::VERSION >= '1.4' && Diff::LCS::VERSION <= '1.6'
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
rspec-expectations/lib/rspec/expectations/configuration.rb:22:5: C: Metrics/ClassLength: Class has too many lines. [105/100]
    class Configuration ...
    ^^^^^^^^^^^^^^^^^^^
rspec-expectations/lib/rspec/matchers/built_in/count_expectation.rb:68:13: C: [Correctable] Style/ComparableBetween: Prefer number.between?(count.first, count.last) over logical comparison.
            number >= count.first && number <= count.last
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```