### PR TITLE
Warn when include_examples is used with a block

### DIFF
--- a/rspec-core/README.md
+++ b/rspec-core/README.md
@@ -89,7 +89,10 @@ You can declare examples within a group using any of `it`, `specify`, or
 ## Shared Examples and Contexts
 
 Declare a shared example group using `shared_examples`, and then include it
-in any group using `include_examples`.
+in any group using `include_examples`, or `it_behaves_like`.
+
+Note that `include_examples` directly includes examples into the current context so
+you often want to use `it_behaves_like` to isolate the examples into a context.
 
 ```ruby
 RSpec.shared_examples "collections" do |collection_class|
@@ -103,7 +106,7 @@ RSpec.describe Array do
 end
 
 RSpec.describe Hash do
-  include_examples "collections", Hash
+  it_behaves_like "collections", Hash
 end
 ```
 
@@ -164,11 +167,11 @@ RSpec.shared_examples "collections" do
 end
 
 RSpec.describe Array do
-  include_examples "collections"
+  it_behaves_like "collections"
 end
 
 RSpec.describe Hash do
-  include_examples "collections"
+  it_behaves_like "collections"
 end
 ```
 

--- a/rspec-core/features/example_groups/shared_examples.feature
+++ b/rspec-core/features/example_groups/shared_examples.feature
@@ -58,9 +58,7 @@ Feature: Using shared examples
   end
   ```
 
-  To prevent this kind of subtle error a warning is emitted if you declare multiple
-  methods with the same name in the same context. Should you get this warning
-  the simplest solution is to replace `include_examples` with `it_behaves_like`, in this
+  The simplest solution is to replace `include_examples` with `it_behaves_like`, in this
   way method overriding is avoided because of the nested context created by `it_behaves_like`
 
   Conventions:

--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -362,6 +362,10 @@ module RSpec
       #
       # @see SharedExampleGroup
       def self.include_examples(name, *args, &block)
+        if block
+          RSpec.deprecate("Passing a block to `include_examples`",
+                          :replacement => "Use `it_behaves_like` instead")
+        end
         find_and_eval_shared("examples", name, caller.first, *args, &block)
       end
 

--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -352,6 +352,13 @@ module RSpec
       #
       # @see SharedExampleGroup
       def self.include_context(name, *args, &block)
+        if block
+          RSpec.deprecate(
+            "Passing a block to `include_context`",
+            :replacement =>
+              "Use `it_behaves_like` instead, or place the block content " \
+              "after the statement.")
+        end
         find_and_eval_shared("context", name, caller.first, *args, &block)
       end
 
@@ -363,8 +370,11 @@ module RSpec
       # @see SharedExampleGroup
       def self.include_examples(name, *args, &block)
         if block
-          RSpec.deprecate("Passing a block to `include_examples`",
-                          :replacement => "Use `it_behaves_like` instead")
+          RSpec.deprecate(
+            "Passing a block to `include_examples`",
+            :replacement =>
+              "Use `it_behaves_like` instead, or place the block content " \
+              "after the statement.")
         end
         find_and_eval_shared("examples", name, caller.first, *args, &block)
       end

--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -356,8 +356,9 @@ module RSpec
           RSpec.deprecate(
             "Passing a block to `include_context`",
             :replacement =>
-              "Use `it_behaves_like` instead, or place the block content " \
-              "after the statement.")
+              "Either use `it_behaves_like` to wrap the block " \
+              "contents in a context, or place the block content " \
+              "within the parent context.")
         end
         find_and_eval_shared("context", name, caller.first, *args, &block)
       end
@@ -373,8 +374,9 @@ module RSpec
           RSpec.deprecate(
             "Passing a block to `include_examples`",
             :replacement =>
-              "Use `it_behaves_like` instead, or place the block content " \
-              "after the statement.")
+              "Either use `it_behaves_like` to wrap the block " \
+              "contents in a context, or place the block content " \
+              "within the parent context.")
         end
         find_and_eval_shared("examples", name, caller.first, *args, &block)
       end

--- a/rspec-core/spec/rspec/core/dsl_spec.rb
+++ b/rspec-core/spec/rspec/core/dsl_spec.rb
@@ -72,30 +72,30 @@ RSpec.describe "The RSpec DSL" do
   end
 
   describe "built in DSL methods" do
-    include_examples "dsl methods", :describe, :context, :shared_examples, :shared_examples_for, :shared_context do
-      def changing_expose_dsl_globally
-        yield
-      end
+    def changing_expose_dsl_globally
+      yield
     end
+
+    include_examples "dsl methods", :describe, :context, :shared_examples, :shared_examples_for, :shared_context
   end
 
   describe "custom example group aliases" do
     context "when adding aliases before exposing the DSL globally" do
-      include_examples "dsl methods", :detail do
-        def changing_expose_dsl_globally
-          RSpec.configuration.alias_example_group_to(:detail)
-          yield
-        end
+      def changing_expose_dsl_globally
+        RSpec.configuration.alias_example_group_to(:detail)
+        yield
       end
+
+      include_examples "dsl methods", :detail
     end
 
     context "when adding aliases after exposing the DSL globally" do
-      include_examples "dsl methods", :detail do
-        def changing_expose_dsl_globally
-          yield
-          RSpec.configuration.alias_example_group_to(:detail)
-        end
+      def changing_expose_dsl_globally
+        yield
+        RSpec.configuration.alias_example_group_to(:detail)
       end
+
+      include_examples "dsl methods", :detail
     end
 
     context "when adding duplicate aliases" do

--- a/rspec-core/spec/rspec/core/filter_manager_spec.rb
+++ b/rspec-core/spec/rspec/core/filter_manager_spec.rb
@@ -184,7 +184,7 @@ module RSpec::Core
       end
 
       describe "location filtering" do
-        include_examples "example identification filter preference", :location do
+        it_behaves_like "example identification filter preference", :location do
           def add_filter(options)
             filter_manager.add_location(__FILE__, [options.fetch(:line_number)])
           end
@@ -192,7 +192,7 @@ module RSpec::Core
       end
 
       describe "id filtering" do
-        include_examples "example identification filter preference", :id do
+        it_behaves_like "example identification filter preference", :id do
           def add_filter(options)
             filter_manager.add_ids(__FILE__, [options.fetch(:scoped_id)])
           end

--- a/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -831,7 +831,7 @@ module RSpec::Core
     end
   end
 
-  RSpec.shared_examples_for "a class satisfying the common multiple exception error interface" do
+  RSpec.shared_context "exception helpers" do
     def new_failure(*a)
       RSpec::Expectations::ExpectationNotMetError.new(*a)
     end
@@ -839,6 +839,10 @@ module RSpec::Core
     def new_error(*a)
       StandardError.new(*a)
     end
+  end
+
+  RSpec.shared_examples_for "a class satisfying the common multiple exception error interface" do
+    include_context "exception helpers"
 
     it 'allows you to keep track of failures and other errors in order' do
       mee = new_multiple_exception_error
@@ -878,7 +882,7 @@ module RSpec::Core
   end
 
   RSpec.describe RSpec::Expectations::ExpectationNotMetError do
-    include_examples "a class satisfying the common multiple exception error interface" do
+    it_behaves_like "a class satisfying the common multiple exception error interface" do
       def new_multiple_exception_error
         failure_aggregator = RSpec::Expectations::FailureAggregator.new(nil, {})
         RSpec::Expectations::MultipleExpectationsNotMetError.new(failure_aggregator)
@@ -887,7 +891,9 @@ module RSpec::Core
   end
 
   RSpec.describe MultipleExceptionError do
-    include_examples "a class satisfying the common multiple exception error interface" do
+    include_context "exception helpers"
+
+    it_behaves_like "a class satisfying the common multiple exception error interface" do
       def new_multiple_exception_error
         MultipleExceptionError.new
       end

--- a/rspec-core/spec/rspec/core/shared_example_group_spec.rb
+++ b/rspec-core/spec/rspec/core/shared_example_group_spec.rb
@@ -606,8 +606,9 @@ module RSpec
               expect(RSpec).to receive(:deprecate).with(
                 "Passing a block to `#{name}`",
                 :replacement =>
-                  "Use `it_behaves_like` instead, or place the block content " \
-                  "after the statement."
+                  "Either use `it_behaves_like` to wrap the block " \
+                  "contents in a context, or place the block content " \
+                  "within the parent context."
               )
 
               group = RSpec.describe("host group") do

--- a/rspec-core/spec/rspec/core/shared_example_group_spec.rb
+++ b/rspec-core/spec/rspec/core/shared_example_group_spec.rb
@@ -599,37 +599,41 @@ module RSpec
         end
       end
 
-      describe "#include_examples" do
-        context "when passed a block" do
-          it "emits a deprecation warning" do
-            expect(RSpec).to receive(:deprecate).with(
-              "Passing a block to `include_examples`",
-              :replacement => "Use `it_behaves_like` instead"
-            )
+      %w[include_examples include_context].each do |name|
+        describe "##{name}" do
+          context "when passed a block" do
+            it "emits a deprecation warning" do
+              expect(RSpec).to receive(:deprecate).with(
+                "Passing a block to `#{name}`",
+                :replacement =>
+                  "Use `it_behaves_like` instead, or place the block content " \
+                  "after the statement."
+              )
 
-            group = RSpec.describe("host group") do
-              shared_examples "some behavior" do
-                example "shared example"
+              group = RSpec.describe("host group") do
+                shared_examples "some behavior" do
+                  example "shared example"
+                end
               end
-            end
 
-            group.include_examples("some behavior") do
-              let(:leak) { "boom" }
+              group.__send__(name, "some behavior") do
+                let(:leak) { "boom" }
+              end
             end
           end
-        end
 
-        context "when not passed a block" do
-          it "does not emit a deprecation warning" do
-            expect(RSpec).not_to receive(:deprecate)
+          context "when not passed a block" do
+            it "does not emit a deprecation warning" do
+              expect(RSpec).not_to receive(:deprecate)
 
-            group = RSpec.describe("host group") do
-              shared_examples "some behavior" do
-                example "shared example"
+              group = RSpec.describe("host group") do
+                shared_examples "some behavior" do
+                  example "shared example"
+                end
               end
-            end
 
-            group.include_examples("some behavior")
+              group.__send__(name, "some behavior")
+            end
           end
         end
       end

--- a/rspec-core/spec/rspec/core/shared_example_group_spec.rb
+++ b/rspec-core/spec/rspec/core/shared_example_group_spec.rb
@@ -598,6 +598,41 @@ module RSpec
           end
         end
       end
+
+      describe "#include_examples" do
+        context "when passed a block" do
+          it "emits a deprecation warning" do
+            expect(RSpec).to receive(:deprecate).with(
+              "Passing a block to `include_examples`",
+              :replacement => "Use `it_behaves_like` instead"
+            )
+
+            group = RSpec.describe("host group") do
+              shared_examples "some behavior" do
+                example "shared example"
+              end
+            end
+
+            group.include_examples("some behavior") do
+              let(:leak) { "boom" }
+            end
+          end
+        end
+
+        context "when not passed a block" do
+          it "does not emit a deprecation warning" do
+            expect(RSpec).not_to receive(:deprecate)
+
+            group = RSpec.describe("host group") do
+              shared_examples "some behavior" do
+                example "shared example"
+              end
+            end
+
+            group.include_examples("some behavior")
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
(partially) fixes https://github.com/rspec/rspec/issues/230
The 4.0 counterpart https://github.com/rspec/rspec/pull/259

:question: Open questions: should we also warn when it is used with arguments?
We warn about this in [our documentation](https://rspec.info/features/3-13/rspec-core/example-groups/shared-examples/):
> When you include parameterized examples in the current context multiple times, you may override previous method definitions and last declaration wins.