### PR TITLE
Fix predicate function scripts

### DIFF
--- a/script/predicate_functions.sh
+++ b/script/predicate_functions.sh
@@ -1,10 +1,10 @@
 function is_mri {
-  if ruby -e "RUBY_ENGINE == 'ruby'"; then
+  if ruby -e "exit(RUBY_ENGINE == 'ruby')"; then
     # RUBY_ENGINE only returns 'ruby' on MRI.
     return 0
   else
     return 1
-  fi;
+  fi
 }
 
 function is_ruby_31_plus {


### PR DESCRIPTION
`ruby -e "RUBY_ENGINE == 'ruby'"` will never return false, you need to wrap in `exit` to get the proper exit code.

~And when we already have the correct exit code, there is no need to wrap the condition with `if` and `return`.~
