### PR TITLE
Fix source_code_uri for the `rspec` gem

### DIFF
--- a/rspec/rspec.gemspec
+++ b/rspec/rspec.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
     'rubygems_mfa_required' => 'true',
-    'source_code_uri' => "https://github.com/rspec/rspec/blob/rspec-metagem-v#{s.version}/rspec"
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/rspec-v#{s.version}/rspec"
   }
 
   s.files            = `git ls-files -- lib/*`.split("\n")


### PR DESCRIPTION
It seems “rspec-metagem” does not exist anymore, but which of these should the `source_code_uri` link to?

- https://github.com/rspec/rspec/blob/rspec-v3.13.1/rspec
- https://github.com/rspec/rspec
