### PR TITLE
Duplicate the error_generator in message expectations

### DIFF
--- a/rspec-mocks/lib/rspec/mocks/message_expectation.rb
+++ b/rspec-mocks/lib/rspec/mocks/message_expectation.rb
@@ -422,7 +422,7 @@ module RSpec
         def initialize(error_generator, expectation_ordering, expected_from, method_double,
                        type=:expectation, opts={}, &implementation_block)
           @type = type
-          @error_generator = error_generator
+          @error_generator = error_generator.dup
           @error_generator.opts = error_generator.opts.merge(opts)
           @expected_from = expected_from
           @method_double = method_double

--- a/rspec-mocks/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/matchers/receive_spec.rb
@@ -525,10 +525,22 @@ module RSpec
               expect { verify_all }.to raise_error(message)
             end
           end
+
+          it "allows custom messages" do
+            wrapped.to receive(:foo), "A custom message"
+            expect { verify_all }.to fail_with("A custom message")
+
+            wrapped.to receive(:foo), "A custom message"
+            wrapped.to receive(:bar), "Also custom message"
+            receiver.bar
+            expect { verify_all }.to fail_with("A custom message")
+          end
         end
+
         it_behaves_like "resets partial mocks cleanly" do
           let(:target) { expect(object) }
         end
+
         it_behaves_like "handles frozen objects cleanly" do
           let(:target) { expect(object) }
         end


### PR DESCRIPTION
Historically we've always passed this in containing the target object in the proxy which helps us with generating the correct error messages, however we then mutate its opts which leaks upwards to the proxy. In addition if we set a custom error message this is then shared by all message expectations which is certainly not desired.

Fixes rspec/rspec#234