### PR TITLE
Move loading HunkGenerator to autoload to prevent load ordering issues

### DIFF
--- a/rspec-support/lib/rspec/support.rb
+++ b/rspec-support/lib/rspec/support.rb
@@ -160,5 +160,6 @@ module RSpec
     # pp, etc by avoiding an unnecessary require. Instead, autoload will take
     # care of loading the differ on first use.
     autoload :Differ, "rspec/support/differ"
+    autoload :HunkGenerator, "rspec/support/hunk_generator"
   end
 end

--- a/rspec-support/lib/rspec/support/differ.rb
+++ b/rspec-support/lib/rspec/support/differ.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 RSpec::Support.require_rspec_support 'encoded_string'
-RSpec::Support.require_rspec_support 'hunk_generator'
 RSpec::Support.require_rspec_support "object_formatter"
 
 require 'pp'


### PR DESCRIPTION
Originally hunk generator was included with the differ where its used, but this introduces a flakey spec. Given that its a reasonable thing to look for I'm just going to autoload this instead. I verified this fixed the flake with a seed of 5248