### PR TITLE
Avoid building full backtrace when we only care about the direct caller

### DIFF
--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -326,7 +326,7 @@ module RSpec
           # Pass :caller so the :location metadata is set properly.
           # Otherwise, it'll be set to the next line because that's
           # the block's source_location.
-          group = example_group("#{report_label} #{name}", :caller => (the_caller = caller)) do
+          group = example_group("#{report_label} #{name}", :caller => (the_caller = caller(1, 1))) do
             find_and_eval_shared("examples", name, the_caller.first, *args, &customization_block)
           end
           group.metadata[:shared_group_name] = name
@@ -347,7 +347,7 @@ module RSpec
       def self.include_context(name, *args)
         issue_block_inclusion_error!("include_context") if block_given?
 
-        find_and_eval_shared("context", name, caller.first, *args)
+        find_and_eval_shared("context", name, caller(1, 1).first, *args)
       end
 
       # Includes shared content mapped to `name` directly in the group in which
@@ -359,7 +359,7 @@ module RSpec
       def self.include_examples(name, *args)
         issue_block_inclusion_error!("include_examples") if block_given?
 
-        find_and_eval_shared("examples", name, caller.first, *args)
+        find_and_eval_shared("examples", name, caller(1, 1).first, *args)
       end
 
       # Clear memoized values when adding/removing examples

--- a/rspec-core/spec/support/aruba_support.rb
+++ b/rspec-core/spec/support/aruba_support.rb
@@ -9,7 +9,7 @@ if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version == "9.1.17.
         relative_arg = relative_arg.to_path if relative_arg.respond_to? :to_path
         relative_arg = JRuby::Type.convert_to_str(relative_arg)
 
-        caller.first.rindex(/:\d+:in /)
+        caller(1, 1).first.rindex(/:\d+:in /)
         file = $` # just the filename
         raise LoadError, "cannot infer basepath" if /\A\((.*)\)/ =~ file # eval etc.
 

--- a/rspec-core/spec/support/formatter_support.rb
+++ b/rspec-core/spec/support/formatter_support.rb
@@ -5,7 +5,7 @@ module FormatterSupport
     return output unless options.fetch(:normalize_output, true)
     output = normalize_durations(output)
 
-    caller_line = RSpec::Core::Metadata.relative_path(caller.first)
+    caller_line = RSpec::Core::Metadata.relative_path(caller(1, 1).first)
     output.lines.reject do |line|
       # remove the direct caller as that line is different for the summary output backtraces
       line.include?(caller_line) ||


### PR DESCRIPTION
`caller` without arguments build the full bakctrace, so it's performance is `O(n)` based on how deep the call stack is, and it can get very expensive.

Profiling of our app shows our test suite spends a bit of 1% of its runtime there.