### PR TITLE
Remove constraint to run main from actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,31 +14,31 @@ permissions:
 
 jobs:
   docs:
-    uses: rspec/rspec/.github/workflows/documentation_coverage.yml@main
+    uses: ./.github/workflows/documentation_coverage.yml
 
   rubocop:
-    uses: rspec/rspec/.github/workflows/rubocop.yml@main
+    uses: ./.github/workflows/rubocop.yml
 
   core:
-    uses: rspec/rspec/.github/workflows/rspec.yml@main
+    uses: ./.github/workflows/rspec.yml
     with:
       library: 'rspec-core'
       rspec_version: '= 4.0.0.pre'
 
   mocks:
-    uses: rspec/rspec/.github/workflows/rspec.yml@main
+    uses: ./.github/workflows/rspec.yml
     with:
       library: 'rspec-mocks'
       rspec_version: '= 4.0.0.pre'
 
   expectations:
-    uses: rspec/rspec/.github/workflows/rspec.yml@main
+    uses: ./.github/workflows/rspec.yml
     with:
       library: 'rspec-expectations'
       rspec_version: '= 4.0.0.pre'
 
   support:
-    uses: rspec/rspec/.github/workflows/rspec.yml@main
+    uses: ./.github/workflows/rspec.yml
     with:
       library: 'rspec-support'
       rspec_version: '= 4.0.0.pre'

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -83,7 +83,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ruby/setup-ruby@v1
         with:
-          bundler: '2.2.22'
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - run: choco install ansicon


### PR DESCRIPTION
Feedback from #292 points out its awkward to modify actions with the main constraint, I agree its annoying to pin versions to branches, however I'm pretty certain it doesn't work as repo actions without this constraint, but lets try...

Narrator: It did indeed not work but...

It seems we can just reference the files directly, I'm not sure why this wasn't how I originally build this so lets switch to it and include the windows fix from #292.