### PR TITLE
Raise ArgumentError when docstring's are not a string (or nil)

### DIFF
--- a/rspec-core/Changelog.md
+++ b/rspec-core/Changelog.md
@@ -35,6 +35,10 @@ Breaking Changes:
   (Phil Pirozhkov, rspec/rspec-core#2864)
 * Unify multi-condition filtering to use "all" semantic. (Phil Pirozhkov, rspec/rspec-core#2874)
 * Change the default order to random. (Santiago Bartesaghi, rspec/rspec-core#2929)
+* Raise an error when an example group description is neither a string, class or module.
+  (Eisuke Yoshida, rspec/rspec-core#3081)
+* Raise an error when an example description is nor a string.
+  (Eisuke Yoshida, rspec/rspec-core#3081)
 
 Enhancements:
 

--- a/rspec-core/features/clear_examples.feature
+++ b/rspec-core/features/clear_examples.feature
@@ -32,7 +32,7 @@ Feature: Running specs multiple times with different runner options in the same 
     require 'spec_helper'
 
     RSpec.describe "truth" do
-      describe true do
+      describe "true" do
         it "is truthy" do
           expect(true).to be_truthy
         end
@@ -42,12 +42,12 @@ Feature: Running specs multiple times with different runner options in the same 
         end
       end
 
-      describe false do
+      describe "false" do
         it "is falsy" do
           expect(false).to be_falsy
         end
 
-        it "is truthy" do
+        it "is not truthy" do
           expect(false).not_to be_truthy
         end
       end

--- a/rspec-core/features/command_line/line_number_appended_to_path.feature
+++ b/rspec-core/features/command_line/line_number_appended_to_path.feature
@@ -41,7 +41,8 @@ Feature: `<file>:<line_number>` (line number appended to file path)
       """
     And a file named "one_liner_spec.rb" with:
       """ruby
-      RSpec.describe 9 do
+      RSpec.describe "9" do
+        subject(:number) { 9 }
 
         it { is_expected.to be > 8 }
 
@@ -153,7 +154,7 @@ Feature: `<file>:<line_number>` (line number appended to file path)
     And the output should not contain "second file"
 
   Scenario: Matching one-liners
-    When I run `rspec one_liner_spec.rb:3 --format doc`
+    When I run `rspec one_liner_spec.rb:4 --format doc`
     Then the examples should all pass
     Then the output should contain "is expected to be > 8"
     But the output should not contain "is expected to be < 10"

--- a/rspec-core/features/command_line/ruby.feature
+++ b/rspec-core/features/command_line/ruby.feature
@@ -12,7 +12,7 @@ Feature: Run with `ruby` command
       """ruby
       require 'rspec/autorun'
 
-      RSpec.describe 1 do
+      RSpec.describe "1" do
         it "is < 2" do
           expect(1).to be < 2
         end

--- a/rspec-core/features/expectation_framework_integration/configure_expectation_framework.feature
+++ b/rspec-core/features/expectation_framework_integration/configure_expectation_framework.feature
@@ -21,7 +21,8 @@ Feature: Configuring an expectation framework
         end
       end
 
-      RSpec.describe 6 do
+      RSpec.describe "multiple" do
+        subject(:number) { 6 }
         it { is_expected.to be_a_multiple_of 3 }
       end
       """
@@ -35,9 +36,10 @@ Feature: Configuring an expectation framework
         config.expect_with :rspec
       end
 
-      RSpec.describe 5 do
+      RSpec.describe "numeric comparison" do
+        subject(:number) { 5 }
         it "is greater than 4" do
-          expect(5).to be > 4
+          expect(number).to be > 4
         end
       end
       """
@@ -52,15 +54,17 @@ Feature: Configuring an expectation framework
         config.expect_with :test_unit
       end
 
-      RSpec.describe [1] do
+      RSpec.describe 'Array comparison' do
+        subject(:array) { [1] }
+
         it "is equal to [1]" do
-          assert_equal [1], [1], "expected [1] to equal [1]"
+          assert_equal [1], array, "expected [1] to equal [1]"
         end
 
-        specify { assert_not_equal [1], [] }
+        specify { assert_not_equal [], array }
 
         it "is equal to [2] (intentional failure)" do
-          assert [1] == [2], "errantly expected [2] to equal [1]"
+          assert array == [2], "errantly expected [2] to equal [1]"
         end
       end
       """
@@ -113,9 +117,11 @@ Feature: Configuring an expectation framework
         config.expect_with :rspec, :test_unit
       end
 
-      RSpec.describe [1] do
+      RSpec.describe 'Array comparison' do
+        subject(:array) { [1] }
+
         it "is equal to [1]" do
-          assert_equal [1], [1], "expected [1] to equal [1]"
+          assert_equal [1], array, "expected [1] to equal [1]"
         end
 
         it "matches array [1]" do
@@ -155,19 +161,21 @@ Feature: Configuring an expectation framework
         config.expect_with :test_unit, :minitest
       end
 
-      RSpec.describe [1] do
+      RSpec.describe 'Array comparison' do
+        subject(:array) { [1] }
+
         it "is equal to [1]" do
-          assert_equal [1], [1], "expected [1] to equal [1]"
+          assert_equal [1], array, "expected [1] to equal [1]"
         end
 
-        specify { assert_not_equal [1], [] }
+        specify { assert_not_equal [], array }
 
         it "the an object is the same as itself" do
           x = [1]
           assert_same x, x, "expected x to be the same x"
         end
 
-        specify { refute_same [1], [1] }
+        specify { refute_same [1], array }
       end
       """
     When I run `rspec example_spec.rb`

--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -146,6 +146,10 @@ module RSpec
         idempotently_define_singleton_method(name) do |*all_args, &block|
           desc, *args = *all_args
 
+          unless NilClass === desc || String === desc
+            raise ArgumentError, "Examples must be described with a string, got: `#{desc.inspect}`"
+          end
+
           options = Metadata.build_hash_from(args)
           options.update(:skip => RSpec::Core::Pending::NOT_YET_IMPLEMENTED) unless block
           options.update(extra_options)
@@ -269,6 +273,10 @@ module RSpec
             combined_metadata = metadata.dup
             combined_metadata.merge!(args.pop) if args.last.is_a? Hash
             args << combined_metadata
+
+            unless NilClass === description || String === description || Class === description || Module === description
+              raise ArgumentError, "Example groups must be described with a string, got: `#{description.inspect}`"
+            end
 
             subclass(self, description, args, registration_collection, &example_group_block)
           ensure

--- a/rspec-core/spec/rspec/core/example_group_spec.rb
+++ b/rspec-core/spec/rspec/core/example_group_spec.rb
@@ -55,16 +55,6 @@ module RSpec::Core
       end
     end
 
-    it 'does not treat the first argument as a metadata key even if it is a symbol' do
-      group = RSpec.describe(:symbol)
-      expect(group.metadata).not_to include(:symbol)
-    end
-
-    it 'treats the first argument as part of the description when it is a symbol' do
-      group = RSpec.describe(:symbol)
-      expect(group.description).to eq("symbol")
-    end
-
     describe "constant naming" do
       around do |ex|
         before_constants = RSpec::ExampleGroups.constants
@@ -1231,6 +1221,66 @@ module RSpec::Core
         expect(group.examples[2].description).to eq('should 3')
       end
 
+    end
+
+    describe "example group doc string" do
+      it "accepts a string for an example group doc string" do
+        expect { RSpec.describe 'MyClass' }.not_to output.to_stderr
+      end
+
+      it "accepts a class for an example group doc string" do
+        expect { RSpec.describe Numeric }.not_to output.to_stderr
+      end
+
+      it "accepts a module for an example group doc string" do
+        expect { RSpec.describe RSpec }.not_to output.to_stderr
+      end
+
+      it "accepts example group without a doc string" do
+        expect { RSpec.describe }.not_to output.to_stderr
+      end
+
+      it "emits a warning when a Symbol is used as an example group doc string" do
+        expect { RSpec.describe :foo }.
+          to raise_error(ArgumentError, /Example groups must be described with a string, got: `:foo`/)
+      end
+
+      it "emits a warning when a Hash is used as an example group doc string" do
+        expect { RSpec.describe(foo: :bar) { } }.
+          to raise_error(/Example groups must be described with a string, got: `#{{:foo=>:bar}.inspect}`/)
+      end
+    end
+
+    describe "example doc string" do
+      let(:group) { RSpec.describe }
+
+      it "accepts a string for an example doc string" do
+        expect { group.it('MyClass') { } }.not_to raise_error
+      end
+
+      it "accepts example without a doc string" do
+        expect { group.it { } }.not_to raise_error
+      end
+
+      it "raises ArgumentError when a Class is used as an example doc string" do
+        expect { group.it(Numeric) { } }.
+          to raise_error(ArgumentError, /Examples must be described with a string, got: `Numeric`/)
+      end
+
+      it "raises ArgumentError when a Module is used as an example doc string" do
+        expect { group.it(RSpec) { } }.
+          to raise_error(ArgumentError, /Examples must be described with a string, got: `RSpec`/)
+      end
+
+      it "raises ArgumentError when a Symbol is used as an example doc string" do
+        expect { group.it(:foo) { } }.
+          to raise_error(ArgumentError, /Examples must be described with a string, got: `:foo`/)
+      end
+
+      it "raises ArgumentError when a Hash is used as an example doc string" do
+        expect { group.it(foo: :bar) { } }.
+          to raise_error(ArgumentError, /Examples must be described with a string, got: `#{{:foo=>:bar}.inspect}`/)
+      end
     end
 
     describe Object, "describing nested example_groups", :little_less_nested => 'yep' do

--- a/rspec-core/spec/rspec/core/example_group_spec.rb
+++ b/rspec-core/spec/rspec/core/example_group_spec.rb
@@ -1240,14 +1240,14 @@ module RSpec::Core
         expect { RSpec.describe }.not_to output.to_stderr
       end
 
-      it "emits a warning when a Symbol is used as an example group doc string" do
+      it "raises ArgumentError when a Symbol is used as an example group doc string" do
         expect { RSpec.describe :foo }.
           to raise_error(ArgumentError, /Example groups must be described with a string, got: `:foo`/)
       end
 
-      it "emits a warning when a Hash is used as an example group doc string" do
+      it "raises ArgumentError when a Hash is used as an example group doc string" do
         expect { RSpec.describe(foo: :bar) { } }.
-          to raise_error(/Example groups must be described with a string, got: `#{{:foo=>:bar}.inspect}`/)
+          to raise_error(%r{Example groups must be described with a string, got: `#{Regexp.escape({ foo: :bar }.inspect)}`})
       end
     end
 
@@ -1279,7 +1279,7 @@ module RSpec::Core
 
       it "raises ArgumentError when a Hash is used as an example doc string" do
         expect { group.it(foo: :bar) { } }.
-          to raise_error(ArgumentError, /Examples must be described with a string, got: `#{{:foo=>:bar}.inspect}`/)
+          to raise_error(ArgumentError, %r{Examples must be described with a string, got: `#{Regexp.escape({ foo: :bar }.inspect)}`})
       end
     end
 

--- a/rspec-core/spec/rspec/core/hooks_filtering_spec.rb
+++ b/rspec-core/spec/rspec/core/hooks_filtering_spec.rb
@@ -317,7 +317,7 @@ module RSpec::Core
           c.after(:each,  :match => false) { filters << "after each in config"}
           c.after(:all,   :match => false) { filters << "after all in config"}
         end
-        group = RSpec.describe(:match => true)
+        group = RSpec.describe("docstring", :match => true)
         group.example("example") {}
         group.run
         expect(filters).to eq([])

--- a/rspec-core/spec/rspec/core/memoized_helpers_spec.rb
+++ b/rspec-core/spec/rspec/core/memoized_helpers_spec.rb
@@ -31,36 +31,6 @@ module RSpec::Core
         end
       end
 
-      describe "with a number" do
-        it "returns the number" do
-          expect(subject_value_for(15)).to eq(15)
-        end
-      end
-
-      describe "with a hash" do
-        it "returns the hash" do
-          expect(subject_value_for(:foo => 3)).to eq(:foo => 3)
-        end
-      end
-
-      describe "with a symbol" do
-        it "returns the symbol" do
-          expect(subject_value_for(:foo)).to eq(:foo)
-        end
-      end
-
-      describe "with true" do
-        it "returns `true`" do
-          expect(subject_value_for(true)).to eq(true)
-        end
-      end
-
-      describe "with false" do
-        it "returns `false`" do
-          expect(subject_value_for(false)).to eq(false)
-        end
-      end
-
       describe "with nil" do
         it "returns `nil`" do
           expect(subject_value_for(nil)).to eq(nil)
@@ -340,7 +310,7 @@ module RSpec::Core
       end
 
       it 'supports a new expect-based syntax' do
-        group = RSpec.describe([1, 2, 3]) do
+        group = RSpec.describe(Array) do
           it { is_expected.to be_an Array }
           it { is_expected.not_to include 4 }
         end

--- a/rspec-core/spec/rspec/core/metadata_spec.rb
+++ b/rspec-core/spec/rspec/core/metadata_spec.rb
@@ -385,12 +385,6 @@ module RSpec
             end
           end
 
-          context "with a Symbol" do
-            it "returns the symbol" do
-              expect(value_for :group).to be(:group)
-            end
-          end
-
           context "with a class" do
             it "returns the class" do
               expect(value_for String).to be(String)
@@ -636,7 +630,7 @@ module RSpec
         it "finds the first non-rspec lib file in the caller array" do
           value = nil
 
-          RSpec.describe(:caller => ["./lib/rspec/core/foo.rb", "#{__FILE__}:#{__LINE__}"]) do
+          RSpec.describe("docstring", :caller => ["./lib/rspec/core/foo.rb", "#{__FILE__}:#{__LINE__}"]) do
             value = metadata[:file_path]
           end
 

--- a/rspec-expectations/features/built_in_matchers/all.feature
+++ b/rspec-expectations/features/built_in_matchers/all.feature
@@ -21,7 +21,9 @@ Feature: `all` matcher
   Scenario: Array usage
     Given a file named "array_all_matcher_spec.rb" with:
       """ruby
-      RSpec.describe [1, 3, 5] do
+      RSpec.describe "Array" do
+        subject(:array) { [1, 3, 5] }
+
         it { is_expected.to all( be_odd ) }
         it { is_expected.to all( be_an(Integer) ) }
         it { is_expected.to all( be < 10 ) }
@@ -42,7 +44,9 @@ Feature: `all` matcher
   Scenario: Compound matcher usage
     Given a file named "compound_all_matcher_spec.rb" with:
       """ruby
-      RSpec.describe ['anything', 'everything', 'something'] do
+      RSpec.describe "Array" do
+        subject(:array) { ['anything', 'everything', 'something'] }
+
         it { is_expected.to all( be_a(String).and include("thing") ) }
         it { is_expected.to all( be_a(String).and end_with("g") ) }
         it { is_expected.to all( start_with("s").or include("y") ) }

--- a/rspec-expectations/features/built_in_matchers/be_within.feature
+++ b/rspec-expectations/features/built_in_matchers/be_within.feature
@@ -25,7 +25,9 @@ Feature: `be_within` matcher
   Scenario: Basic usage
     Given a file named "be_within_matcher_spec.rb" with:
       """ruby
-      RSpec.describe 27.5 do
+      RSpec.describe "Float" do
+        subject(:number) { 27.5 }
+
         it { is_expected.to be_within(0.5).of(27.9) }
         it { is_expected.to be_within(0.5).of(28.0) }
         it { is_expected.to be_within(0.5).of(27.1) }

--- a/rspec-expectations/features/built_in_matchers/comparisons.feature
+++ b/rspec-expectations/features/built_in_matchers/comparisons.feature
@@ -13,7 +13,9 @@ Feature: Comparison matchers
   Scenario: Numeric operator matchers
     Given a file named "numeric_operator_matchers_spec.rb" with:
       """ruby
-      RSpec.describe 18 do
+      RSpec.describe "Numeric" do
+        subject(:number) { 18 }
+
         it { is_expected.to be < 20 }
         it { is_expected.to be > 15 }
         it { is_expected.to be <= 19 }

--- a/rspec-expectations/features/built_in_matchers/contain_exactly.feature
+++ b/rspec-expectations/features/built_in_matchers/contain_exactly.feature
@@ -21,7 +21,9 @@ Feature: `contain_exactly` matcher
   Scenario: Array is expected to contain every value
     Given a file named "contain_exactly_matcher_spec.rb" with:
       """ruby
-      RSpec.describe [1, 2, 3] do
+      RSpec.describe "Array" do
+        subject(:array) { [1, 2, 3] }
+
         it { is_expected.to contain_exactly(1, 2, 3) }
         it { is_expected.to contain_exactly(1, 3, 2) }
         it { is_expected.to contain_exactly(2, 1, 3) }
@@ -48,7 +50,9 @@ Feature: `contain_exactly` matcher
   Scenario: Array is not expected to contain every value
     Given a file named "contain_exactly_matcher_spec.rb" with:
       """ruby
-      RSpec.describe [1, 2, 3] do
+      RSpec.describe "Array" do
+        subject(:array) { [1, 2, 3] }
+
         it { is_expected.to_not contain_exactly(1, 2, 3, 4) }
         it { is_expected.to_not contain_exactly(1, 2) }
 

--- a/rspec-expectations/features/built_in_matchers/cover.feature
+++ b/rspec-expectations/features/built_in_matchers/cover.feature
@@ -13,7 +13,9 @@ Feature: `cover` matcher
   Scenario: Range usage
     Given a file named "range_cover_matcher_spec.rb" with:
       """ruby
-      RSpec.describe (1..10) do
+      RSpec.describe "Range" do
+        subject(:range) { (1..10) }
+
         it { is_expected.to cover(4) }
         it { is_expected.to cover(6) }
         it { is_expected.to cover(8) }

--- a/rspec-expectations/features/built_in_matchers/end_with.feature
+++ b/rspec-expectations/features/built_in_matchers/end_with.feature
@@ -30,7 +30,9 @@ Feature: `end_with` matcher
   Scenario: Array usage
     Given a file named "example_spec.rb" with:
       """ruby
-      RSpec.describe [0, 1, 2, 3, 4] do
+      RSpec.describe "Array" do
+        subject(:array) { [0, 1, 2, 3, 4] }
+
         it { is_expected.to end_with 4 }
         it { is_expected.to end_with 3, 4 }
         it { is_expected.not_to end_with 3 }

--- a/rspec-expectations/features/built_in_matchers/have_attributes.feature
+++ b/rspec-expectations/features/built_in_matchers/have_attributes.feature
@@ -21,7 +21,9 @@ Feature: `have_attributes` matcher
       """ruby
       Person = Struct.new(:name, :age)
 
-      RSpec.describe Person.new("Jim", 32) do
+      RSpec.describe "Person" do
+        subject(:person) { Person.new("Jim", 32) }
+
         it { is_expected.to have_attributes(:name => "Jim") }
         it { is_expected.to have_attributes(:name => a_string_starting_with("J") ) }
         it { is_expected.to have_attributes(:age => 32) }

--- a/rspec-expectations/features/built_in_matchers/include.feature
+++ b/rspec-expectations/features/built_in_matchers/include.feature
@@ -35,7 +35,9 @@ Feature: `include` matcher
   Scenario: Array usage
     Given a file named "array_include_matcher_spec.rb" with:
       """ruby
-      RSpec.describe [1, 3, 7] do
+      RSpec.describe "Array" do
+        subject(:array) { [1, 3, 7] }
+
         it { is_expected.to include(1) }
         it { is_expected.to include(3) }
         it { is_expected.to include(7) }
@@ -108,7 +110,9 @@ Feature: `include` matcher
   Scenario: Hash usage
     Given a file named "hash_include_matcher_spec.rb" with:
       """ruby
-      RSpec.describe :a => 7, :b => 5 do
+      RSpec.describe "Hash" do
+        subject(:hash) { {:a => 7, :b => 5} }
+
         it { is_expected.to include(:a) }
         it { is_expected.to include(:b, :a) }
         it { is_expected.to include(:a => 7) }
@@ -158,7 +162,9 @@ Feature: `include` matcher
   Scenario: Counts usage
     Given a file named "include_matcher_with_counts_spec.rb" with:
       """ruby
-        RSpec.describe [{:c => 7}, {:a => 1}, {:b => 2}, {:c => 1}, {:a => 3}, {:c => 7}] do
+        RSpec.describe "Array of Hashes" do
+          subject(:array) { [{:c => 7}, {:a => 1}, {:b => 2}, {:c => 1}, {:a => 3}, {:c => 7}] }
+
           it { is_expected.to include(:b => 2).exactly(1).times }
           it { is_expected.to include(:b => 2).once }
           it { is_expected.to include(have_key(:a)).twice }

--- a/rspec-expectations/features/built_in_matchers/match.feature
+++ b/rspec-expectations/features/built_in_matchers/match.feature
@@ -33,7 +33,9 @@ Feature: `match` matcher
   Scenario: Regular expression usage
     Given a file named "regexp_match_spec.rb" with:
       """ruby
-      RSpec.describe /foo/ do
+      RSpec.describe "Regexp" do
+        subject(:regexp) { /foo/ }
+
         it { is_expected.to match("food") }
         it { is_expected.not_to match("drinks") }
 

--- a/rspec-expectations/features/built_in_matchers/predicates.feature
+++ b/rspec-expectations/features/built_in_matchers/predicates.feature
@@ -50,12 +50,12 @@ Feature: Predicate matchers
   Scenario: Expecting `subject` to `be_zero` (based on Integer#zero?)
     Given a file named "be_zero_spec.rb" with:
       """ruby
-      RSpec.describe 0 do
-        it { is_expected.to be_zero }
+      RSpec.describe "Integer" do
+        it { expect(0).to be_zero }
       end
 
-      RSpec.describe 7 do
-        it { is_expected.to be_zero } # deliberate failure
+      RSpec.describe "Integer" do
+        it { expect(7).to be_zero } # deliberate failure
       end
       """
     When I run `rspec be_zero_spec.rb`
@@ -65,12 +65,12 @@ Feature: Predicate matchers
   Scenario: Expecting `subject` to not `be_empty` (based on Array#empty?)
     Given a file named "not_to_be_empty_spec.rb" with:
       """ruby
-      RSpec.describe [1, 2, 3] do
-        it { is_expected.not_to be_empty }
+      RSpec.describe "Array" do
+        it { expect([1, 2, 3]).not_to be_empty }
       end
 
-      RSpec.describe [] do
-        it { is_expected.not_to be_empty } # deliberate failure
+      RSpec.describe "Array" do
+        it { expect([]).not_to be_empty } # deliberate failure
       end
       """
     When I run `rspec not_to_be_empty_spec.rb`
@@ -125,7 +125,9 @@ Feature: Predicate matchers
          end
        end
 
-       RSpec.describe 12 do
+       RSpec.describe "Integer" do
+         subject(:number) { 12 }
+
          it { is_expected.to be_multiple_of(3) }
          it { is_expected.not_to be_multiple_of(7) }
 

--- a/rspec-expectations/features/built_in_matchers/respond_to.feature
+++ b/rspec-expectations/features/built_in_matchers/respond_to.feature
@@ -70,7 +70,9 @@ Feature: `respond_to` matcher
   Scenario: Specify arguments
     Given a file named "respond_to_matcher_argument_checking_spec.rb" with:
       """ruby
-      RSpec.describe 7 do
+      RSpec.describe "Integer" do
+        subject(:number) { 7 }
+
         it { is_expected.to respond_to(:zero?).with(0).arguments }
         it { is_expected.not_to respond_to(:zero?).with(1).argument }
 

--- a/rspec-expectations/features/built_in_matchers/satisfy.feature
+++ b/rspec-expectations/features/built_in_matchers/satisfy.feature
@@ -21,7 +21,9 @@ Feature: `satisfy` matcher
   Scenario: Basic usage
     Given a file named "satisfy_matcher_spec.rb" with:
       """ruby
-      RSpec.describe 10 do
+      RSpec.describe "Integer" do
+        subject(:number) { 10 }
+
         it { is_expected.to satisfy { |v| v > 5 } }
         it { is_expected.not_to satisfy { |v| v > 15 } }
 

--- a/rspec-expectations/features/built_in_matchers/start_with.feature
+++ b/rspec-expectations/features/built_in_matchers/start_with.feature
@@ -30,7 +30,9 @@ Feature: `start_with` matcher
   Scenario: With an array
     Given a file named "example_spec.rb" with:
       """ruby
-      RSpec.describe [0, 1, 2, 3, 4] do
+      RSpec.describe "Array" do
+        subject(:array) { [0, 1, 2, 3, 4] }
+
         it { is_expected.to start_with 0 }
         it { is_expected.to start_with(0, 1)}
         it { is_expected.not_to start_with(2) }

--- a/rspec-expectations/features/built_in_matchers/types.feature
+++ b/rspec-expectations/features/built_in_matchers/types.feature
@@ -26,7 +26,9 @@ Feature: Type matchers
         include MyModule
       end
 
-      RSpec.describe 17.0 do
+      RSpec.describe "Float" do
+        subject(:float_number) { 17.0 }
+
         # the actual class
         it { is_expected.to be_kind_of(Float) }
         it { is_expected.to be_a_kind_of(Float) }
@@ -79,7 +81,9 @@ Feature: Type matchers
         include MyModule
       end
 
-      RSpec.describe 17.0 do
+      RSpec.describe "Float" do
+        subject(:float_number) { 17.0 }
+
         # the actual class
         it { is_expected.to be_instance_of(Float) }
         it { is_expected.to be_an_instance_of(Float) }

--- a/rspec-expectations/features/custom_matchers/define_matcher.feature
+++ b/rspec-expectations/features/custom_matchers/define_matcher.feature
@@ -15,21 +15,25 @@ Feature: Defining a custom matcher
         end
       end
 
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject { 9 }
         it { is_expected.to be_a_multiple_of(3) }
       end
 
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject { 9 }
         it { is_expected.not_to be_a_multiple_of(4) }
       end
 
       # fail intentionally to generate expected output
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject { 9 }
         it { is_expected.to be_a_multiple_of(4) }
       end
 
       # fail intentionally to generate expected output
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject { 9 }
         it { is_expected.not_to be_a_multiple_of(3) }
       end
       """
@@ -60,8 +64,8 @@ Feature: Defining a custom matcher
       end
 
       # fail intentionally to generate expected output
-      RSpec.describe 9 do
-        it { is_expected.to be_a_multiple_of(4) }
+      RSpec.describe "Integer" do
+        it { expect(9).to be_a_multiple_of(4) }
       end
       """
     When I run `rspec ./matcher_with_failure_message_spec.rb`
@@ -84,8 +88,8 @@ Feature: Defining a custom matcher
       end
 
       # fail intentionally to generate expected output
-      RSpec.describe 9 do
-        it { is_expected.not_to be_a_multiple_of(3) }
+      RSpec.describe "Integer" do
+        it { expect(9).not_to be_a_multiple_of(3) }
       end
       """
     When I run `rspec ./matcher_with_failure_for_message_spec.rb`
@@ -107,12 +111,12 @@ Feature: Defining a custom matcher
         end
       end
 
-      RSpec.describe 9 do
-        it { is_expected.to be_a_multiple_of(3) }
+      RSpec.describe "Integer" do
+        it { expect(9).to be_a_multiple_of(3) }
       end
 
-      RSpec.describe 9 do
-        it { is_expected.not_to be_a_multiple_of(4) }
+      RSpec.describe "Integer" do
+        it { expect(9).not_to be_a_multiple_of(4) }
       end
       """
     When I run `rspec ./matcher_overriding_description_spec.rb --format documentation`
@@ -156,8 +160,8 @@ Feature: Defining a custom matcher
         end
       end
 
-      RSpec.describe 10 do
-        it { is_expected.to be_the_sum_of(1,2,3,4) }
+      RSpec.describe "Integer" do
+        it { expect(10).to be_the_sum_of(1,2,3,4) }
       end
       """
     When I run `rspec ./matcher_with_multiple_args_spec.rb --format documentation`
@@ -178,8 +182,8 @@ Feature: Defining a custom matcher
         description { "be lazily equal to #{block_arg.call}" }
       end
 
-      RSpec.describe 10 do
-        it { is_expected.to be_lazily_equal_to { 10 } }
+      RSpec.describe "Integer" do
+        it { expect(10).to be_lazily_equal_to { 10 } }
       end
       """
     When I run `rspec ./matcher_with_block_arg_spec.rb --format documentation`
@@ -290,7 +294,9 @@ Feature: Defining a custom matcher
         end
       end
 
-      RSpec.describe [1, 2, 3] do
+      RSpec.describe "Array" do
+        subject(:array) { [1, 2, 3] }
+
         it { is_expected.to contain(1, 2) }
         it { is_expected.not_to contain(4, 5, 6) }
 
@@ -315,7 +321,9 @@ Feature: Defining a custom matcher
         match { |actual| is_multiple?(actual) }
       end
 
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject(:number) { 9 }
+
         it { is_expected.to be_a_multiple_of(3) }
         it { is_expected.not_to be_a_multiple_of(4) }
 
@@ -344,7 +352,9 @@ Feature: Defining a custom matcher
         match { |actual| is_multiple?(actual, expected) }
       end
 
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject(:number) { 9 }
+
         it { is_expected.to be_a_multiple_of(3) }
         it { is_expected.not_to be_a_multiple_of(4) }
 
@@ -418,11 +428,15 @@ Feature: Defining a custom matcher
         end
       end
 
-      RSpec.describe 1 do
+      RSpec.describe "Integer" do
+        subject(:number) { 1 }
+
         it { is_expected.to is_lower_than 2 }
       end
 
-      RSpec.describe 1 do
+      RSpec.describe "Integer" do
+        subject(:number) { 1 }
+
         it { is_expected.not_to is_lower_than 'a' }
       end
 
@@ -448,7 +462,9 @@ Feature: Defining a custom matcher
 
       RSpec::Matchers.alias_matcher :be_n_of , :be_a_multiple_of
 
-      RSpec.describe 9 do
+      RSpec.describe "Integer" do
+        subject(:number) { 9 }
+
         it { is_expected.to be_n_of(3) }
       end
       """

--- a/rspec-expectations/features/custom_matchers/define_matcher_with_fluent_interface.feature
+++ b/rspec-expectations/features/custom_matchers/define_matcher_with_fluent_interface.feature
@@ -15,7 +15,9 @@ Feature: Defining a matcher with fluent interface
         end
       end
 
-      RSpec.describe 5 do
+      RSpec.describe "Integer" do
+        subject(:number) { 5 }
+
         it { is_expected.to be_bigger_than(4).and_smaller_than(6) }
       end
       """
@@ -34,7 +36,9 @@ Feature: Defining a matcher with fluent interface
         chain :and_smaller_than, :second
       end
 
-      RSpec.describe 5 do
+      RSpec.describe "Integer" do
+        subject(:number) { 5 }
+
         it { is_expected.to be_bigger_than(4).and_smaller_than(6) }
       end
       """
@@ -55,7 +59,9 @@ Feature: Defining a matcher with fluent interface
           end
         end
 
-        RSpec.describe 5 do
+        RSpec.describe "Integer" do
+        subject(:number) { 5 }
+
           it { is_expected.to be_bigger_than(4).and_smaller_than(6) }
         end
         """


### PR DESCRIPTION
This was originallly rspec/rspec-core#3081 it got merged prior to the monorepo migration to get it into 4-0-dev but it has some consquences when run across the entire build surrounding metadata, and needs properly allowing classes (even if I have a preference against them, they are too widly used to "break" in 4 plus theres the surrounding debate about `described_class` we've yet to have) in example groups.

3.99 counterpart https://github.com/rspec/rspec/pull/107

Fixes https://github.com/rspec/rspec/issues/40