### PR TITLE
tests: fix StdErrSplitter spec on JRuby and console specs on Apple Silicon

### DIFF
--- a/rspec-core/spec/spec_helper.rb
+++ b/rspec-core/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'rspec/support/spec'
+# Preload io/console on MacOS JRuby to avoid warnings later due to https://github.com/jruby/jruby/issues/8271
+require 'io/console' if RSpec::Support::Ruby.jruby? && RSpec::Support::OS.apple_silicon?
 
 $rspec_core_without_stderr_monkey_patch = RSpec::Core::Configuration.new
 

--- a/rspec-expectations/spec/spec_helper.rb
+++ b/rspec-expectations/spec/spec_helper.rb
@@ -2,6 +2,8 @@
 
 require 'rspec/support/spec'
 require 'rspec/support/spec/in_sub_process'
+# Preload io/console on MacOS JRuby to avoid warnings later due to https://github.com/jruby/jruby/issues/8271
+require 'io/console' if RSpec::Support::Ruby.jruby? && RSpec::Support::OS.apple_silicon?
 
 RSpec::Support::Spec::Coverage.setup do
   minimum_coverage 100

--- a/rspec-mocks/spec/spec_helper.rb
+++ b/rspec-mocks/spec/spec_helper.rb
@@ -1,4 +1,6 @@
 require 'rspec/support/spec'
+# Preload io/console on MacOS JRuby to avoid warnings later due to https://github.com/jruby/jruby/issues/8271
+require 'io/console' if RSpec::Support::Ruby.jruby? && RSpec::Support::OS.apple_silicon?
 
 RSpec::Support::Spec::Coverage.setup do
   minimum_coverage 98

--- a/rspec-support/lib/rspec/support/ruby_features.rb
+++ b/rspec-support/lib/rspec/support/ruby_features.rb
@@ -18,6 +18,14 @@ module RSpec
       def windows_file_path?
         ::File::ALT_SEPARATOR == '\\'
       end
+
+      def macos?
+        !!(RbConfig::CONFIG['host_os']&.downcase =~ /darwin/)
+      end
+
+      def apple_silicon?
+        macos? && !!(RbConfig::CONFIG['host_cpu'] =~ /arm64|aarch64/)
+      end
     end
 
     # @api private

--- a/rspec-support/lib/rspec/support/spec/library_wide_checks.rb
+++ b/rspec-support/lib/rspec/support/spec/library_wide_checks.rb
@@ -112,6 +112,10 @@ RSpec.shared_examples_for "library wide checks" do |lib, options|
   end
 
   it "issues no warnings when the spec files are loaded", :slow do
+    if RSpec::Support::Ruby.jruby? && RSpec::Support::OS.apple_silicon?
+      pending "JRuby on MacOS Apple Silicon outputs warnings due to lack of native console (and stty) support per https://github.com/jruby/jruby/issues/8271"
+    end
+
     expect(spec_file_results).to have_successful_no_warnings_output
   end
 

--- a/rspec-support/spec/rspec/support/ruby_features_spec.rb
+++ b/rspec-support/spec/rspec/support/ruby_features_spec.rb
@@ -33,6 +33,43 @@ module RSpec
           expect(OS).to_not be_windows_file_path
         end
       end
+
+      describe ".macos?" do
+        %w[darwin Darwin].each do |fragment|
+          it "returns true when host os is #{fragment}" do
+            stub_const("RbConfig::CONFIG", 'host_os' => fragment)
+            expect(OS.macos?).to be true
+          end
+        end
+
+        %w[cygwin mswin mingw bccwin wince emx linux].each do |fragment|
+          it "returns false when host os is #{fragment}" do
+            stub_const("RbConfig::CONFIG", 'host_os' => fragment)
+            expect(OS.macos?).to be false
+          end
+        end
+      end
+
+      describe ".apple_silicon?" do
+        %w[arm64 aarch64].each do |fragment|
+          it "returns true when host cpu is #{fragment}" do
+            stub_const("RbConfig::CONFIG", 'host_os' => 'darwin', 'host_cpu' => fragment)
+            expect(OS.apple_silicon?).to be true
+          end
+        end
+
+        %w[i386 x86 x86_64 amd64].each do |fragment|
+          it "returns false when host cpu is #{fragment}" do
+            stub_const("RbConfig::CONFIG", 'host_os' => 'darwin', 'host_cpu' => fragment)
+            expect(OS.apple_silicon?).to be false
+          end
+        end
+
+        it "returns false when host os is not darwin" do
+          stub_const("RbConfig::CONFIG", 'host_os' => 'linux', 'host_cpu' => 'arm64')
+          expect(OS.apple_silicon?).to be false
+        end
+      end
     end
 
     RSpec.describe Ruby do

--- a/rspec-support/spec/rspec/support/spec/stderr_splitter_spec.rb
+++ b/rspec-support/spec/rspec/support/spec/stderr_splitter_spec.rb
@@ -121,11 +121,11 @@ RSpec.describe 'RSpec::Support::StdErrSplitter' do
   # Detecting STDERR in a way that doesn't use a reference
   if STDERR.respond_to?(:path)
     def be_stderr
-      have_attributes({:path => '<STDERR>'})
+      have_attributes(:path => '<STDERR>')
     end
   elsif STDERR.inspect =~ /STDERR/
     def be_stderr
-      have_attributes({:inspect => "#<IO:<STDERR>>"})
+      have_attributes(:inspect => "#<IO:<STDERR>>")
     end
   else
     def be_stderr

--- a/rspec-support/spec/rspec/support/spec/stderr_splitter_spec.rb
+++ b/rspec-support/spec/rspec/support/spec/stderr_splitter_spec.rb
@@ -102,26 +102,34 @@ RSpec.describe 'RSpec::Support::StdErrSplitter' do
 
   # This spec replicates what matchers do when capturing stderr, e.g `to_stderr_from_any_process`
   it 'is able to restore the stream from a cloned StdErrSplitter' do
-    if RSpec::Support::Ruby.jruby?
-      skip """
-      This spec is currently unsupported on JRuby on CI due to tempfiles not being
-      a file, this situtation was discussed here https://github.com/rspec/rspec-support/pull/598#issuecomment-2200779633
-      """
-    end
-
     cloned = splitter.clone
-    expect(splitter.to_io).not_to be_a(File)
+    expect(splitter.to_io).to be_stderr
 
     tempfile = Tempfile.new("foo")
     begin
       splitter.reopen(tempfile)
-      expect(splitter.to_io).to be_a(File)
+      expect(splitter.to_io).to_not be_stderr
     ensure
       splitter.reopen(cloned)
       tempfile.close
       tempfile.unlink
     end
     # This is the important part of the test that would fail without proper cloning hygeine
-    expect(splitter.to_io).not_to be_a(File)
+    expect(splitter.to_io).to be_stderr
+  end
+
+  # Detecting STDERR in a way that doesn't use a reference
+  if STDERR.respond_to?(:path)
+    def be_stderr
+      have_attributes({:path => '<STDERR>'})
+    end
+  elsif STDERR.inspect =~ /STDERR/
+    def be_stderr
+      have_attributes({:inspect => "#<IO:<STDERR>>"})
+    end
+  else
+    def be_stderr
+      raise skip "JRuby < 9.0.0.0 doesn't have a predictable identifier for stdout"
+    end
   end
 end

--- a/rspec-support/spec/rspec/support/spec/stderr_splitter_spec.rb
+++ b/rspec-support/spec/rspec/support/spec/stderr_splitter_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe 'RSpec::Support::StdErrSplitter' do
       tempfile.close
       tempfile.unlink
     end
-    # This is the important part of the test that would fail without proper cloning hygeine
+    # This is the important part of the test that would fail without proper cloning hygiene
     expect(splitter.to_io).to be_stderr
   end
 
@@ -129,7 +129,7 @@ RSpec.describe 'RSpec::Support::StdErrSplitter' do
     end
   else
     def be_stderr
-      raise skip "JRuby < 9.0.0.0 doesn't have a predictable identifier for stdout"
+      raise "Unable to determine a predictable identifier for stdout (e.g on JRuby < 9.0)"
     end
   end
 end

--- a/rspec-support/spec/spec_helper.rb
+++ b/rspec-support/spec/spec_helper.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 require 'rspec/support/spec'
+# Preload io/console on MacOS JRuby to avoid warnings later due to https://github.com/jruby/jruby/issues/8271
+require 'io/console' if RSpec::Support::Ruby.jruby? && RSpec::Support::OS.apple_silicon?
+
 RSpec::Support::Spec::Coverage.setup
 
 RSpec::Matchers.define_negated_matcher :avoid_raising_errors, :raise_error


### PR DESCRIPTION
Augments #98 which fixes a StdErrSplitter spec

- validates #98 works on JRuby 9.4 and 10 (on Linux GHA and MacOS arm64 at least), tweaks error message and fixes rubocop
- corrects remaining JRuby specs still failing on MacOS Arm64 (not in CI, so best efforts to get them to work locally - not expecting it to be maintained over time)
  - `io/console` is required by `pp` in various places; and prints a one-time only nag. Pre-loading it fixes a random spec failing (_typically_ whichever one happens to autoload `rspec/support/differ`)
  - an alternative would be to early require `rspec/support/differ`, but is a bit less direct.

I am not sure there is an appropriate (shared) place for the condition I've added; it seemed a bit hacky for rspec-support package itself, but I can find somewhere there to put it to avoid the duplication if I am pointed to an appropriate place.