### PR TITLE
Clear thread local internal variable rather than set to false fixes #218

### DIFF
--- a/rspec-mocks/lib/rspec/mocks/message_expectation.rb
+++ b/rspec-mocks/lib/rspec/mocks/message_expectation.rb
@@ -620,7 +620,14 @@ module RSpec
         end
 
         def invoking_internals=(value)
-          RSpec::Support.thread_local_data[:"__rspec_#{object_id}_invoking_internals"] = value
+          # We clear the key for this rather than setting to false because otherwise the amount of
+          # thread local data will keep growing over the lifetime of the thread (which is a long
+          # time on a single threaded spec run e.g standard MRI)
+          if value
+            RSpec::Support.thread_local_data[:"__rspec_#{object_id}_invoking_internals"] = true
+          else
+            RSpec::Support.thread_local_data.delete(:"__rspec_#{object_id}_invoking_internals")
+          end
         end
 
         def invoke_incrementing_actual_calls_by(increment, allowed_to_fail, parent_stub, *args, &block)


### PR DESCRIPTION
#156 inadvertently leads to a growing amount thread variables as the key is object specific and won't be cleaned up until the thread dies which on MRI is never? Instead set to true when setting, then delete the key when setting to false.