### PR TITLE
Allow nested mock calls by changing an internal safeguard

### DIFF
--- a/rspec-mocks/spec/rspec/mocks/partial_double_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/partial_double_spec.rb
@@ -61,6 +61,19 @@ module RSpec
         an_object.call :my_method
       end
 
+      # This is a regresion test for rspec/rspec#212 / rspec/rspec#213
+      it "supports nesting" do
+        nested = false
+        expect(object).to receive(:nested).twice do
+          unless nested
+            nested = true
+            object.nested
+          end
+        end
+
+        object.nested
+      end
+
       it "can disallow messages from being received" do
         expect(object).not_to receive(:fuhbar)
         expect_fast_failure_from(


### PR DESCRIPTION
#116 prevented nested calls from iterating counters to defend against recursion during error message formatting, but this can break legitimate nested loops, so we switch that to only safeguarding internals e.g the error generation against this.