### PR TITLE
Remove supports_taint?

### DIFF
--- a/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -630,7 +630,7 @@ module RSpec::Core
         end
       end
 
-      context "when backtrace will generate a security error", :skip => !RSpec::Support::RubyFeatures.supports_taint? do
+      context "when backtrace will generate a security error" do
         let(:exception) { instance_double(Exception, :backtrace => [ "#{__FILE__}:#{__LINE__}"]) }
 
         it "is handled gracefully" do

--- a/rspec-core/spec/rspec/core/formatters/html_snippet_extractor_spec.rb
+++ b/rspec-core/spec/rspec/core/formatters/html_snippet_extractor_spec.rb
@@ -12,15 +12,6 @@ module RSpec
           expect(RSpec::Core::Formatters::HtmlSnippetExtractor.new.lines_around("blech", 8)).to eq("# Couldn't get snippet for blech")
         end
 
-        if RSpec::Support::RubyFeatures.supports_taint?
-          it "falls back on a default message when it gets a security error" do
-            message = with_safe_set_to_level_that_triggers_security_errors do
-              RSpec::Core::Formatters::HtmlSnippetExtractor.new.lines_around("blech".dup.taint, 8)
-            end
-            expect(message).to eq("# Couldn't get snippet for blech")
-          end
-        end
-
         describe "snippet extraction" do
           let(:snippet) do
             HtmlSnippetExtractor.new.snippet(["#{__FILE__}:#{__LINE__}"])

--- a/rspec-support/Changelog.md
+++ b/rspec-support/Changelog.md
@@ -5,6 +5,7 @@ Breaking Changes:
 
 * Ruby < 2.3 is no longer supported. (Phil Pirozhkov, rspec/rspec-support#436)
 * Removed unused `RSpec::Support::ObjectFormatter::BigDecimalInspector`. (Jon Rowe, rspec/rspec#254)
+* Remove unsupported `RubyFeature.supports_taint?` check. (Jon Rowe, rspec/rspec#255)
 
 Enhancements
 

--- a/rspec-support/lib/rspec/support/ruby_features.rb
+++ b/rspec-support/lib/rspec/support/ruby_features.rb
@@ -89,16 +89,6 @@ module RSpec
         end
       end
 
-      if RUBY_VERSION.to_f >= 2.7
-        def supports_taint?
-          false
-        end
-      else
-        def supports_taint?
-          true
-        end
-      end
-
       # TruffleRuby disables ripper due to low performance
       if Ruby.rbx? || Ruby.truffleruby?
         def ripper_supported?

--- a/rspec-support/spec/rspec/support/ruby_features_spec.rb
+++ b/rspec-support/spec/rspec/support/ruby_features_spec.rb
@@ -73,10 +73,6 @@ module RSpec
         expect(RubyFeatures.supports_syntax_suggest?).to eq(RUBY_VERSION.to_f >= 3.2)
       end
 
-      specify "#supports_taint?" do
-        RubyFeatures.supports_taint?
-      end
-
       describe "#ripper_supported?" do
         def ripper_is_implemented?
           in_sub_process_if_possible do


### PR DESCRIPTION
Oddly theres a spec we skipped but it passes on Ruby 3 so I'm inclined to keep it.