### PR TITLE
Avoid infinite loop when classes mock #is_a?

### DIFF
--- a/rspec-mocks/Changelog.md
+++ b/rspec-mocks/Changelog.md
@@ -13,6 +13,10 @@ Breaking Changes:
   (Phil Pirozhkov, rspec/rspec-mocks#1410)
 * Fix stubbing of prepended-only methods. (Lin Jen-Shin, rspec/rspec-mocks#1218)
 
+Bug Fixes:
+
+* Work around possible infinite loop when stubbing `is_a?`. (Erin Paget, rspec/rspec#265)
+
 ### 3.13.5 / 2025-05-27
 [Full Changelog](https://github.com/rspec/rspec/compare/rspec-mocks-v3.13.4...rspec-mocks-v3.13.5)
 

--- a/rspec-mocks/lib/rspec/mocks/proxy.rb
+++ b/rspec-mocks/lib/rspec/mocks/proxy.rb
@@ -32,7 +32,7 @@ module RSpec
 
       # @private
       def ensure_can_be_proxied!(object)
-        return unless object.is_a?(Symbol)
+        return unless Symbol === object
 
         msg = "Cannot proxy frozen objects. Symbols such as #{object} cannot be mocked or stubbed."
         raise ArgumentError, msg


### PR DESCRIPTION
Fixes #73.

The `Proxy` class in `rspec-mocks` uses `is_a?(Symbol)` to determine whether we can safely stub methods on a given receiver. This can cause an infinite loop when a class explicitly overrides `#is_a?`.

Now, when a class stubs `#is_a?`, we'll use the original, un-stubbed version of `#is_a?` to perform this eligibility check.