### PR TITLE
Add `detailed_message` detection to `RubyFeatures`

### DIFF
--- a/rspec-support/lib/rspec/support/ruby_features.rb
+++ b/rspec-support/lib/rspec/support/ruby_features.rb
@@ -96,6 +96,16 @@ module RSpec
         end
       end
 
+      if Exception.method_defined?(:detailed_message)
+        def supports_exception_detailed_message?
+          true
+        end
+      else
+        def supports_exception_detailed_message?
+          false
+        end
+      end
+
       if RUBY_VERSION.to_f >= 3.2
         def supports_syntax_suggest?
           true


### PR DESCRIPTION
Adds a feature detection method to check if the Ruby version supports `Exception#detailed_message`, which was introduced in Ruby 3.2.0. This will enable future code to use the `detailed_message` method when available,  falling back to `message.to_s` on older Ruby versions.