### PR TITLE
Add GEM_HOME to exclusion patterns in backtrace formatter

### DIFF
--- a/rspec-core/lib/rspec/core/backtrace_formatter.rb
+++ b/rspec-core/lib/rspec/core/backtrace_formatter.rb
@@ -10,6 +10,7 @@ module RSpec
 
         patterns = %w[ /lib\d*/ruby/ bin/ exe/rspec /lib/bundler/ /exe/bundle: ]
         patterns << "org/jruby/" if RUBY_PLATFORM == 'java'
+        patterns << ENV["GEM_HOME"] if ENV.key?("GEM_HOME")
         patterns.map! { |s| Regexp.new(s.gsub("/", File::SEPARATOR)) }
 
         @exclusion_patterns = [Regexp.union(RSpec::CallerFilter::IGNORE_REGEX, *patterns)]

--- a/rspec-core/spec/rspec/core/backtrace_formatter_spec.rb
+++ b/rspec-core/spec/rspec/core/backtrace_formatter_spec.rb
@@ -135,6 +135,19 @@ module RSpec::Core
         expect(BacktraceFormatter.new.format_backtrace(bundler_trace)).to eq ["/some/other/file.rb:13"]
       end
 
+      it "excludes lines from GEM_HOME by default" do
+        trace = [
+          "/usr/local/bundle/gems/activerecord-8.0.2/lib/active_record/validations.rb",
+          "/some/other/file.rb:13",
+          "/usr/local/bundle/gems/activerecord-8.0.2/lib/active_record/validations.rb"
+        ]
+        # GEM_HOME is defined by the base docker image for Ruby. See:
+        # https://github.com/docker-library/ruby/blob/235b3ffb2060c837137b32ea55f75816f2f4e4c4/3.4/bookworm/Dockerfile#L100C14-L100C31
+        with_env_vars 'GEM_HOME' => "/usr/local/bundle" do
+          expect(BacktraceFormatter.new.format_backtrace(trace)).to eq ["/some/other/file.rb:13"]
+        end
+      end
+
       context "when every line is filtered out" do
         let(:backtrace) do
           [


### PR DESCRIPTION
The base Docker Ruby image sets an environment variable called GEM_HOME to store gems in. With this change, the backtrace_formatter.rb is made aware of this location so it can also filter backtrace lines from gems within this location. This is particularly helpful when running code in CI platforms like Buildkite.

 You can see where this ENV variable is set in this link:

 https://github.com/docker-library/ruby/blob/235b3ffb2060c837137b32ea55f75816f2f4e4c4/3.4/bookworm/Dockerfile#L100C14-L100C31