### PR TITLE
Update min RuboCop version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -107,7 +107,7 @@ gem "rr", "~> 1.0.4"
 
 # No need to run rubocop on earlier versions
 if RUBY_VERSION >= '3.3' && RUBY_ENGINE == 'ruby'
-  gem "rubocop", "~> 1.69"
+  gem "rubocop", "~> 1.80"
 end
 
 gem 'test-unit', '~> 3.0' if RUBY_VERSION.to_f >= 2.2


### PR DESCRIPTION
I had

 3. rubocop-1.69.2
 4. rubocop-1.74.0

installed, and both were failing for me:

```
$ bundle exec rubocop
Error: unrecognized cop or department Naming/PredicateMethod found in /Users/pirj/source/rspec/common_rubocop_config.yml
Did you mean `Naming/PredicateName`?
unrecognized cop or department Naming/PredicatePrefix found in /Users/pirj/source/rspec/common_rubocop_config.yml
Did you mean `Naming/PredicateName`?
unrecognized cop or department Style/CollectionQuerying found in /Users/pirj/source/rspec/common_rubocop_config.yml
Did you mean `Style/ModuleFunction`?
```
