### PR TITLE
build: fix & enable JRuby 10 tests

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -56,7 +56,8 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - jruby-9.4.9.0
+          - jruby-9.4
+          - jruby-10.0
       fail-fast: false
     continue-on-error: false
     defaults:

--- a/rspec-core/spec/integration/failed_line_detection_spec.rb
+++ b/rspec-core/spec/integration/failed_line_detection_spec.rb
@@ -83,11 +83,6 @@ RSpec.describe 'Failed line detection' do
                            and include("raise 'AppMod failure'").
                            and include("raise 'SpecSupport failure'")
 
-    if RUBY_VERSION.to_f > 3.3
-      # Ruby 3.4 seems to print the calling function and we've not configured it otherwise
-      expect(last_cmd_stdout).to include("AppMod.trigger_failure")
-    end
-
     write_file "spec/change_config_spec.rb", "
       require './app/app_mod'
 

--- a/rspec-core/spec/rspec/core_spec.rb
+++ b/rspec-core/spec/rspec/core_spec.rb
@@ -71,11 +71,6 @@ RSpec.describe RSpec do
       # Prevent rspec/autorun from trying to run RSpec.
       disable_autorun_code
     ], :skip_spec_files => %r{/fake_libs/}, :allowed_loaded_feature_regexps => allowed_loaded_features do
-    if RSpec::Support::Ruby.jruby? && JRUBY_VERSION =~ /9\.1\.17\.0/
-      before(:example, :description => /spec files/) do
-        pending "JRuby 9.1.17.0 generates unrelated warnings"
-      end
-    end
   end
 
   describe ".configuration" do

--- a/rspec-expectations/spec/rspec/expectations/failure_aggregator_spec.rb
+++ b/rspec-expectations/spec/rspec/expectations/failure_aggregator_spec.rb
@@ -69,7 +69,7 @@ module RSpec::Expectations
 
     it 'ensures the sub-failure backtraces are in a form that overlaps with the aggregated failure backtrace' do
       if RSpec::Support::Ruby.jruby?
-        pending "This is broken on 9.2.x.x" unless RSpec::Support::Ruby.jruby_version < '9.2.0.0'
+        pending "This is broken on JRuby 9.2+"
       end
       # On JRuby, `caller` and `raise` backtraces can differ significantly --
       # I've seen one include java frames but not the other -- and as a result,
@@ -463,6 +463,10 @@ module RSpec::Expectations
       elsif RSpec::Support::Ruby.mri? || RSpec::Support::Ruby.truffleruby?
         def exception_complement(block_levels)
           ":in `block (#{block_levels} levels) in <module:Expectations>'"
+        end
+      elsif RUBY_VERSION.to_f > 3.3
+        def exception_complement(block_levels)
+          ":in 'block in Expectations'"
         end
       else
         def exception_complement(block_levels)

--- a/rspec-mocks/spec/rspec/mocks/partial_double_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/partial_double_spec.rb
@@ -633,10 +633,6 @@ module RSpec
 
         context "on a class with a private `new`" do
           it 'uses the method signature from `#initialize` for arg verification' do
-            if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version < '9.2.1.0'
-              pending "Failing on JRuby due to https://github.com/jruby/jruby/issues/2565"
-            end
-
             subclass = Class.new(klass) do
               private_class_method :new
             end

--- a/rspec-mocks/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/verifying_doubles/class_double_with_class_loaded_spec.rb
@@ -165,10 +165,6 @@ module RSpec
 
         context "on a class with a private `new`" do
           it 'uses the method signature from `#initialize` for arg verification' do
-            if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version < '9.2.1.0'
-              pending "Failing on JRuby due to https://github.com/jruby/jruby/issues/2565"
-            end
-
             klass = Class.new(LoadedClass) do
               private_class_method :new
             end

--- a/rspec-support/spec/rspec/support/ruby_features_spec.rb
+++ b/rspec-support/spec/rspec/support/ruby_features_spec.rb
@@ -124,9 +124,6 @@ module RSpec
         end
 
         it 'returns whether Ripper is correctly implemented in the current environment' do
-          if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version.between?('9.0.0.0', '9.2.1.0')
-            pending "Ripper is not supported on JRuby 9.1.17.0 despite this tests claims"
-          end
           expect(RubyFeatures.ripper_supported?).to eq(ripper_is_implemented? && ripper_works_correctly?)
         end
 


### PR DESCRIPTION
- Enables tests for JRuby 10
  - cleans up old conditions for JRuby 9.1/9.2 - all of these versions are thoroughly EOL now. 9.4 will go into maintenance only mode soon.
- ~~Currently the Windows tests are failing because setup-ruby [now hard forces any `bundler-version`](https://github.com/ruby/setup-ruby/releases/tag/v1.278.0) specified in the action. We shouldn't need to set this to a fixed version now, I believe.~~


~~The current way the actions are written aren't very PR/contributor friendly as they always run off their rspec/rspec@main versions rather than those on the current branch/fork, so the test run here won't actually show the impact.~~

~~Nevertheless, you can see the results at https://github.com/chadlwilson/rspec/actions/runs/20961999317 which has a [temporary throwaway commit](https://github.com/chadlwilson/rspec/pull/1/changes/f536ff0c0bb854eb0c277bcb2a8efe32f0b1b8b1) to run the actions from my fork+branch.~~