### PR TITLE
[rspec-core] build: fix file load errors spec on Ruby 3.2.10

### DIFF
--- a/rspec-core/spec/integration/spec_file_load_errors_spec.rb
+++ b/rspec-core/spec/integration/spec_file_load_errors_spec.rb
@@ -216,29 +216,17 @@ RSpec.describe 'Spec file load errors' do
             While loading ./broken_file a `raise SyntaxError` occurred, RSpec will now quit.
           EOS
 
-          # There was a fix was backported in 3.2.3, but syntax changed in 3.4.0 in terms of line endings
-          if RUBY_VERSION > '3.2.2'
-            expect(formatted_output.gsub("\n\n", "\n")).to include unindent(<<-EOS)
-            SyntaxError:
-              --> ./tmp/aruba/broken_file.rb
-              Unmatched keyword, missing `end' ?
-                1  class WorkInProgress
-              > 2    def initialize(arg)
-                3    def foo
-                4    end
-                5  end
-            EOS
-          else
-            expect(formatted_output).to include unindent(<<-EOS)
-            SyntaxError:
-              --> ./tmp/aruba/broken_file.rb
-              Unmatched keyword, missing `end' ?
-                1  class WorkInProgress
-              > 2    def initialize(arg)
-                4    end
-                5  end
-            EOS
-          end
+          # Extra blank lines were added in 3.4.0; strip out for compat with 3.2/3.3
+          expect(formatted_output.gsub("\n\n", "\n")).to include unindent(<<-EOS)
+          SyntaxError:
+            --> ./tmp/aruba/broken_file.rb
+            Unmatched keyword, missing `end' ?
+              1  class WorkInProgress
+            > 2    def initialize(arg)
+              3    def foo
+              4    end
+              5  end
+          EOS
           expect(formatted_output).to include %r{./tmp/aruba/broken_file.rb:\d: syntax error}
 
           expect(formatted_output).to include unindent(<<-EOS)


### PR DESCRIPTION
The recent release of Ruby `3.2.10` broke a string-based version comparison in the CRuby tests on 3.2.x.

This branch was added only to support Ruby `3.2.0` -> `3.2.2` (inclusive), but since `3.2.3` was patched over 2 years ago from 18 Jan 2024 onwards and we are up to `3.2.10`, I think it should be fine to remove the special case now. The specific example only runs on `3.2.0` onwards as it relates to the newer syntax-suggest functionality in 3.2.

The blank line normalisation is still needed, as this was only changed in Ruby 3.4.x onwards; so adjusted the comment accordingly.