### PR TITLE
Handle frozen backtraces in exception presenter

### DIFF
--- a/rspec-core/lib/rspec/core/formatters/exception_presenter.rb
+++ b/rspec-core/lib/rspec/core/formatters/exception_presenter.rb
@@ -266,15 +266,16 @@ module RSpec
           line_regex = RSpec.configuration.in_project_source_dir_regex
           loaded_spec_files = RSpec.configuration.loaded_spec_files
 
-          exception_backtrace.reject! do |line|
-            line.start_with?("<internal:")
-          end
+          reduced_backtrace =
+            exception_backtrace.reject do |line|
+              line.start_with?("<internal:")
+            end
 
-          exception_backtrace.find do |line|
+          reduced_backtrace.find do |line|
             next unless (line_path = line[/(.+?):(\d+)(|:\d+)/, 1])
             path = File.expand_path(line_path)
             loaded_spec_files.include?(path) || path =~ line_regex
-          end || exception_backtrace.first
+          end || reduced_backtrace.first
         end
 
         def formatted_message_and_backtrace(colorizer)

--- a/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -679,6 +679,14 @@ module RSpec::Core
         end
       end
 
+      context "when the stacktrace is frozen" do
+        let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:#{__LINE__}"].tap(&:freeze)) }
+
+        it 'still finds the backtrace line' do
+          expect(read_failed_lines.first).to include("instance_double(Exception, :backtrace => [ \"\#{__FILE__}:\#{__LINE__}\"")
+        end
+      end
+
       context "when String alias to_int to_i" do
         before do
           String.class_exec do


### PR DESCRIPTION
Fixes #217 