### PR TITLE
[rspec-expectations] Remove deprecated warn_about_potential_false_positives

### DIFF
--- a/rspec-expectations/Changelog.md
+++ b/rspec-expectations/Changelog.md
@@ -16,6 +16,8 @@ Breaking Changes:
 * Remove deprecated `StartAndEndWith` matcher base class. (Phil Pirozhkov, rspec/rspec-expectations#1288)
 * Raise `ArgumentError` when a `nil` is passed as the first argument to `raise_error`.
   (Phil Pirozhkov, rspec/rspec-expectations#1389)
+* Remove deprecated `RSpec::Expectations::Config#warn_about_potential_false_positives`.
+  (Anthony Clark, Phil Pirozhkov, rspec/rspec#260)
 
 Enhancements:
 

--- a/rspec-expectations/lib/rspec/expectations/configuration.rb
+++ b/rspec-expectations/lib/rspec/expectations/configuration.rb
@@ -93,25 +93,6 @@ module RSpec
         end
       end
 
-      # Configures whether RSpec will warn about matcher use which will
-      # potentially cause false positives in tests.
-      #
-      # @param [Boolean] boolean
-      # @deprecated Use {#on_potential_false_positives=} which supports :warn, :raise, and :nothing behaviors
-      def warn_about_potential_false_positives=(boolean)
-        RSpec.deprecate(
-          "warn_about_potential_false_positives=",
-          :replacement => "`on_potential_false_positives=` which supports :warn, :raise, and :nothing behaviors"
-        )
-        if boolean
-          self.on_potential_false_positives = :warn
-        elsif warn_about_potential_false_positives?
-          self.on_potential_false_positives = :nothing
-        else
-          # no-op, handler is something else
-        end
-      end
-
       # Configures what RSpec will do about matcher use which would potentially cause
       # false positives in tests. Defaults to `:warn` since this is generally the desired behavior,
       # but can also be set to `:raise` or `:nothing`.
@@ -149,18 +130,6 @@ module RSpec
 
       def strict_predicate_matchers?
         @strict_predicate_matchers
-      end
-
-      # Indicates whether RSpec will warn about matcher use which will
-      # potentially cause false positives in tests, generally you want to
-      # avoid such scenarios so this defaults to `true`.
-      # @deprecated Use {#on_potential_false_positives} which supports :warn, :raise, and :nothing behaviors
-      def warn_about_potential_false_positives?
-        RSpec.deprecate(
-          "warn_about_potential_false_positives?",
-          :replacement => "`on_potential_false_positives` which supports :warn, :raise, and :nothing behaviors"
-        )
-        on_potential_false_positives == :warn
       end
 
       # @private

--- a/rspec-expectations/spec/rspec/expectations/configuration_spec.rb
+++ b/rspec-expectations/spec/rspec/expectations/configuration_spec.rb
@@ -85,50 +85,6 @@ module RSpec
         end
       end
 
-      describe "#warn_about_potential_false_positives?" do
-        it "is deprecated" do
-          expect(RSpec).to receive(:deprecate).with(
-            "warn_about_potential_false_positives?",
-            :replacement => "`on_potential_false_positives` which supports :warn, :raise, and :nothing behaviors"
-          )
-          config.warn_about_potential_false_positives?
-        end
-
-        it "returns true when on_potential_false_positives is :warn" do
-          config.on_potential_false_positives = :warn
-          expect(RSpec).to receive(:deprecate)
-          expect(config.warn_about_potential_false_positives?).to be true
-        end
-
-        it "returns false when on_potential_false_positives is not :warn" do
-          config.on_potential_false_positives = :nothing
-          expect(RSpec).to receive(:deprecate)
-          expect(config.warn_about_potential_false_positives?).to be false
-        end
-      end
-
-      describe "#warn_about_potential_false_positives=" do
-        it "is deprecated" do
-          expect(RSpec).to receive(:deprecate).with(
-            "warn_about_potential_false_positives=",
-            :replacement => "`on_potential_false_positives=` which supports :warn, :raise, and :nothing behaviors"
-          ).at_least(:once)
-          config.warn_about_potential_false_positives = true
-        end
-
-        it "sets on_potential_false_positives to :warn when true" do
-          allow(RSpec).to receive(:deprecate)
-          config.warn_about_potential_false_positives = true
-          expect(config.on_potential_false_positives).to eq(:warn)
-        end
-
-        it "sets on_potential_false_positives to :nothing when false" do
-          allow(RSpec).to receive(:deprecate)
-          config.warn_about_potential_false_positives = false
-          expect(config.on_potential_false_positives).to eq(:nothing)
-        end
-      end
-
       describe '#on_potential_false_positives' do
         it 'is set to :warn by default' do
           expect(config.on_potential_false_positives).to eq :warn

--- a/rspec-expectations/spec/rspec/matchers/built_in/raise_error_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/raise_error_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe "expect { ... }.to raise_error" do
     end
   end
 
-  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
-    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+  it "can suppress the warning when configured to do so", :potential_false_positives do
+    RSpec::Expectations.configuration.on_potential_false_positives = :nothing
     expect_no_warnings
     expect { raise }.to raise_error
   end
 
-  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
+  it "can suppress the warning when configured to do so", :potential_false_positives do
     RSpec::Expectations.configuration.on_potential_false_positives = :nothing
     expect_no_warnings
     expect { raise }.to raise_error
@@ -186,8 +186,8 @@ RSpec.describe "expect { ... }.not_to raise_error" do
       expect { "bees" }.not_to raise_error(RuntimeError)
     end
 
-    it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
-      RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+    it "can suppress the warning when configured to do so", :potential_false_positives do
+      RSpec::Expectations.configuration.on_potential_false_positives = :nothing
       expect_no_warnings
       expect { "bees" }.not_to raise_error(RuntimeError)
     end
@@ -295,28 +295,28 @@ RSpec.describe "expect { ... }.to raise_error.with_message(message)" do
 end
 
 RSpec.describe "expect { ... }.not_to raise_error('message')" do
-  it "issues a warning when configured to do so", :warn_about_potential_false_positives do
-    RSpec::Expectations.configuration.warn_about_potential_false_positives = true
+  it "issues a warning when configured to do so", :potential_false_positives do
+    RSpec::Expectations.configuration.on_potential_false_positives = :warn
     expect_warning_with_call_site __FILE__, __LINE__+1, /not_to raise_error\(message\)` risks false positives/
     expect { raise 'blarg' }.not_to raise_error('blah')
   end
 
-  it "supresses the warning when configured to do so", :warn_about_potential_false_positives do
-    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+  it "suppresses the warning when configured to do so", :potential_false_positives do
+    RSpec::Expectations.configuration.on_potential_false_positives = :nothing
     expect_no_warnings
     expect { raise 'blarg' }.not_to raise_error('blah')
   end
 end
 
 RSpec.describe "expect { ... }.not_to raise_error(/message/)" do
-  it "issues a warning when configured to do so", :warn_about_potential_false_positives do
-    RSpec::Expectations.configuration.warn_about_potential_false_positives = true
+  it "issues a warning when configured to do so", :potential_false_positives do
+    RSpec::Expectations.configuration.on_potential_false_positives = :warn
     expect_warning_with_call_site __FILE__, __LINE__+1, /not_to raise_error\(message\)` risks false positives/
     expect { raise 'blarg' }.not_to raise_error(/blah/)
   end
 
-  it "supresses the warning when configured to do so", :warn_about_potential_false_positives do
-    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+  it "suppresses the warning when configured to do so", :potential_false_positives do
+    RSpec::Expectations.configuration.on_potential_false_positives = :nothing
     expect_no_warnings
     expect { raise 'blarg' }.not_to raise_error(/blah/)
   end
@@ -352,8 +352,8 @@ RSpec.describe "expect { ... }.not_to raise_error(NamedError)" do
     expect {}.not_to raise_error(NameError)
   end
 
-  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
-    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+  it "can suppress the warning when configured to do so", :potential_false_positives do
+    RSpec::Expectations.configuration.on_potential_false_positives = :nothing
     expect_no_warnings
     expect {}.not_to raise_error(NameError)
   end
@@ -389,8 +389,8 @@ RSpec.describe "expect { ... }.not_to raise_error(NamedError, error_message) wit
     expect {}.not_to raise_error(RuntimeError, "example message")
   end
 
-  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
-    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+  it "can suppress the warning when configured to do so", :potential_false_positives do
+    RSpec::Expectations.configuration.on_potential_false_positives = :nothing
     expect_no_warnings
     expect {}.not_to raise_error(RuntimeError, "example message")
   end
@@ -427,8 +427,8 @@ RSpec.describe "expect { ... }.not_to raise_error(NamedError, error_message) wit
     expect {}.not_to raise_error(RuntimeError, /ample mess/)
   end
 
-  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
-    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+  it "can suppress the warning when configured to do so", :potential_false_positives do
+    RSpec::Expectations.configuration.on_potential_false_positives = :nothing
     expect_no_warnings
     expect {}.not_to raise_error(RuntimeError, /ample mess/)
   end
@@ -513,8 +513,8 @@ RSpec.describe "expect { ... }.not_to raise_error(NamedError, error_message) { |
     expect {}.not_to raise_error(RuntimeError, "example message") { |err| }
   end
 
-  it "can supresses the warning when configured to do so", :warn_about_potential_false_positives do
-    RSpec::Expectations.configuration.warn_about_potential_false_positives = false
+  it "can suppress the warning when configured to do so", :potential_false_positives do
+    RSpec::Expectations.configuration.on_potential_false_positives = :nothing
     expect_no_warnings
     expect {}.not_to raise_error(RuntimeError, "example message") { |err| }
   end

--- a/rspec-expectations/spec/spec_helper.rb
+++ b/rspec-expectations/spec/spec_helper.rb
@@ -65,13 +65,13 @@ RSpec.configure do |config|
   config.project_source_dirs -= ["lib"]
 end
 
-RSpec.shared_context "with warn_about_potential_false_positives set to false" do
-  original_value = RSpec::Expectations.configuration.warn_about_potential_false_positives?
+RSpec.shared_context "with on_potential_false_positives set to nothing" do
+  original_value = RSpec::Expectations.configuration.on_potential_false_positives
 
-  after(:context)  { RSpec::Expectations.configuration.warn_about_potential_false_positives = original_value }
+  after(:context)  { RSpec::Expectations.configuration.on_potential_false_positives = original_value }
 end
 
-RSpec.configuration.include_context "with warn_about_potential_false_positives set to false", :warn_about_potential_false_positives
+RSpec.configuration.include_context "with on_potential_false_positives set to nothing", :potential_false_positives
 
 RSpec.shared_context "with modified configuration" do
   around do |example|


### PR DESCRIPTION
Originally deprecated in #199

Deprecated in 3.99 in #124
