### PR TITLE
Remove mentions and references to rspec-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,9 +149,6 @@ Once you've set up the environment, you'll need to cd into the working
 directory of whichever repo you want to work in. From there you can run the
 specs and cucumber features, and make patches.
 
-NOTE: You do not need to use rspec-dev to work on a specific RSpec repo. You
-can treat each RSpec repo as an independent project.
-
 * [Build details](BUILD_DETAIL.md)
 * [Code of Conduct](CODE_OF_CONDUCT.md)
 * [Detailed contributing guide](CONTRIBUTING.md)

--- a/rspec-core/spec/rspec/core/rake_task_spec.rb
+++ b/rspec-core/spec/rspec/core/rake_task_spec.rb
@@ -252,7 +252,7 @@ module RSpec::Core
         "/Users/myron/code/some-gem/bundle/ruby/2.1.0/bundler/gems/%s-8d2e4e570994/lib"
 
       it_configures_rspec_load_path "bundler :path dependencies",
-        "/Users/myron/code/rspec/repos/%s/lib"
+        "/Users/myron/code/rspec/%s/lib"
 
       it_configures_rspec_load_path "a rubygem",
         "/Users/myron/.gem/ruby/1.9.3/gems/%s-3.1.0.beta1/lib"

--- a/rspec-core/spec/rspec/core/rake_task_spec.rb
+++ b/rspec-core/spec/rspec/core/rake_task_spec.rb
@@ -252,7 +252,7 @@ module RSpec::Core
         "/Users/myron/code/some-gem/bundle/ruby/2.1.0/bundler/gems/%s-8d2e4e570994/lib"
 
       it_configures_rspec_load_path "bundler :path dependencies",
-        "/Users/myron/code/rspec-dev/repos/%s/lib"
+        "/Users/myron/code/rspec/repos/%s/lib"
 
       it_configures_rspec_load_path "a rubygem",
         "/Users/myron/.gem/ruby/1.9.3/gems/%s-3.1.0.beta1/lib"
@@ -260,21 +260,6 @@ module RSpec::Core
       it "does not include extra load path entries for other gems that have `rspec-core` in its path" do
         # matchers are lazily loaded with autoload, so we need to get the matcher before manipulating the load path.
         include_extra_load_path_entries = include("simplecov", "minitest", "rspec-core/spec")
-
-        # these are items on my load path due to `bundle install --standalone`,
-        # and my initial logic caused all these to be included in the `-I` option.
-        $LOAD_PATH.replace([
-           "/Users/user/code/rspec-dev/repos/rspec-core/spec",
-           "/Users/user/code/rspec-dev/repos/rspec-core/bundle/ruby/1.9.1/gems/simplecov-0.8.2/lib",
-           "/Users/user/code/rspec-dev/repos/rspec-core/bundle/ruby/1.9.1/gems/simplecov-html-0.8.0/lib",
-           "/Users/user/code/rspec-dev/repos/rspec-core/bundle/ruby/1.9.1/gems/minitest-5.3.3/lib",
-           "/Users/user/code/rspec-dev/repos/rspec/lib",
-           "/Users/user/code/rspec-dev/repos/rspec-mocks/lib",
-           "/Users/user/code/rspec-dev/repos/rspec-core/lib",
-           "/Users/user/code/rspec-dev/repos/rspec-expectations/lib",
-           "/Users/user/code/rspec-dev/repos/rspec-support/lib",
-           "/Users/user/code/rspec-dev/repos/rspec-core/bundle",
-        ])
 
         expect(spec_command).not_to include_extra_load_path_entries
       end

--- a/rspec/README.md
+++ b/rspec/README.md
@@ -37,11 +37,8 @@ See http://rspec.info/documentation/ for links to documentation for all gems.
 
 ## Contribute
 
-* [http://github.com/rspec/rspec-dev](http://github.com/rspec/rspec-dev)
+* [http://github.com/rspec/rspec](http://github.com/rspec/rspec)
 
 ## Also see
 
-* [https://github.com/rspec/rspec-core](https://github.com/rspec/rspec-core)
-* [https://github.com/rspec/rspec-expectations](https://github.com/rspec/rspec-expectations)
-* [https://github.com/rspec/rspec-mocks](https://github.com/rspec/rspec-mocks)
 * [https://github.com/rspec/rspec-rails](https://github.com/rspec/rspec-rails)


### PR DESCRIPTION
Related to "Fix broken links" item from https://github.com/rspec/rspec/issues/153
