### PR TITLE
Pin bundler to 2.x

### DIFF
--- a/script/bundle
+++ b/script/bundle
@@ -4,7 +4,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/functions.sh
 
 echo "bundle install --standalone"
-if is_ruby_4_plus; then
+if is_ruby_32_plus; then
   bundle _2.7.2_ install --standalone
 else
   bundle install --standalone

--- a/script/predicate_functions.sh
+++ b/script/predicate_functions.sh
@@ -15,6 +15,14 @@ function is_ruby_31_plus {
   fi
 }
 
+function is_ruby_32_plus {
+  if ruby -e "exit(RUBY_VERSION.to_f >= 3.2)"; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 function is_ruby_4_plus {
   if ruby -e "exit(RUBY_VERSION.to_f >= 4)"; then
     return 0

--- a/script/update_rubygems_and_install_bundler
+++ b/script/update_rubygems_and_install_bundler
@@ -3,8 +3,8 @@ set -e
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 source $SCRIPT_DIR/functions.sh
 
-if is_ruby_4_plus; then
-  echo "Downgrading bundler to 2.7.2"
+if is_ruby_32_plus; then
+  echo "Pinning bundler to 2.7.2"
   yes | gem update --no-document --system
   yes | gem install bundler:2.7.2
 elif is_ruby_31_plus; then


### PR DESCRIPTION
Bundler 4.0.0 is not currently supported by aruba and is now general release for all Rubies > 3.2