### PR TITLE
Remove typo in rspec-mocks

### DIFF
--- a/rspec-mocks/lib/rspec/mocks/any_instance/expectation_chain.rb
+++ b/rspec-mocks/lib/rspec/mocks/any_instance/expectation_chain.rb
@@ -25,7 +25,7 @@ module RSpec
         def create_message_expectation_on(instance)
           proxy = ::RSpec::Mocks.space.proxy_for(instance)
           method_name, opts = @expectation_args
-          opts = (opts || {}).merge(:expected_form => IGNORED_BACKTRACE_LINE)
+          opts ||= {}
 
           me = proxy.add_message_expectation(method_name, opts, &@expectation_block)
           if RSpec::Mocks.configuration.yield_receiver_to_any_instance_implementation_blocks?

--- a/rspec-mocks/lib/rspec/mocks/any_instance/stub_chain.rb
+++ b/rspec-mocks/lib/rspec/mocks/any_instance/stub_chain.rb
@@ -13,7 +13,7 @@ module RSpec
         def create_message_expectation_on(instance)
           proxy = ::RSpec::Mocks.space.proxy_for(instance)
           method_name, opts = @expectation_args
-          opts = (opts || {}).merge(:expected_form => IGNORED_BACKTRACE_LINE)
+          opts ||= {}
 
           stub = proxy.add_stub(method_name, opts, &@expectation_block)
           @recorder.stubs[stub.message] << stub


### PR DESCRIPTION
A previous refactoring (a long long time ago) the any-instance mocks introduced a typo with metadata providing a fallback backtrace line, one which is unnecessary because any uses of the metadata have their own fallback in the form of a call to `CallerFilter.first_non_rspec_line`.

Given the historic nature of this typo and its lack of ill effect, I'm electing to remove it rather than fix it.