### PR TITLE
Fix `World::Null.traverse_example_group_trees_until` to accept a dummy block argument

### DIFF
--- a/rspec-core/Changelog.md
+++ b/rspec-core/Changelog.md
@@ -7,6 +7,11 @@ Enhancements:
   allways print a line number rather than an example id when the line number is ambiguous.
   (Baden Ashford, rspec/rspec-core#3085)
 
+Bug Fixes:
+
+* Add explicit block parameter to `RSpec::World::Null.traverse_example_group_trees_until` to
+  prevent warning. (@viralpraxis, rspec/rspec#240)
+
 ### 3.13.4 / 2025-05-27
 [Full Changelog](http://github.com/rspec/rspec/compare/rspec-core-v3.13.3...rspec-core-v3.13.4)
 

--- a/rspec-core/lib/rspec/core/world.rb
+++ b/rspec-core/lib/rspec/core/world.rb
@@ -269,7 +269,7 @@ module RSpec
           []
         end
 
-        def self.traverse_example_group_trees_until
+        def self.traverse_example_group_trees_until(&_block)
         end
 
         # :nocov:

--- a/rspec-core/spec/rspec/core/world_spec.rb
+++ b/rspec-core/spec/rspec/core/world_spec.rb
@@ -2,7 +2,6 @@ class Bar; end
 class Foo; end
 
 module RSpec::Core
-
   RSpec.describe RSpec::Core::World do
     let(:configuration) { RSpec.configuration }
     let(:world) { RSpec.world }
@@ -324,6 +323,38 @@ module RSpec::Core
             expect(reporter).not_to receive(:message)
             world.announce_filters
           end
+        end
+      end
+    end
+
+    context "Null implements the same api World" do
+      # JRuby has refine as a method so exclude it
+      methods = World::Null.methods - Object.methods - [:refine]
+      methods.each do |name|
+        specify "##{name} has the same signature" do
+          null_signature =
+            World::Null.method(name).parameters.map do |signature|
+              if signature.length == 2
+                type, variable_name = *signature
+
+                if variable_name == :_
+                  [type]
+                else
+                  variable_name_as_string = variable_name.to_s
+
+                  if variable_name_as_string.start_with?("_")
+                    [type, variable_name_as_string.gsub(/^_/, "").to_sym]
+                  else
+                    [type, variable_name]
+                  end
+                end
+              else
+                signature
+              end
+            end
+          world_signature = World.instance_method(name).parameters
+
+          expect(null_signature).to eq(world_signature)
         end
       end
     end


### PR DESCRIPTION
To fix this warning

```
rspec-core-3.13.5/lib/rspec/core/configuration.rb:2370: warning: the block passed to 'RSpec::Core::World::Null.traverse_example_group_trees_until' defined 3.4.0/gems/rspec-core-3.13.5/lib/rspec/core/world.rb:272 may be ignored
```

we can simply change `Null.traverse_example_group_trees_until` to accept a `&_block`, just like `World#traverse_example_group_trees_until` does.