### PR TITLE
Fix build for 3.13

### DIFF
--- a/rspec-expectations/spec/rspec/matchers/built_in/eq_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/eq_spec.rb
@@ -20,11 +20,9 @@ module RSpec
       it "compares by sending == to actual (not expected)" do
         called = false
         actual = Class.new do
-          # rubocop:disable Naming/MethodName
           define_method :== do |_other|
             called = true
           end
-          # rubocop:enable Naming/MethodName
         end.new
 
         expect(actual).to eq :anything # to trigger the matches? method

--- a/rspec-support/spec/rspec/support/method_signature_verifier_spec.rb
+++ b/rspec-support/spec/rspec/support/method_signature_verifier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec/support'
 require 'rspec/support/method_signature_verifier'
 
@@ -916,11 +918,13 @@ module RSpec
         end
 
         describe 'a proc' do
-          it 'will match partial args' do
-            a_proc = proc { |_a, _b| }
-            expect(validate a_proc, 1).to be(true)
-            expect(validate a_proc, 2, 2).to be(true)
-            expect(validate a_proc, 3, 3, 3).to be(false)
+          if RUBY_VERSION.to_f > 1.8
+            it 'will match partial args' do
+              a_proc = proc { |_a, _b| }
+              expect(validate a_proc, 1).to be(true)
+              expect(validate a_proc, 2, 2).to be(true)
+              expect(validate a_proc, 3, 3, 3).to be(false)
+            end
           end
 
           if RubyFeatures.kw_args_supported?


### PR DESCRIPTION
Cleanup an uneeded rubocop rule, and suppress a test on 1.8.7

The test if from #121 but as the functionality was gated in a way that 1.8.7 wouldn't have received a change I'm comfortable not pandering to it here.