### PR TITLE
[WIP] Warn if not all examples are run

### DIFF
--- a/rspec-core/lib/rspec/core/notifications.rb
+++ b/rspec-core/lib/rspec/core/notifications.rb
@@ -285,7 +285,8 @@ module RSpec::Core
     #                                                  the spec suite
     SummaryNotification = Struct.new(:duration, :examples, :failed_examples,
                                      :pending_examples, :load_time,
-                                     :errors_outside_of_examples_count)
+                                     :errors_outside_of_examples_count,
+                                     :expected_example_count)
     class SummaryNotification
       # @api
       # @return [Fixnum] the number of examples run
@@ -311,13 +312,17 @@ module RSpec::Core
         summary = Formatters::Helpers.pluralize(example_count, "example") +
           ", " + Formatters::Helpers.pluralize(failure_count, "failure")
         summary += ", #{pending_count} pending" if pending_count > 0
+
         if errors_outside_of_examples_count > 0
           summary += (
             ", " +
             Formatters::Helpers.pluralize(errors_outside_of_examples_count, "error") +
             " occurred outside of examples"
           )
+        elsif expected_example_count > example_count
+          summary += ", #{expected_example_count - example_count} example not run for unknown reasons"
         end
+
         summary
       end
 
@@ -331,7 +336,7 @@ module RSpec::Core
       #                          specific colors.
       # @return [String] A colorized results line.
       def colorized_totals_line(colorizer=::RSpec::Core::Formatters::ConsoleCodes)
-        if failure_count > 0 || errors_outside_of_examples_count > 0
+        if failure_count > 0 || errors_outside_of_examples_count > 0 || expected_example_count > example_count
           colorizer.wrap(totals_line, RSpec.configuration.failure_color)
         elsif pending_count > 0
           colorizer.wrap(totals_line, RSpec.configuration.pending_color)

--- a/rspec-core/lib/rspec/core/reporter.rb
+++ b/rspec-core/lib/rspec/core/reporter.rb
@@ -8,13 +8,14 @@ module RSpec::Core
         :close, :deprecation, :deprecation_summary, :dump_failures, :dump_pending,
         :dump_profile, :dump_summary, :example_failed, :example_group_finished,
         :example_group_started, :example_passed, :example_pending, :example_started,
-        :message, :seed, :start, :start_dump, :stop, :example_finished
+        :message, :seed, :start, :start_dump, :stop, :example_finished, :expected_example_count
       ])
 
     def initialize(configuration)
       @configuration = configuration
       @listeners = Hash.new { |h, k| h[k] = Set.new }
       @examples = []
+      @expected_example_count = 0
       @failed_examples = []
       @pending_examples = []
       @duration = @start = @load_time = nil
@@ -89,6 +90,7 @@ module RSpec::Core
     def start(expected_example_count, time=RSpec::Core::Time.now)
       @start = time
       @load_time = (@start - @configuration.start_time).to_f
+      @expected_example_count = expected_example_count
       notify :seed, Notifications::SeedNotification.new(@configuration.seed, seed_used?)
       notify :start, Notifications::StartNotification.new(expected_example_count, @load_time)
     end
@@ -185,7 +187,7 @@ module RSpec::Core
         end
         notify :dump_summary, Notifications::SummaryNotification.new(@duration, @examples, @failed_examples,
                                                                      @pending_examples, @load_time,
-                                                                     @non_example_exception_count)
+                                                                     @non_example_exception_count, @expected_example_count)
         notify :seed, Notifications::SeedNotification.new(@configuration.seed, seed_used?)
       end
     end

--- a/rspec-core/spec/rspec/core/notifications_spec.rb
+++ b/rspec-core/spec/rspec/core/notifications_spec.rb
@@ -452,6 +452,24 @@ module RSpec::Core::Notifications
           expect(fully_formatted).to include('<red>2 examples, 0 failures, 1 error occurred outside of examples</red>')
         end
       end
+
+      context "when there are specs expected to have been run which are missing" do
+        subject(:notification) do
+          summary_notification(
+            duration,
+            examples,
+            failed_examples,
+            pending_examples,
+            load_time,
+            errors_outside_of_examples_count,
+            3
+          )
+        end
+
+        it "turns the summary like red" do
+          expect(fully_formatted).to include('<red>2 examples, 0 failures, 1 example not run for unknown reasons</red>')
+        end
+      end
     end
   end
 end

--- a/rspec-core/spec/support/formatter_support.rb
+++ b/rspec-core/spec/support/formatter_support.rb
@@ -257,9 +257,11 @@ module FormatterSupport
     ::RSpec::Core::Notifications::ExamplesNotification.new reporter
   end
 
-  def summary_notification(duration, examples, failed, pending, time, errors = 0)
-    ::RSpec::Core::Notifications::SummaryNotification.new duration, examples, failed, pending, time, errors
+  # rubocop:disable Metrics/ParameterLists
+  def summary_notification(duration, examples, failed, pending, time, errors = 0, expected_example_count = 0)
+    ::RSpec::Core::Notifications::SummaryNotification.new duration, examples, failed, pending, time, errors, expected_example_count
   end
+  # rubocop:enable Metrics/ParameterLists
 
   def profile_notification(duration, examples, number)
     ::RSpec::Core::Notifications::ProfileNotification.new duration, examples, number, reporter.instance_variable_get('@profiler').example_groups


### PR DESCRIPTION
In some situations (like a mid run `SystemExit`) not all examples are run yet it can appear like this was a successful suite run, we can attempt to check for this by comparing the expected number of specs vs what was run.

I'm not 100% sure on this yet.