### PR TITLE
Raise on include_examples/context with a block

### DIFF
--- a/rspec-core/Changelog.md
+++ b/rspec-core/Changelog.md
@@ -36,6 +36,7 @@ Breaking Changes:
 * Unify multi-condition filtering to use "all" semantic. (Phil Pirozhkov, rspec/rspec-core#2874)
 * Change the default order to random. (Santiago Bartesaghi, rspec/rspec-core#2929)
 * Default warning level is now `:deprecations_only`. (Jon Rowe, rspec/rspec#161)
+* Raise an error when a block is passed to `include_examples`. (Phil Pirozhkov, rspec/rspec#259)
 
 Enhancements:
 

--- a/rspec-core/README.md
+++ b/rspec-core/README.md
@@ -75,7 +75,7 @@ You can declare examples within a group using any of `it`, `specify`, or
 ## Shared Examples and Contexts
 
 Declare a shared example group using `shared_examples`, and then include it
-in any group using `include_examples`.
+in any group using `it_behaves_like` or `include_examples`.
 
 ```ruby
 RSpec.shared_examples "collections" do |collection_class|
@@ -84,14 +84,38 @@ RSpec.shared_examples "collections" do |collection_class|
   end
 end
 
+RSpec.shared_examples "implements #empty?" do
+  it "returns true when there are no members" do
+    expect(empty_target).to be_empty
+  end
+
+  it "returns false when there are members" do
+    expect(non_empty_target).to_not be_empty
+  end
+end
+
 RSpec.describe Array do
   include_examples "collections", Array
+
+  it_behaves_like "implements #empty?" do
+    let(:empty_target) { Array.new }
+    let(:non_empty_target) { [:key] }
+  end
 end
 
 RSpec.describe Hash do
   include_examples "collections", Hash
+
+  it_behaves_like "implements #empty?" do
+    let(:empty_target) { Hash.new }
+    let(:non_empty_target) { {key: :value} }
+  end
 end
 ```
+
+Note that `include_examples` directly includes examples into the current context, whilst
+`it_behaves_like` wraps the examples in a new context which allows you to pass a block
+to customise things like `let` or `subject` without using local variables passed in.
 
 Nearly anything that can be declared within an example group can be declared
 within a shared example group. This includes `before`, `after`, and `around`

--- a/rspec-core/features/example_groups/shared_context.feature
+++ b/rspec-core/features/example_groups/shared_context.feature
@@ -56,24 +56,6 @@ Feature: Using `shared_context`
     When I run `rspec shared_context_example.rb`
     Then the examples should all pass
 
-  Scenario: Declare a shared context, include it with `include_context` and extend it with an additional block
-    Given a file named "shared_context_example.rb" with:
-      """ruby
-      require "./shared_stuff.rb"
-
-      RSpec.describe "including shared context using 'include_context' and a block" do
-        include_context "shared stuff" do
-          let(:shared_let) { {'in_a' => 'block'} }
-        end
-
-        it "evaluates the block in the shared context" do
-          expect(shared_let['in_a']).to eq('block')
-        end
-      end
-      """
-    When I run `rspec shared_context_example.rb`
-    Then the examples should all pass
-
   Scenario: Declare a shared context and include it with metadata
     Given a file named "shared_context_example.rb" with:
       """ruby

--- a/rspec-core/features/example_groups/shared_examples.feature
+++ b/rspec-core/features/example_groups/shared_examples.feature
@@ -56,9 +56,7 @@ Feature: Using shared examples
   end
   ```
 
-  To prevent this kind of subtle error a warning is emitted if you declare multiple
-  methods with the same name in the same context. Should you get this warning
-  the simplest solution is to replace `include_examples` with `it_behaves_like`, in this
+  The simplest solution is to replace `include_examples` with `it_behaves_like`, in this
   way method overriding is avoided because of the nested context created by `it_behaves_like`
 
   Conventions:

--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -344,8 +344,10 @@ module RSpec
       # context.
       #
       # @see SharedExampleGroup
-      def self.include_context(name, *args, &block)
-        find_and_eval_shared("context", name, caller.first, *args, &block)
+      def self.include_context(name, *args)
+        issue_block_inclusion_error!("include_context") if block_given?
+
+        find_and_eval_shared("context", name, caller.first, *args)
       end
 
       # Includes shared content mapped to `name` directly in the group in which
@@ -354,8 +356,10 @@ module RSpec
       # context.
       #
       # @see SharedExampleGroup
-      def self.include_examples(name, *args, &block)
-        find_and_eval_shared("examples", name, caller.first, *args, &block)
+      def self.include_examples(name, *args)
+        issue_block_inclusion_error!("include_examples") if block_given?
+
+        find_and_eval_shared("examples", name, caller.first, *args)
       end
 
       # Clear memoized values when adding/removing examples
@@ -391,6 +395,15 @@ module RSpec
           self, Metadata.relative_path(inclusion_location),
           args, customization_block
         )
+      end
+
+      # @private
+      def self.issue_block_inclusion_error!(method)
+        raise ArgumentError,
+              "Do not pass a block to `#{method}`. " \
+              "Either use `it_behaves_like` to wrap the block " \
+              "contents in a context, or place the block content " \
+              "within the parent context."
       end
 
       # @!endgroup

--- a/rspec-core/spec/rspec/core/dsl_spec.rb
+++ b/rspec-core/spec/rspec/core/dsl_spec.rb
@@ -20,18 +20,18 @@ RSpec.describe "The RSpec DSL" do
   end
 
   describe "built in DSL methods" do
-    include_examples "dsl methods", :describe, :context, :shared_examples, :shared_examples_for, :shared_context do
-      def setup
-      end
+    include_examples "dsl methods", :describe, :context, :shared_examples, :shared_examples_for, :shared_context
+
+    def setup
     end
   end
 
   describe "custom example group aliases" do
     context "when adding aliases before exposing the DSL globally" do
-      include_examples "dsl methods", :detail do
-        def setup
-          RSpec.configuration.alias_example_group_to(:detail)
-        end
+      include_examples "dsl methods", :detail
+
+      def setup
+        RSpec.configuration.alias_example_group_to(:detail)
       end
     end
 

--- a/rspec-core/spec/rspec/core/filter_manager_spec.rb
+++ b/rspec-core/spec/rspec/core/filter_manager_spec.rb
@@ -184,7 +184,7 @@ module RSpec::Core
       end
 
       describe "location filtering" do
-        include_examples "example identification filter preference", :location do
+        it_behaves_like "example identification filter preference", :location do
           def add_filter(options)
             filter_manager.add_location(__FILE__, [options.fetch(:line_number)])
           end
@@ -192,7 +192,7 @@ module RSpec::Core
       end
 
       describe "id filtering" do
-        include_examples "example identification filter preference", :id do
+        it_behaves_like "example identification filter preference", :id do
           def add_filter(options)
             filter_manager.add_ids(__FILE__, [options.fetch(:scoped_id)])
           end

--- a/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -818,7 +818,7 @@ module RSpec::Core
     end
   end
 
-  RSpec.shared_examples_for "a class satisfying the common multiple exception error interface" do
+  RSpec.shared_context "exception helpers" do
     def new_failure(*a)
       RSpec::Expectations::ExpectationNotMetError.new(*a)
     end
@@ -826,6 +826,10 @@ module RSpec::Core
     def new_error(*a)
       StandardError.new(*a)
     end
+  end
+
+  RSpec.shared_examples_for "a class satisfying the common multiple exception error interface" do
+    include_context "exception helpers"
 
     it 'allows you to keep track of failures and other errors in order' do
       mee = new_multiple_exception_error
@@ -865,7 +869,7 @@ module RSpec::Core
   end
 
   RSpec.describe RSpec::Expectations::ExpectationNotMetError do
-    include_examples "a class satisfying the common multiple exception error interface" do
+    it_behaves_like "a class satisfying the common multiple exception error interface" do
       def new_multiple_exception_error
         failure_aggregator = RSpec::Expectations::FailureAggregator.new(nil, {})
         RSpec::Expectations::MultipleExpectationsNotMetError.new(failure_aggregator)
@@ -874,7 +878,9 @@ module RSpec::Core
   end
 
   RSpec.describe MultipleExceptionError do
-    include_examples "a class satisfying the common multiple exception error interface" do
+    include_context "exception helpers"
+
+    it_behaves_like "a class satisfying the common multiple exception error interface" do
       def new_multiple_exception_error
         MultipleExceptionError.new
       end

--- a/rspec-expectations/spec/rspec/matchers/built_in/base_matcher_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/base_matcher_spec.rb
@@ -106,23 +106,23 @@ module RSpec::Matchers::BuiltIn
       end
 
       context "for a DSL-defined custom matcher" do
-        include_examples "detecting default failure message" do
-          def build_matcher(&block)
-            definition = Proc.new do
-              match {}
-              module_exec(&block) if block
-            end
+        include_examples "detecting default failure message"
 
-            RSpec::Matchers::DSL::Matcher.new(:matcher_name, definition, self)
+        def build_matcher(&block)
+          definition = Proc.new do
+            match {}
+            module_exec(&block) if block
           end
+
+          RSpec::Matchers::DSL::Matcher.new(:matcher_name, definition, self)
         end
       end
 
       context "for a matcher that subclasses `BaseMatcher`" do
-        include_examples "detecting default failure message" do
-          def build_matcher(&block)
-            Class.new(RSpec::Matchers::BuiltIn::BaseMatcher, &block).new
-          end
+        include_examples "detecting default failure message"
+
+        def build_matcher(&block)
+          Class.new(RSpec::Matchers::BuiltIn::BaseMatcher, &block).new
         end
       end
 

--- a/rspec-expectations/spec/rspec/matchers/built_in/yield_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/yield_spec.rb
@@ -34,13 +34,13 @@ end
 # NOTE: `yield` passes a probe to expect an that probe should be passed
 # to expectation target. This is different from the other block matchers.
 RSpec.shared_examples "an RSpec probe-yielding block-only matcher" do |**options|
-  include_examples "an RSpec block-only matcher", **options do
-    let(:valid_expectation) { expect { |block| valid_block(&block) } }
-    let(:invalid_expectation) { expect { |block| invalid_block(&block) } }
+  include_examples "an RSpec block-only matcher", **options
 
-    let(:valid_block_lambda) { lambda { |block| valid_block(&block) } }
-    let(:invalid_block_lambda) { lambda { |block| invalid_block(&block) } }
-  end
+  let(:valid_expectation) { expect { |block| valid_block(&block) } }
+  let(:invalid_expectation) { expect { |block| invalid_block(&block) } }
+
+  let(:valid_block_lambda) { lambda { |block| valid_block(&block) } }
+  let(:invalid_block_lambda) { lambda { |block| invalid_block(&block) } }
 end
 
 RSpec.describe "yield_control matcher" do

--- a/rspec-mocks/spec/rspec/mocks/before_all_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/before_all_spec.rb
@@ -2,74 +2,74 @@ require 'support/before_all_shared_example_group'
 
 RSpec.describe "Using rspec-mocks features in before(:all) blocks" do
   describe "#stub_const" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        stub_const("SomeNewConst", Class.new)
-      end
+    include_examples "fails in a before(:all) block"
 
-      it 'does not stub the const' do
-        expect(defined?(SomeNewConst)).to be_falsey
-      end
+    def use_rspec_mocks
+      stub_const("SomeNewConst", Class.new)
+    end
+
+    it 'does not stub the const' do
+      expect(defined?(SomeNewConst)).to be_falsey
     end
   end
 
   describe "#hide_const(for an undefined const)" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        hide_const("Foo")
-      end
+    include_examples "fails in a before(:all) block"
+
+    def use_rspec_mocks
+      hide_const("Foo")
     end
   end
 
   describe "#hide_const(for a defined const)" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        hide_const("Float")
-      end
+    include_examples "fails in a before(:all) block"
 
-      it 'does not hide the const' do
-        expect(defined?(Float)).to be_truthy
-      end
+    def use_rspec_mocks
+      hide_const("Float")
+    end
+
+    it 'does not hide the const' do
+      expect(defined?(Float)).to be_truthy
     end
   end
 
   describe "allow(...).to receive_message_chain" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        allow(Object).to receive_message_chain(:foo, :bar)
-      end
+    include_examples "fails in a before(:all) block"
+
+    def use_rspec_mocks
+      allow(Object).to receive_message_chain(:foo, :bar)
     end
   end
 
   describe "#expect(...).to receive" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        expect(Object).to receive(:foo)
-      end
+    include_examples "fails in a before(:all) block"
+
+    def use_rspec_mocks
+      expect(Object).to receive(:foo)
     end
   end
 
   describe "#allow(...).to receive" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        allow(Object).to receive(:foo)
-      end
+    include_examples "fails in a before(:all) block"
+
+    def use_rspec_mocks
+      allow(Object).to receive(:foo)
     end
   end
 
   describe "#expect_any_instance_of(...).to receive" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        expect_any_instance_of(Object).to receive(:foo)
-      end
+    include_examples "fails in a before(:all) block"
+
+    def use_rspec_mocks
+      expect_any_instance_of(Object).to receive(:foo)
     end
   end
 
   describe "#allow_any_instance_of(...).to receive" do
-    include_examples "fails in a before(:all) block" do
-      def use_rspec_mocks
-        allow_any_instance_of(Object).to receive(:foo)
-      end
+    include_examples "fails in a before(:all) block"
+
+    def use_rspec_mocks
+      allow_any_instance_of(Object).to receive(:foo)
     end
   end
 end

--- a/rspec-mocks/spec/rspec/mocks/matchers/have_received_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/matchers/have_received_spec.rb
@@ -673,12 +673,12 @@ module RSpec
     end
 
     RSpec.describe Matchers::HaveReceived, "when used in a context that has rspec-mocks and rspec-expectations available" do
-      include_examples Matchers::HaveReceived do
-        # Override `fail_including` for this context, since `have_received` is a normal
-        # rspec-expectations matcher, the error class is different.
-        def fail_including(*snippets)
-          raise_error(RSpec::Expectations::ExpectationNotMetError, a_string_including(*snippets))
-        end
+      include_examples Matchers::HaveReceived
+
+      # Override `fail_including` for this context, since `have_received` is a normal
+      # rspec-expectations matcher, the error class is different.
+      def fail_including(*snippets)
+        raise_error(RSpec::Expectations::ExpectationNotMetError, a_string_including(*snippets))
       end
     end
 


### PR DESCRIPTION
When you include parameterized examples in the current context multiple times, you may override previous method definitions and last declaration wins.

Fixes #230

Targets 4.0-pre
For 3.99, there's #243
