### PR TITLE
FuzzyMatcher compares to a Range via ==

### DIFF
--- a/rspec-support/lib/rspec/support/fuzzy_matcher.rb
+++ b/rspec-support/lib/rspec/support/fuzzy_matcher.rb
@@ -10,6 +10,9 @@ module RSpec
       def self.values_match?(expected, actual)
         if Hash === actual
           return hashes_match?(expected, actual) if Hash === expected
+        elsif Range === expected
+          # Check that actual is an equivalent Range, rather than included/covered.
+          return expected == actual
         elsif Array === expected && Enumerable === actual && !(Struct === actual)
           return arrays_match?(expected, actual.to_a)
         end

--- a/rspec-support/spec/rspec/support/fuzzy_matcher_spec.rb
+++ b/rspec-support/spec/rspec/support/fuzzy_matcher_spec.rb
@@ -27,6 +27,13 @@ module RSpec
         expect(/foo/).not_to match_against(/bar/)
       end
 
+      it 'can match a range only against a range' do
+        expect(1..5).to match_against(1..5)
+        expect(1..5).not_to match_against(1..6)
+        expect(1..5).not_to match_against(2..4)
+        expect(1..5).not_to match_against(3)
+      end
+
       it 'can match a class against an instance' do
         expect(String).to match_against("foo")
         expect(String).not_to match_against(123)


### PR DESCRIPTION
The default behavior of using `expected === actual` doesn't behave as one would expect for the case where your expected value is an instance of Range, which causes everything _relying_ on FuzzyMatcher to give odd results for that case.

The prompting example is:

    expect(OpenStruct.new(a: (1..5))).to have_attributes(a: (1..3))

which passes (since `(1..5) === (1..3)`). Range has a specific implementation of triple-equals, owing to its use in case-statements (eg `when (1..9) then :small`), but the semantics of that implementation do not match what one typically needs when expressing a value-matcher in a test.

Note that the `be_between` and `cover` composable matchers already exist, so while this _will_ cause this to break:

    expect(OpenStruct.new(a: 5)).to have_attributes(a: (1..100))

that is already better expressed in another way.

Fixes #233