### PR TITLE
Refactor coverage setup to make sure rspec-core shares config

### DIFF
--- a/rspec-core/script/rspec_with_simplecov
+++ b/rspec-core/script/rspec_with_simplecov
@@ -11,29 +11,15 @@ $0 = "rspec"
 $:.unshift File.expand_path '../../../bundle', __FILE__
 
 require 'bundler/setup'
+require 'rspec/support/spec/coverage'
 
 # To use simplecov while running rspec-core's test suite, we must
 # load simplecov _before_ loading any of rspec-core's files.
 # So, this executable exists purely as a wrapper script that
 # first loads simplecov, and then loads rspec.
-begin
-  # Simplecov emits some ruby warnings when loaded, so silence them.
-  old_verbose, $VERBOSE = $VERBOSE, false
-
-  unless ENV['NO_COVERAGE']
-    require 'simplecov'
-
-    SimpleCov.start do
-      root File.expand_path("../..", __FILE__)
-      add_filter %r{/bundle/}
-      add_filter %r{/tmp/}
-      add_filter %r{/spec/}
-      minimum_coverage(100)
-    end
-  end
-rescue LoadError # rubocop:disable Lint/SuppressedException
-ensure
-  $VERBOSE = old_verbose
+RSpec::Support::Spec::Coverage.setup do
+  root File.expand_path("../..", __FILE__)
+  minimum_coverage 100
 end
 
 load File.expand_path("../../exe/rspec", __FILE__)

--- a/rspec-expectations/spec/spec_helper.rb
+++ b/rspec-expectations/spec/spec_helper.rb
@@ -3,7 +3,7 @@
 require 'rspec/support/spec'
 require 'rspec/support/spec/in_sub_process'
 
-RSpec::Support::Spec.setup_simplecov do
+RSpec::Support::Spec::Coverage.setup do
   minimum_coverage 100
 end
 

--- a/rspec-mocks/spec/spec_helper.rb
+++ b/rspec-mocks/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'rspec/support/spec'
 
-RSpec::Support::Spec.setup_simplecov do
+RSpec::Support::Spec::Coverage.setup do
   minimum_coverage 98
 end
 

--- a/rspec-support/lib/rspec/support/spec/coverage.rb
+++ b/rspec-support/lib/rspec/support/spec/coverage.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'rspec/support'
+
+RSpec::Support.require_rspec_support "ruby_features"
+
+module RSpec
+  module Support
+    module Spec
+      module Coverage
+        def self.setup(&block)
+          # Simplecov emits some ruby warnings when loaded, so silence them.
+          old_verbose, $VERBOSE = $VERBOSE, false
+
+          return if ENV['NO_COVERAGE']
+          return if RUBY_ENGINE != 'ruby' || RSpec::Support::OS.windows?
+
+          # Don't load it when we're running a single isolated
+          # test file rather than the whole suite.
+          #
+          # The extra defined check is so that script/rspec_with_simplecov can reuse
+          # this logic.
+          return if defined?(RSpec.configuration) && RSpec.configuration.files_to_run.one?
+
+          require 'simplecov'
+          start(&block)
+        rescue LoadError
+          warn "Simplecov could not be loaded"
+        ensure
+          $VERBOSE = old_verbose
+        end
+
+        def self.start(&block)
+          SimpleCov.start do
+            add_filter "bundle/"
+            add_filter "tmp/"
+            add_filter do |source_file|
+              # Filter out `spec` directory except when it is under `lib`
+              # (as is the case in rspec-support)
+              source_file.filename.include?('/spec/') && !source_file.filename.include?('/lib/')
+            end
+
+            instance_eval(&block) if block
+          end
+        end
+        private_class_method :start
+      end
+    end
+  end
+end

--- a/rspec-support/spec/spec_helper.rb
+++ b/rspec-support/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'rspec/support/spec'
-RSpec::Support::Spec.setup_simplecov
+RSpec::Support::Spec::Coverage.setup
 
 RSpec::Matchers.define_negated_matcher :avoid_raising_errors, :raise_error
 RSpec::Matchers.define_negated_matcher :avoid_changing, :change


### PR DESCRIPTION
Refactor coverage setup to make sure rspec-core shares config, previously its script skipped config checks like skipping on JRuby / Windows by using its own config.