### PR TITLE
Use Prism for parsing

### DIFF
--- a/common_rubocop_config.yml
+++ b/common_rubocop_config.yml
@@ -99,6 +99,10 @@ Lint/AmbiguousOperatorPrecedence:
   Exclude:
     - '**/benchmarks/**/*'
 
+Lint/DuplicateMethods:
+  Exclude:
+    - '*/spec/**/*_spec.rb'
+
 Lint/EmptyBlock:
   Exclude:
     - '**/benchmarks/**/*'

--- a/rspec-core/lib/rspec/core/formatters/snippet_extractor.rb
+++ b/rspec-core/lib/rspec/core/formatters/snippet_extractor.rb
@@ -1,4 +1,5 @@
 RSpec::Support.require_rspec_support 'ruby_features'
+RSpec::Support.require_rspec_support 'source'
 
 module RSpec
   module Core
@@ -8,37 +9,110 @@ module RSpec
         NoSuchFileError = Class.new(StandardError)
         NoSuchLineError = Class.new(StandardError)
 
-        def self.extract_line_at(file_path, line_number)
-          source = source_from_file(file_path)
-          line = source.lines[line_number - 1]
-          raise NoSuchLineError unless line
-          line
+        # There are three scenarios in which we could be extracting snippets.
+        # One in which Prism is supported (all Rubies 3.3+), one in which Ripper
+        # is supported (CRuby 1.9+, most JRubies), and one in which neither is
+        # supported.
+        class BaseExtractor
+          private
+
+          def extract_line_at(file_path, line_number)
+            source = source_from_file(file_path)
+            line = source.lines[line_number - 1]
+            raise NoSuchLineError unless line
+            line
+          end
+
+          def source_from_file(path)
+            raise NoSuchFileError unless File.exist?(path)
+            RSpec.world.source_from_file(path)
+          end
         end
 
-        def self.source_from_file(path)
-          raise NoSuchFileError unless File.exist?(path)
-          RSpec.world.source_from_file(path)
+        class PrismExtractor < BaseExtractor
+          # Extracts the lines of the expression at the given line number up to
+          # the maximum line count using Prism.
+          def extract(file_path, beginning_line_number, max_line_count)
+            try_extract(file_path, beginning_line_number, max_line_count) ||
+              [extract_line_at(file_path, beginning_line_number)]
+          end
+
+          private
+
+          # Use a breadth-first search to find the first node that starts on the
+          # given line number and is a child of a `Prism::StatementsNode`. This
+          # effectively means it is the outermost node that starts on the given
+          # line number.
+          def find_node(root, line_number)
+            queue = [[nil, root]]
+
+            until queue.empty?
+              parent, node = queue.shift
+              if parent.is_a?(Prism::StatementsNode)
+                break node if node.is_a?(Prism::CallNode) && node.message_loc&.start_line == line_number
+                break node if node.start_line == line_number
+              end
+              node.compact_child_nodes.each { |child| queue << [node, child] }
+            end
+          end
+
+          def try_extract(file_path, beginning_line_number, max_line_count)
+            # If only one line is allowed, then there is nothing to extract.
+            return if max_line_count == 1
+
+            # If the source has a syntax error, then we will not attempt to
+            # extract anything.
+            source = Support::Source::PrismSource.new(source_from_file(file_path))
+            result = source.parse_result
+            return if result.failure?
+
+            # If we did not find a node, then we will bail out here.
+            return unless (found = find_node(result.value, beginning_line_number))
+
+            end_line = found.end_line
+
+            # If we found a node, then we want to make sure we include any
+            # heredoc content as well, which may extend beyond the end line
+            # of the node.
+            queue = [found]
+            while (child = queue.shift)
+              case child.type
+              when :string_node, :interpolated_string_node, :x_string_node, :interpolated_x_string_node
+                end_line = [end_line, child.closing_loc.end_line - 1].max if child.heredoc?
+              end
+              queue.concat(child.compact_child_nodes)
+            end
+
+            # Now clamp the end line based on the max line count if given,
+            # and slice out the lines from the source.
+            start_line = found.start_line
+            end_line = [end_line, start_line + max_line_count - 1].min if max_line_count
+            source.lines[(start_line - 1)..(end_line - 1)]
+          end
         end
 
-        if RSpec::Support::RubyFeatures.ripper_supported?
+        class RipperExtractor < BaseExtractor
+          # Raised when we are unable to find an expression at the given line
+          # number.
           NoExpressionAtLineError = Class.new(StandardError)
 
           attr_reader :source, :beginning_line_number, :max_line_count
 
-          def self.extract_expression_lines_at(file_path, beginning_line_number, max_line_count=nil)
+          # Extracts the lines of the expression at the given line number up to
+          # the maximum line count using Ripper.
+          def extract(file_path, beginning_line_number, max_line_count)
+            @source = Support::Source::RipperSource.new(source_from_file(file_path))
+            @beginning_line_number = beginning_line_number
+            @max_line_count = max_line_count
+
             if max_line_count == 1
               [extract_line_at(file_path, beginning_line_number)]
             else
-              source = source_from_file(file_path)
-              new(source, beginning_line_number, max_line_count).expression_lines
+              expression_lines
             end
           end
 
-          def initialize(source, beginning_line_number, max_line_count=nil)
-            @source = source
-            @beginning_line_number = beginning_line_number
-            @max_line_count = max_line_count
-          end
+          private
 
           def expression_lines
             line_range = line_range_of_expression
@@ -49,10 +123,8 @@ module RSpec
 
             source.lines[(line_range.begin - 1)..(line_range.end - 1)]
           rescue SyntaxError, NoExpressionAtLineError
-            [self.class.extract_line_at(source.path, beginning_line_number)]
+            [extract_line_at(source.path, beginning_line_number)]
           end
-
-          private
 
           def line_range_of_expression
             @line_range_of_expression ||= begin
@@ -119,16 +191,38 @@ module RSpec
           def location_nodes_at_beginning_line
             source.nodes_by_line_number[beginning_line_number]
           end
-        else
-          # :nocov:
-          def self.extract_expression_lines_at(file_path, beginning_line_number, *)
-            [extract_line_at(file_path, beginning_line_number)]
-          end
-          # :nocov:
         end
 
-        def self.least_indentation_from(lines)
-          lines.map { |line| line[/^[ \t]*/] }.min
+        class ParserlessExtractor < BaseExtractor
+          # If we do not have a parser available, then we will just return the
+          # line at the given line number.
+          def extract(file_path, beginning_line_number, *)
+            [extract_line_at(file_path, beginning_line_number)]
+          end
+        end
+
+        class << self
+          def extract_expression_lines_at(file_path, beginning_line_number, max_line_count=nil)
+            extractor.extract(file_path, beginning_line_number, max_line_count)
+          end
+
+          def least_indentation_from(lines)
+            lines.map { |line| line[/^[ \t]*/] }.min
+          end
+
+          private
+
+          # :nocov:
+          def extractor
+            if RSpec::Support::RubyFeatures.prism_supported?
+              PrismExtractor.new
+            elsif RSpec::Support::RubyFeatures.ripper_supported?
+              RipperExtractor.new
+            else
+              ParserlessExtractor.new
+            end
+          end
+          # :nocov:
         end
       end
     end

--- a/rspec-core/script/rspec_with_simplecov
+++ b/rspec-core/script/rspec_with_simplecov
@@ -20,6 +20,10 @@ require 'rspec/support/spec/coverage'
 RSpec::Support::Spec::Coverage.setup do
   root File.expand_path("../..", __FILE__)
   minimum_coverage 100
+  if RUBY_VERSION.to_f < 3.3
+    # We use Prism on later Rubies which can't be checked for coverage here.
+    add_filter "lib/rspec/core/formatters/snippet_extractor.rb"
+  end
 end
 
 load File.expand_path("../../exe/rspec", __FILE__)

--- a/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -426,7 +426,7 @@ module RSpec::Core
           end
         end
 
-        context 'with multiline expression and single line RSpec exception message', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+        context 'with multiline expression and single line RSpec exception message', :skip => !RSpec::Support::RubyFeatures.parser_supported? do
           let(:expression) do
             expect('RSpec').
               to be_a(Integer)
@@ -464,7 +464,7 @@ module RSpec::Core
           end
         end
 
-        context 'with multiline expression and multiline RSpec exception message', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+        context 'with multiline expression and multiline RSpec exception message', :skip => !RSpec::Support::RubyFeatures.parser_supported? do
           let(:expression) do
             expect('RSpec').
               to be_falsey
@@ -505,7 +505,7 @@ module RSpec::Core
           end
         end
 
-        context 'with multiline expression and RSpec exception message starting with linefeed (like `eq` matcher)', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+        context 'with multiline expression and RSpec exception message starting with linefeed (like `eq` matcher)', :skip => !RSpec::Support::RubyFeatures.parser_supported? do
           let(:expression) do
             expect('Rspec').
               to eq('RSpec')
@@ -546,7 +546,7 @@ module RSpec::Core
           end
         end
 
-        context 'with multiline expression and single line non-RSpec exception message', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+        context 'with multiline expression and single line non-RSpec exception message', :skip => !RSpec::Support::RubyFeatures.parser_supported? do
           let(:expression) do
             expect { fail 'Something is wrong!' }.
               to change { RSpec }
@@ -574,7 +574,7 @@ module RSpec::Core
         presenter.send(:read_failed_lines)
       end
 
-      context 'when the failed expression spans multiple lines', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+      context 'when the failed expression spans multiple lines', :skip => !RSpec::Support::RubyFeatures.parser_supported? do
         let(:exception) do
           begin
             expect('RSpec').to be_a(String).

--- a/rspec-core/spec/rspec/core/formatters/snippet_extractor_spec.rb
+++ b/rspec-core/spec/rspec/core/formatters/snippet_extractor_spec.rb
@@ -89,329 +89,366 @@ module RSpec::Core::Formatters
       end
     end
 
-    context 'in Ripper supported environment', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
-      context 'when the expression spans multiple lines' do
-        let(:source) do
-          do_something_fail :foo,
-                            :bar
+    context 'in parser supported environment' do
+      shared_examples 'an extractor' do
+        subject(:expression_lines) do
+          described_class.new.extract(file_path, line_number, max_line_count)
         end
 
-        it 'returns the lines' do
-          expect(expression_lines).to eq([
-            '          do_something_fail :foo,',
-            '                            :bar'
-          ])
-        end
-      end
+        context 'when the expression spans multiple lines' do
+          let(:source) do
+            do_something_fail :foo,
+                              :bar
+          end
 
-      context 'when the expression ends with ")"-only line' do
-        let(:source) do
-          do_something_fail(:foo
-          )
-        end
-
-        it 'returns all the lines' do
-          expect(expression_lines).to eq([
-            '          do_something_fail(:foo',
-            '          )'
-          ])
-        end
-      end
-
-      context 'when the expression ends with "}"-only line' do
-        let(:source) do
-          do_something_fail {
-          }
-        end
-
-        it 'returns all the lines' do
-          expect(expression_lines).to eq([
-            '          do_something_fail {',
-            '          }'
-          ])
-        end
-      end
-
-      context 'when the expression ends with "]"-only line' do
-        let(:source) do
-          do_something_fail :foo, [
-          ]
-        end
-
-        it 'returns all the lines' do
-          expect(expression_lines).to eq([
-            '          do_something_fail :foo, [',
-            '          ]'
-          ])
-        end
-      end
-
-      context 'when the expression contains do-end block and ends with "end"-only line' do
-        let(:source) do
-          do_something_fail do
+          it 'returns the lines' do
+            expect(expression_lines).to eq([
+              '            do_something_fail :foo,',
+              '                              :bar'
+            ])
           end
         end
 
-        it 'returns all the lines' do
-          expect(expression_lines).to eq([
-            '          do_something_fail do',
-            '          end'
-          ])
-        end
-      end
-
-      argument_error_points_invoker = RSpec::Support::Ruby.jruby?
-      context 'when the expression is a method definition and ends with "end"-only line', :skip => argument_error_points_invoker do
-        let(:source) do
-          obj = Object.new
-
-          def obj.foo(arg)
-            p arg
+        context 'when the expression ends with ")"-only line' do
+          let(:source) do
+            do_something_fail(:foo
+            )
           end
 
-          obj.foo
-        end
-
-        it 'returns all the lines' do
-          expect(expression_lines).to eq([
-            '          def obj.foo(arg)',
-            '            p arg',
-            '          end'
-          ])
-        end
-      end
-
-      context 'when the expression line includes an "end"-less method definition' do
-        include RSpec::Support::InSubProcess
-
-        around(:example) do |example|
-          require 'tempfile'
-          example.call
-        end
-
-        let(:source) do
-          in_sub_process do
-            load(file.path)
+          it 'returns all the lines' do
+            expect(expression_lines).to eq([
+              '            do_something_fail(:foo',
+              '            )'
+            ])
           end
         end
 
-        let(:file) do
-          file = Tempfile.new('source.rb')
+        context 'when the expression ends with "}"-only line' do
+          let(:source) do
+            do_something_fail {
+            }
+          end
 
-          file.write(unindent(<<-END))
+          it 'returns all the lines' do
+            expect(expression_lines).to eq([
+              '            do_something_fail {',
+              '            }'
+            ])
+          end
+        end
+
+        context 'when the expression ends with "]"-only line' do
+          let(:source) do
+            do_something_fail :foo, [
+            ]
+          end
+
+          it 'returns all the lines' do
+            expect(expression_lines).to eq([
+              '            do_something_fail :foo, [',
+              '            ]'
+            ])
+          end
+        end
+
+        context 'when the expression contains do-end block and ends with "end"-only line' do
+          let(:source) do
+            do_something_fail do
+            end
+          end
+
+          it 'returns all the lines' do
+            expect(expression_lines).to eq([
+              '            do_something_fail do',
+              '            end'
+            ])
+          end
+        end
+
+        context 'when the expression line includes an "end"-less method definition' do
+          include RSpec::Support::InSubProcess
+
+          around(:example) do |example|
+            require 'tempfile'
+            example.call
+          end
+
+          let(:source) do
+            in_sub_process do
+              load(file.path)
+            end
+          end
+
+          let(:file) do
+            file = Tempfile.new('source.rb')
+
+            file.write(unindent(<<-END))
+              obj = Object.new
+
+              def obj.foo = raise
+
+              obj.foo
+            END
+
+            file.close
+
+            file
+          end
+
+          after do
+            file.unlink
+          end
+
+          it 'returns only the line' do
+            expect(expression_lines).to eq([
+              'def obj.foo = raise'
+            ])
+          end
+        end
+
+        context "when the expression ends with multiple paren-only lines of same type" do
+          let(:source) do
+            do_something_fail(:foo, (:bar
+              )
+            )
+          end
+
+          it 'returns all the lines' do
+            expect(expression_lines).to eq([
+              '            do_something_fail(:foo, (:bar',
+              '              )',
+              '            )'
+            ])
+          end
+        end
+
+        context "when the expression includes paren and heredoc pairs as non-nested structure" do
+          let(:source) do
+            do_something_fail(<<-END)
+              foo
+            END
+          end
+
+          it 'returns all the lines' do
+            expect(expression_lines).to eq([
+              '            do_something_fail(<<-END)',
+              '              foo',
+              '            END'
+            ])
+          end
+        end
+
+        context "when the expression includes paren and xstring heredoc pairs as non-nested structure" do
+          def `(cmd)
+            cmd
+          end
+
+          let(:source) do
+            do_something_fail(<<-`END`)
+              foo
+            END
+          end
+
+          it 'returns all the lines' do
+            expect(expression_lines).to eq([
+              '            do_something_fail(<<-`END`)',
+              '              foo',
+              '            END'
+            ])
+          end
+        end
+
+        context 'when the expression spans lines after the closing paren line' do
+          let(:source) do
+            do_something_fail(:foo
+            ).
+            do_something_chain
+          end
+
+          # [:program,
+          #  [[:call,
+          #    [:method_add_arg, [:fcall, [:@ident, "do_something_fail", [1, 10]]], [:arg_paren, nil]],
+          #    :".",
+          #    [:@ident, "do_something_chain", [3, 10]]]]]
+
+          it 'returns all the lines' do
+            expect(expression_lines).to eq([
+              '            do_something_fail(:foo',
+              '            ).',
+              '            do_something_chain'
+            ])
+          end
+        end
+
+        context "when the expression's final line includes the same type of opening paren of another multiline expression" do
+          let(:source) do
+            do_something_fail(:foo
+            ); another_expression(:bar
+            )
+          end
+
+          it 'ignores another expression' do
+            expect(expression_lines).to eq([
+              '            do_something_fail(:foo',
+              '            ); another_expression(:bar'
+            ])
+          end
+        end
+
+        context "when the expression's first line includes a closing paren of another multiline expression" do
+          let(:source) do
+            another_expression(:bar
+            ); do_something_fail(:foo
+            )
+          end
+
+          it 'ignores another expression' do
+            expect(expression_lines).to eq([
+              '            ); do_something_fail(:foo',
+              '            )'
+            ])
+          end
+        end
+
+        context 'when no expression exists at the line' do
+          let(:file_path) do
+            __FILE__
+          end
+
+          let(:line_number) do
+            __LINE__ + 1
+            # The failure happened here without expression
+          end
+
+          it 'returns the line by falling back to the simple single line extraction' do
+            expect(expression_lines).to eq([
+              '            # The failure happened here without expression'
+            ])
+          end
+        end
+
+        context 'when Ripper cannot parse the source', :isolated_directory do
+          let(:file_path) { 'invalid_source.rb' }
+
+          let(:line_number) { 1 }
+
+          let(:source) { <<-EOS.gsub(/^ +\|/, '') }
+            |expect("some string").to include(
+            |  "some", "string"
+            |]
+          EOS
+
+          before do
+            File.open(file_path, 'w') { |file| file.write(source) }
+          end
+
+          it 'returns the line by falling back to the simple single line extraction' do
+            expect(expression_lines).to eq([
+              'expect("some string").to include('
+            ])
+          end
+        end
+
+        context 'when max line count is given' do
+          let(:max_line_count) do
+            2
+          end
+
+          let(:source) do
+            do_something_fail "line1", [
+              "line2",
+              "line3"
+            ]
+          end
+
+          it 'returns the lines without exceeding the given count' do
+            expect(expression_lines).to eq([
+              '            do_something_fail "line1", [',
+              '              "line2",'
+            ])
+          end
+        end
+
+        context 'when max line count is 1' do
+          let(:max_line_count) do
+            1
+          end
+
+          let(:source) do
+            do_something_fail "line1", [
+              "line2",
+              "line3"
+            ]
+          end
+
+          before do
+            RSpec.reset # Clear source cache
+          end
+
+          it 'returns the line without parsing the source for efficiency' do
+            require 'ripper'
+            expect(Ripper).not_to receive(:sexp)
+            expect(expression_lines).to eq([
+              '            do_something_fail "line1", ['
+            ])
+          end
+        end
+      end
+
+      shared_examples 'an extractor except JRuby' do
+        context 'when the expression is a method definition and ends with "end"-only line' do
+          let(:source) do
             obj = Object.new
 
-            def obj.foo = raise
+            def obj.foo(arg)
+              p arg
+            end
 
             obj.foo
-          END
-
-          file.close
-
-          file
-        end
-
-        after do
-          file.unlink
-        end
-
-        it 'returns only the line' do
-          expect(expression_lines).to eq([
-            'def obj.foo = raise'
-          ])
-        end
-      end
-
-      context 'when the expression is a setter method definition', :skip => argument_error_points_invoker do
-        let(:source) do
-          obj = Object.new
-
-          def obj.foo=(arg1, arg2)
-            @foo = arg1
           end
 
-          obj.foo = 1
+          it 'returns all the lines' do
+            expect(expression_lines).to eq([
+              '            def obj.foo(arg)',
+              '              p arg',
+              '            end'
+            ])
+          end
         end
 
-        it 'returns all the lines without confusing it with "end"-less method' do
-          expect(expression_lines).to eq([
-            '          def obj.foo=(arg1, arg2)',
-            '            @foo = arg1',
-            '          end'
-          ])
-        end
-      end
+        context 'when the expression is a setter method definition' do
+          let(:source) do
+            obj = Object.new
 
-      context "when the expression ends with multiple paren-only lines of same type" do
-        let(:source) do
-          do_something_fail(:foo, (:bar
-            )
-          )
-        end
+            def obj.foo=(arg1, arg2)
+              @foo = arg1
+            end
 
-        it 'returns all the lines' do
-          expect(expression_lines).to eq([
-            '          do_something_fail(:foo, (:bar',
-            '            )',
-            '          )'
-          ])
-        end
-      end
+            obj.foo = 1
+          end
 
-      context "when the expression includes paren and heredoc pairs as non-nested structure" do
-        let(:source) do
-          do_something_fail(<<-END)
-            foo
-          END
-        end
-
-        it 'returns all the lines' do
-          expect(expression_lines).to eq([
-            '          do_something_fail(<<-END)',
-            '            foo',
-            '          END'
-          ])
+          it 'returns all the lines without confusing it with "end"-less method' do
+            expect(expression_lines).to eq([
+              '            def obj.foo=(arg1, arg2)',
+              '              @foo = arg1',
+              '            end'
+            ])
+          end
         end
       end
 
-      context 'when the expression spans lines after the closing paren line' do
-        let(:source) do
-          do_something_fail(:foo
-          ).
-          do_something_chain
-        end
-
-        # [:program,
-        #  [[:call,
-        #    [:method_add_arg, [:fcall, [:@ident, "do_something_fail", [1, 10]]], [:arg_paren, nil]],
-        #    :".",
-        #    [:@ident, "do_something_chain", [3, 10]]]]]
-
-        it 'returns all the lines' do
-          expect(expression_lines).to eq([
-            '          do_something_fail(:foo',
-            '          ).',
-            '          do_something_chain'
-          ])
-        end
+      describe SnippetExtractor::PrismExtractor, skip: !RSpec::Support::RubyFeatures.prism_supported? do
+        it_behaves_like 'an extractor'
+        it_behaves_like 'an extractor except JRuby', skip: RSpec::Support::Ruby.jruby?
       end
 
-      context "when the expression's final line includes the same type of opening paren of another multiline expression" do
-        let(:source) do
-          do_something_fail(:foo
-          ); another_expression(:bar
-          )
-        end
-
-        it 'ignores another expression' do
-          expect(expression_lines).to eq([
-            '          do_something_fail(:foo',
-            '          ); another_expression(:bar'
-          ])
-        end
-      end
-
-      context "when the expression's first line includes a closing paren of another multiline expression" do
-        let(:source) do
-          another_expression(:bar
-          ); do_something_fail(:foo
-          )
-        end
-
-        it 'ignores another expression' do
-          expect(expression_lines).to eq([
-            '          ); do_something_fail(:foo',
-            '          )'
-          ])
-        end
-      end
-
-      context 'when no expression exists at the line' do
-        let(:file_path) do
-          __FILE__
-        end
-
-        let(:line_number) do
-          __LINE__ + 1
-          # The failure happened here without expression
-        end
-
-        it 'returns the line by falling back to the simple single line extraction' do
-          expect(expression_lines).to eq([
-            '          # The failure happened here without expression'
-          ])
-        end
-      end
-
-      context 'when Ripper cannot parse the source', :isolated_directory do
-        let(:file_path) { 'invalid_source.rb' }
-
-        let(:line_number) { 1 }
-
-        let(:source) { <<-EOS.gsub(/^ +\|/, '') }
-          |expect("some string").to include(
-          |  "some", "string"
-          |]
-        EOS
-
-        before do
-          File.open(file_path, 'w') { |file| file.write(source) }
-        end
-
-        it 'returns the line by falling back to the simple single line extraction' do
-          expect(expression_lines).to eq([
-            'expect("some string").to include('
-          ])
-        end
-      end
-
-      context 'when max line count is given' do
-        let(:max_line_count) do
-          2
-        end
-
-        let(:source) do
-          do_something_fail "line1", [
-            "line2",
-            "line3"
-          ]
-        end
-
-        it 'returns the lines without exceeding the given count' do
-          expect(expression_lines).to eq([
-            '          do_something_fail "line1", [',
-            '            "line2",'
-          ])
-        end
-      end
-
-      context 'when max line count is 1' do
-        let(:max_line_count) do
-          1
-        end
-
-        let(:source) do
-          do_something_fail "line1", [
-            "line2",
-            "line3"
-          ]
-        end
-
-        before do
-          RSpec.reset # Clear source cache
-        end
-
-        it 'returns the line without parsing the source for efficiency' do
-          require 'ripper'
-          expect(Ripper).not_to receive(:sexp)
-          expect(expression_lines).to eq([
-            '          do_something_fail "line1", ['
-          ])
-        end
+      describe SnippetExtractor::RipperExtractor, skip: !RSpec::Support::RubyFeatures.ripper_supported? do
+        it_behaves_like 'an extractor'
+        it_behaves_like 'an extractor except JRuby', skip: RSpec::Support::Ruby.jruby?
       end
     end
 
-    context 'in Ripper unsupported environment', :skip => RSpec::Support::RubyFeatures.ripper_supported? do
+    context 'in parser unsupported environment', :skip => RSpec::Support::RubyFeatures.parser_supported? do
       context 'when the expression spans multiple lines' do
         let(:source) do
           do_something_fail :foo,
@@ -423,6 +460,21 @@ module RSpec::Core::Formatters
             '          do_something_fail :foo,'
           ])
         end
+      end
+    end
+
+    context 'when using the ParserlessExtractor' do
+      let(:extractor) { SnippetExtractor::ParserlessExtractor.new }
+
+      let(:source) do
+        do_something_fail :foo,
+                          :bar
+      end
+
+      it 'returns only the first line' do
+        expect(extractor.extract(file_path, line_number)).to eq([
+          '        do_something_fail :foo,'
+        ])
       end
     end
   end

--- a/rspec-expectations/features/built_in_matchers/change.feature
+++ b/rspec-expectations/features/built_in_matchers/change.feature
@@ -26,7 +26,7 @@ Feature: `change` matcher
       end
       """
 
-  @skip-when-ripper-unsupported
+  @skip-when-parser-unsupported
   Scenario: Expect change
     Given a file named "spec/example_spec.rb" with:
       """ruby
@@ -47,7 +47,7 @@ Feature: `change` matcher
     Then the output should contain "1 failure"
     Then the output should contain "expected `Counter.count` to have changed by 2, but was changed by 1"
 
-  @skip-when-ripper-unsupported
+  @skip-when-parser-unsupported
   Scenario: Expect no change
     Given a file named "spec/example_spec.rb" with:
       """ruby

--- a/rspec-expectations/features/built_in_matchers/satisfy.feature
+++ b/rspec-expectations/features/built_in_matchers/satisfy.feature
@@ -17,7 +17,7 @@ Feature: `satisfy` matcher
   end
   ```
 
-  @skip-when-ripper-unsupported
+  @skip-when-parser-unsupported
   Scenario: Basic usage
     Given a file named "satisfy_matcher_spec.rb" with:
       """ruby

--- a/rspec-expectations/features/define_negated_matcher.feature
+++ b/rspec-expectations/features/define_negated_matcher.feature
@@ -3,7 +3,7 @@ Feature: Define negated matcher
   You can use `RSpec::Matchers.define_negated_matcher` to define a negated version of
   an existing matcher. This is particularly useful in composed matcher expressions.
 
-  @skip-when-ripper-unsupported
+  @skip-when-parser-unsupported
   Scenario: Composed negated matcher expression
     Given a file named "composed_negated_expression_spec.rb" with:
       """ruby

--- a/rspec-expectations/features/support/ruby_features.rb
+++ b/rspec-expectations/features/support/ruby_features.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 
-Around "@skip-when-ripper-unsupported" do |scenario, block|
+Around "@skip-when-parser-unsupported" do |scenario, block|
   require 'rspec/support/ruby_features'
 
-  if ::RSpec::Support::RubyFeatures.ripper_supported?
+  if ::RSpec::Support::RubyFeatures.parser_supported?
     block.call
   else
-    skip_this_scenario "Skipping scenario #{scenario.name} because Ripper is not supported"
+    skip_this_scenario "Skipping scenario #{scenario.name} because no parser is supported"
   end
 end

--- a/rspec-expectations/lib/rspec/expectations/block_snippet_extractor.rb
+++ b/rspec-expectations/lib/rspec/expectations/block_snippet_extractor.rb
@@ -3,43 +3,286 @@
 module RSpec
   module Expectations
     # @private
-    class BlockSnippetExtractor # rubocop:disable Metrics/ClassLength
+    class BlockSnippetExtractor
       # rubocop should properly handle `Struct.new {}` as an inner class definition.
+
+      Error = Class.new(StandardError)
+      TargetNotFoundError = Class.new(Error)
+      AmbiguousTargetError = Class.new(Error)
 
       attr_reader :proc, :method_name
 
-      def self.try_extracting_single_line_body_of(proc, method_name)
-        lines = new(proc, method_name).body_content_lines
+      def self.try_extracting_single_line_body_of(proc, method_name, extractor=nil)
+        lines = new(proc, method_name, extractor).body_content_lines
         return nil unless lines.count == 1
         lines.first
       rescue Error
         nil
       end
 
-      def initialize(proc, method_name)
+      def initialize(proc, method_name, extractor=nil)
         @proc = proc
         @method_name = method_name.to_s.freeze
+        @extractor = extractor || supported_extractor
       end
 
       # Ideally we should properly handle indentations of multiline snippet,
       # but it's not implemented yet since because we use result of this method only when it's a
       # single line and implementing the logic introduces additional complexity.
       def body_content_lines
-        raw_body_lines.map(&:strip).reject(&:empty?)
+        @extractor.extract(method_name, source, beginning_line_number).map(&:strip).reject(&:empty?)
+      end
+
+      class PrismBlockSnippetExtractor
+        # Extract the block body snippet using Prism nodes.
+        def extract(method_name, source, beginning_line_number)
+          root = Support::Source::PrismSource.new(source).parse_result.value
+
+          case (blocks = find_blocks(root, method_name.to_sym, beginning_line_number)).size
+          when 1
+            body = blocks.first.body
+            body ? body.slice.lines : []
+          when 0
+            raise TargetNotFoundError
+          else
+            raise AmbiguousTargetError
+          end
+        end
+
+        private
+
+        def find_blocks(root, target, beginning_line_number)
+          queue = [[nil, root]]
+          blocks = []
+
+          until queue.empty?
+            parent, node = queue.shift
+
+            if parent.is_a?(Prism::CallNode) &&
+               node.is_a?(Prism::BlockNode) &&
+               parent.name == target &&
+               node.start_line == beginning_line_number
+              blocks << node
+            end
+
+            node.compact_child_nodes.each { |child| queue << [node, child] }
+          end
+
+          blocks
+        end
+      end
+
+      class RipperBlockSnippetExtractor # rubocop:disable Metrics/ClassLength
+        # Extract the block body snippet using Ripper tokens.
+        def extract(method_name, source, beginning_line_number)
+          BlockTokenExtractor.
+            new(method_name, Support::Source::RipperSource.new(source), beginning_line_number).
+            body_tokens.map(&:string).join.split("\n")
+        end
+
+        # @private
+        # Performs extraction of block body snippet using tokens,
+        # which cannot be done with node information.
+        BlockTokenExtractor = Struct.new(:method_name, :source, :beginning_line_number) do
+          attr_reader :state, :body_tokens
+
+          def initialize(*)
+            super
+            parse!
+          end
+
+          private
+
+          def parse!
+            @state = :initial
+
+            catch(:finish) do
+              source.tokens.each do |token|
+                invoke_state_handler(token)
+              end
+            end
+          end
+
+          def finish!
+            throw :finish
+          end
+
+          def invoke_state_handler(token)
+            __send__("#{state}_state", token)
+          end
+
+          def initial_state(token)
+            @state = :after_method_call if token.location == block_locator.method_call_location
+          end
+
+          def after_method_call_state(token)
+            @state = :after_opener if handle_opener_token(token)
+          end
+
+          def after_opener_state(token)
+            if handle_closer_token(token)
+              finish_or_find_next_block_if_incorrect!
+            elsif pipe_token?(token)
+              finalize_pending_tokens!
+              @state = :after_beginning_of_args
+            else
+              pending_tokens << token
+              handle_opener_token(token)
+              @state = :after_beginning_of_body unless token.type == :on_sp
+            end
+          end
+
+          def after_beginning_of_args_state(token)
+            @state = :after_beginning_of_body if pipe_token?(token)
+          end
+
+          def after_beginning_of_body_state(token)
+            if handle_closer_token(token)
+              finish_or_find_next_block_if_incorrect!
+            else
+              pending_tokens << token
+              handle_opener_token(token)
+            end
+          end
+
+          def pending_tokens
+            @pending_tokens ||= []
+          end
+
+          def finalize_pending_tokens!
+            pending_tokens.freeze.tap do
+              @pending_tokens = nil
+            end
+          end
+
+          def finish_or_find_next_block_if_incorrect!
+            body_tokens = finalize_pending_tokens!
+
+            if correct_block?(body_tokens)
+              @body_tokens = body_tokens
+              finish!
+            else
+              @state = :after_method_call
+            end
+          end
+
+          def handle_opener_token(token)
+            opener_token?(token).tap do |boolean|
+              opener_token_stack.push(token) if boolean
+            end
+          end
+
+          def opener_token?(token)
+            token.type == :on_lbrace || (token.type == :on_kw && token.string == 'do')
+          end
+
+          def handle_closer_token(token)
+            if opener_token_stack.last.closed_by?(token)
+              opener_token_stack.pop
+              opener_token_stack.empty?
+            else
+              false
+            end
+          end
+
+          def opener_token_stack
+            @opener_token_stack ||= []
+          end
+
+          def pipe_token?(token)
+            token.type == :on_op && token.string == '|'
+          end
+
+          def correct_block?(body_tokens)
+            return true if block_locator.body_content_locations.empty?
+            content_location = block_locator.body_content_locations.first
+            content_location.between?(body_tokens.first.location, body_tokens.last.location)
+          end
+
+          def block_locator
+            @block_locator ||= BlockLocator.new(method_name, source, beginning_line_number)
+          end
+        end
+
+        # @private
+        # Locates target block with node information (semantics), which tokens don't have.
+        BlockLocator = Struct.new(:method_name, :source, :beginning_line_number) do
+          def method_call_location
+            @method_call_location ||= method_ident_node.location
+          end
+
+          def body_content_locations
+            @body_content_locations ||= block_body_node.map(&:location).compact
+          end
+
+          private
+
+          def method_ident_node
+            method_call_node = block_wrapper_node.children.first
+            method_call_node.find do |node|
+              method_ident_node?(node)
+            end
+          end
+
+          def block_body_node
+            block_node = block_wrapper_node.children[1]
+            block_node.children.last
+          end
+
+          def block_wrapper_node
+            case candidate_block_wrapper_nodes.size
+            when 1
+              candidate_block_wrapper_nodes.first
+            when 0
+              raise TargetNotFoundError
+            else
+              raise AmbiguousTargetError
+            end
+          end
+
+          def candidate_block_wrapper_nodes
+            @candidate_block_wrapper_nodes ||= candidate_method_ident_nodes.map do |method_ident_node|
+              block_wrapper_node = method_ident_node.each_ancestor.find { |node| node.type == :method_add_block }
+              next nil unless block_wrapper_node
+              method_call_node = block_wrapper_node.children.first
+              method_call_node.include?(method_ident_node) ? block_wrapper_node : nil
+            end.compact
+          end
+
+          def candidate_method_ident_nodes
+            source.nodes_by_line_number[beginning_line_number].select do |node|
+              method_ident_node?(node)
+            end
+          end
+
+          def method_ident_node?(node)
+            node.type == :@ident && node.args.first == method_name
+          end
+        end
       end
 
     private
 
-      def raw_body_lines
-        raw_body_snippet.split("\n")
+      # :nocov:
+      def supported_extractor
+        if RSpec::Support::RubyFeatures.prism_supported?
+          PrismBlockSnippetExtractor.new
+        elsif RSpec::Support::RubyFeatures.ripper_supported?
+          RipperBlockSnippetExtractor.new
+        end
+      end
+      # :nocov:
+
+      def file_path
+        source_location.first
       end
 
-      def raw_body_snippet
-        block_token_extractor.body_tokens.map(&:string).join
+      def beginning_line_number
+        source_location[1]
       end
 
-      def block_token_extractor
-        @block_token_extractor ||= BlockTokenExtractor.new(method_name, source, beginning_line_number)
+      def source_location
+        proc.source_location || raise(TargetNotFoundError)
       end
 
       if RSpec.respond_to?(:world)
@@ -55,202 +298,6 @@ module RSpec
           @source ||= RSpec::Support::Source.from_file(file_path)
         end
         # :nocov:
-      end
-
-      def file_path
-        source_location.first
-      end
-
-      def beginning_line_number
-        source_location[1]
-      end
-
-      def source_location
-        proc.source_location || raise(TargetNotFoundError)
-      end
-
-      Error = Class.new(StandardError)
-      TargetNotFoundError = Class.new(Error)
-      AmbiguousTargetError = Class.new(Error)
-
-      # @private
-      # Performs extraction of block body snippet using tokens,
-      # which cannot be done with node information.
-      BlockTokenExtractor = Struct.new(:method_name, :source, :beginning_line_number) do
-        attr_reader :state, :body_tokens
-
-        def initialize(*)
-          super
-          parse!
-        end
-
-        private
-
-        def parse!
-          @state = :initial
-
-          catch(:finish) do
-            source.tokens.each do |token|
-              invoke_state_handler(token)
-            end
-          end
-        end
-
-        def finish!
-          throw :finish
-        end
-
-        def invoke_state_handler(token)
-          __send__("#{state}_state", token)
-        end
-
-        def initial_state(token)
-          @state = :after_method_call if token.location == block_locator.method_call_location
-        end
-
-        def after_method_call_state(token)
-          @state = :after_opener if handle_opener_token(token)
-        end
-
-        def after_opener_state(token)
-          if handle_closer_token(token)
-            finish_or_find_next_block_if_incorrect!
-          elsif pipe_token?(token)
-            finalize_pending_tokens!
-            @state = :after_beginning_of_args
-          else
-            pending_tokens << token
-            handle_opener_token(token)
-            @state = :after_beginning_of_body unless token.type == :on_sp
-          end
-        end
-
-        def after_beginning_of_args_state(token)
-          @state = :after_beginning_of_body if pipe_token?(token)
-        end
-
-        def after_beginning_of_body_state(token)
-          if handle_closer_token(token)
-            finish_or_find_next_block_if_incorrect!
-          else
-            pending_tokens << token
-            handle_opener_token(token)
-          end
-        end
-
-        def pending_tokens
-          @pending_tokens ||= []
-        end
-
-        def finalize_pending_tokens!
-          pending_tokens.freeze.tap do
-            @pending_tokens = nil
-          end
-        end
-
-        def finish_or_find_next_block_if_incorrect!
-          body_tokens = finalize_pending_tokens!
-
-          if correct_block?(body_tokens)
-            @body_tokens = body_tokens
-            finish!
-          else
-            @state = :after_method_call
-          end
-        end
-
-        def handle_opener_token(token)
-          opener_token?(token).tap do |boolean|
-            opener_token_stack.push(token) if boolean
-          end
-        end
-
-        def opener_token?(token)
-          token.type == :on_lbrace || (token.type == :on_kw && token.string == 'do')
-        end
-
-        def handle_closer_token(token)
-          if opener_token_stack.last.closed_by?(token)
-            opener_token_stack.pop
-            opener_token_stack.empty?
-          else
-            false
-          end
-        end
-
-        def opener_token_stack
-          @opener_token_stack ||= []
-        end
-
-        def pipe_token?(token)
-          token.type == :on_op && token.string == '|'
-        end
-
-        def correct_block?(body_tokens)
-          return true if block_locator.body_content_locations.empty?
-          content_location = block_locator.body_content_locations.first
-          content_location.between?(body_tokens.first.location, body_tokens.last.location)
-        end
-
-        def block_locator
-          @block_locator ||= BlockLocator.new(method_name, source, beginning_line_number)
-        end
-      end
-
-      # @private
-      # Locates target block with node information (semantics), which tokens don't have.
-      BlockLocator = Struct.new(:method_name, :source, :beginning_line_number) do
-        def method_call_location
-          @method_call_location ||= method_ident_node.location
-        end
-
-        def body_content_locations
-          @body_content_locations ||= block_body_node.map(&:location).compact
-        end
-
-        private
-
-        def method_ident_node
-          method_call_node = block_wrapper_node.children.first
-          method_call_node.find do |node|
-            method_ident_node?(node)
-          end
-        end
-
-        def block_body_node
-          block_node = block_wrapper_node.children[1]
-          block_node.children.last
-        end
-
-        def block_wrapper_node
-          case candidate_block_wrapper_nodes.size
-          when 1
-            candidate_block_wrapper_nodes.first
-          when 0
-            raise TargetNotFoundError
-          else
-            raise AmbiguousTargetError
-          end
-        end
-
-        def candidate_block_wrapper_nodes
-          @candidate_block_wrapper_nodes ||= candidate_method_ident_nodes.map do |method_ident_node|
-            block_wrapper_node = method_ident_node.each_ancestor.find { |node| node.type == :method_add_block }
-            next nil unless block_wrapper_node
-            method_call_node = block_wrapper_node.children.first
-            method_call_node.include?(method_ident_node) ? block_wrapper_node : nil
-          end.compact
-        end
-
-        def candidate_method_ident_nodes
-          source.nodes_by_line_number[beginning_line_number].select do |node|
-            method_ident_node?(node)
-          end
-        end
-
-        def method_ident_node?(node)
-          node.type == :@ident && node.args.first == method_name
-        end
       end
     end
   end

--- a/rspec-expectations/lib/rspec/matchers/built_in/change.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/change.rb
@@ -419,7 +419,7 @@ module RSpec
           end
         end
 
-        if RSpec::Support::RubyFeatures.ripper_supported?
+        if RSpec::Support::RubyFeatures.parser_supported?
           def extract_value_block_snippet
             return nil unless @value_proc
             Expectations::BlockSnippetExtractor.try_extracting_single_line_body_of(@value_proc, @matcher_name)

--- a/rspec-expectations/lib/rspec/matchers/built_in/satisfy.rb
+++ b/rspec-expectations/lib/rspec/matchers/built_in/satisfy.rb
@@ -38,7 +38,7 @@ module RSpec
 
       private
 
-        if RSpec::Support::RubyFeatures.ripper_supported?
+        if RSpec::Support::RubyFeatures.parser_supported?
           def block_representation
             if (block_snippet = extract_block_snippet)
               "expression `#{block_snippet}`"

--- a/rspec-expectations/spec/rspec/expectations/block_snippet_extractor_spec.rb
+++ b/rspec-expectations/spec/rspec/expectations/block_snippet_extractor_spec.rb
@@ -3,308 +3,318 @@
 require 'rspec/expectations/block_snippet_extractor'
 
 module RSpec::Expectations
-  RSpec.describe BlockSnippetExtractor, :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
-    subject(:extractor) do
-      BlockSnippetExtractor.new(proc_object, 'target_method')
-    end
-
-    let(:proc_object) do
-      @proc_object
-    end
-
-    def target_method(*, &block)
-      @proc_object = block
-    end
-
-    def another_method(*, &_block)
-    end
-
-    before do
-      expression
-    end
-
-    describe '.try_extracting_single_line_body_of' do
-      subject(:try_extracting_single_line_body) do
-        BlockSnippetExtractor.try_extracting_single_line_body_of(proc_object, 'target_method')
+  RSpec.describe BlockSnippetExtractor, :skip => !RSpec::Support::RubyFeatures.parser_supported? do
+    shared_examples 'a block snippet extractor' do
+      subject(:extractor) do
+        BlockSnippetExtractor.new(proc_object, 'target_method', described_class.new)
       end
 
-      context 'with a single line body block' do
-        let(:expression) do
-          target_method { 1.positive? }
-        end
-
-        it 'returns the body' do
-          expect(try_extracting_single_line_body).to eq('1.positive?')
-        end
+      let(:proc_object) do
+        @proc_object
       end
 
-      context 'with a multiline body block' do
-        let(:expression) do
-          target_method do
-            1.positive?
-            2.negative?
+      def target_method(*, &block)
+        @proc_object = block
+      end
+
+      def another_method(*, &_block)
+      end
+
+      before do
+        expression
+      end
+
+      describe '.try_extracting_single_line_body_of' do
+        subject(:try_extracting_single_line_body) do
+          BlockSnippetExtractor.try_extracting_single_line_body_of(proc_object, 'target_method')
+        end
+
+        context 'with a single line body block' do
+          let(:expression) do
+            target_method { 1.positive? }
+          end
+
+          it 'returns the body' do
+            expect(try_extracting_single_line_body).to eq('1.positive?')
           end
         end
 
-        it 'returns nil' do
-          expect(try_extracting_single_line_body).to be_nil
-        end
-      end
-
-      context 'when the block snippet cannot be extracted due to ambiguity' do
-        let(:expression) do
-          target_method { 1.positive? }; dummy_object.target_method { 2.negative? }
-        end
-
-        let(:dummy_object) do
-          double('dummy_object', :target_method => nil)
-        end
-
-        it 'returns nil' do
-          expect(try_extracting_single_line_body).to be_nil
-        end
-      end
-    end
-
-    describe '#body_content_lines' do
-      subject(:body_content_lines) do
-        extractor.body_content_lines
-      end
-
-      context 'with `target_method {}`' do
-        let(:expression) do
-          target_method {}
-        end
-
-        it 'returns empty lines' do
-          expect(body_content_lines).to eq([])
-        end
-      end
-
-      context 'with `target_method { body }`' do
-        let(:expression) do
-          target_method { 1.positive? }
-        end
-
-        it 'returns the body content lines' do
-          expect(body_content_lines).to eq(['1.positive?'])
-        end
-      end
-
-      context 'with `target_method do body end`' do
-        let(:expression) do
-          target_method do
-            1.positive?
-          end
-        end
-
-        it 'returns the body content lines' do
-          expect(body_content_lines).to eq(['1.positive?'])
-        end
-      end
-
-      context 'with `target_method { |arg1, arg2| body }`' do
-        let(:expression) do
-          target_method { |_arg1, _arg2| 1.positive? }
-        end
-
-        it 'returns the body content lines' do
-          expect(body_content_lines).to eq(['1.positive?'])
-        end
-      end
-
-      context 'with `target_method(:arg1, :arg2) { body }`' do
-        let(:expression) do
-          target_method(:arg1, :arg2) { 1.positive? }
-        end
-
-        it 'returns the body content lines' do
-          expect(body_content_lines).to eq(['1.positive?'])
-        end
-      end
-
-      context 'with `target_method(:arg1,:arg2){|arg1,arg2|body}`' do
-        let(:expression) do
-          target_method(:arg1, :arg2) { |_arg1, _arg2|1.positive? }
-        end
-
-        it 'returns the body content lines' do
-          expect(body_content_lines).to eq(['1.positive?'])
-        end
-      end
-
-      context 'with a multiline block containing a single line body' do
-        let(:expression) do
-          target_method do
-            1.positive?
-          end
-        end
-
-        it 'returns the body content lines' do
-          expect(body_content_lines).to eq(['1.positive?'])
-        end
-      end
-
-      context 'with a multiline body block' do
-        let(:expression) do
-          target_method do
-            1.positive?
-            2.negative?
-          end
-        end
-
-        it 'returns the body content lines' do
-          expect(body_content_lines).to eq([
-            '1.positive?',
-            '2.negative?'
-          ])
-        end
-      end
-
-      context 'with `target_method { { :key => "value" } }`' do
-        let(:expression) do
-          target_method { { :key => "value" } }
-        end
-
-        it 'does not confuse the hash curly with the block closer' do
-          expect(body_content_lines).to eq(['{ :key => "value" }'])
-        end
-      end
-
-      context 'with a do-end block containing another do-end block' do
-        let(:expression) do
-          target_method do
-            2.times do |index|
-              puts index
+        context 'with a multiline body block' do
+          let(:expression) do
+            target_method do
+              1.positive?
+              2.negative?
             end
           end
+
+          it 'returns nil' do
+            expect(try_extracting_single_line_body).to be_nil
+          end
         end
 
-        it 'does not confuse the inner `end` with the outer `end`' do
-          expect(body_content_lines).to eq([
-            '2.times do |index|',
-            'puts index',
-            'end'
-          ])
+        context 'when the block snippet cannot be extracted due to ambiguity' do
+          let(:expression) do
+            target_method { 1.positive? }; dummy_object.target_method { 2.negative? }
+          end
+
+          let(:dummy_object) do
+            double('dummy_object', :target_method => nil)
+          end
+
+          it 'returns nil' do
+            expect(try_extracting_single_line_body).to be_nil
+          end
         end
       end
 
-      context "when there's another method invocation on the same line before the target" do
-        let(:expression) do
-          another_method { 2.negative? }; target_method { 1.positive? }
+      describe '#body_content_lines' do
+        subject(:body_content_lines) do
+          extractor.body_content_lines
         end
 
-        it 'correctly extracts the target snippet' do
-          expect(body_content_lines).to eq(['1.positive?'])
+        context 'with `target_method {}`' do
+          let(:expression) do
+            target_method {}
+          end
+
+          it 'returns empty lines' do
+            expect(body_content_lines).to eq([])
+          end
+        end
+
+        context 'with `target_method { body }`' do
+          let(:expression) do
+            target_method { 1.positive? }
+          end
+
+          it 'returns the body content lines' do
+            expect(body_content_lines).to eq(['1.positive?'])
+          end
+        end
+
+        context 'with `target_method do body end`' do
+          let(:expression) do
+            target_method do
+              1.positive?
+            end
+          end
+
+          it 'returns the body content lines' do
+            expect(body_content_lines).to eq(['1.positive?'])
+          end
+        end
+
+        context 'with `target_method { |arg1, arg2| body }`' do
+          let(:expression) do
+            target_method { |_arg1, _arg2| 1.positive? }
+          end
+
+          it 'returns the body content lines' do
+            expect(body_content_lines).to eq(['1.positive?'])
+          end
+        end
+
+        context 'with `target_method(:arg1, :arg2) { body }`' do
+          let(:expression) do
+            target_method(:arg1, :arg2) { 1.positive? }
+          end
+
+          it 'returns the body content lines' do
+            expect(body_content_lines).to eq(['1.positive?'])
+          end
+        end
+
+        context 'with `target_method(:arg1,:arg2){|arg1,arg2|body}`' do
+          let(:expression) do
+            target_method(:arg1, :arg2) { |_arg1, _arg2|1.positive? }
+          end
+
+          it 'returns the body content lines' do
+            expect(body_content_lines).to eq(['1.positive?'])
+          end
+        end
+
+        context 'with a multiline block containing a single line body' do
+          let(:expression) do
+            target_method do
+              1.positive?
+            end
+          end
+
+          it 'returns the body content lines' do
+            expect(body_content_lines).to eq(['1.positive?'])
+          end
+        end
+
+        context 'with a multiline body block' do
+          let(:expression) do
+            target_method do
+              1.positive?
+              2.negative?
+            end
+          end
+
+          it 'returns the body content lines' do
+            expect(body_content_lines).to eq([
+              '1.positive?',
+              '2.negative?'
+            ])
+          end
+        end
+
+        context 'with `target_method { { :key => "value" } }`' do
+          let(:expression) do
+            target_method { { :key => "value" } }
+          end
+
+          it 'does not confuse the hash curly with the block closer' do
+            expect(body_content_lines).to eq(['{ :key => "value" }'])
+          end
+        end
+
+        context 'with a do-end block containing another do-end block' do
+          let(:expression) do
+            target_method do
+              2.times do |index|
+                puts index
+              end
+            end
+          end
+
+          it 'does not confuse the inner `end` with the outer `end`' do
+            expect(body_content_lines).to eq([
+              '2.times do |index|',
+              'puts index',
+              'end'
+            ])
+          end
+        end
+
+        context "when there's another method invocation on the same line before the target" do
+          let(:expression) do
+            another_method { 2.negative? }; target_method { 1.positive? }
+          end
+
+          it 'correctly extracts the target snippet' do
+            expect(body_content_lines).to eq(['1.positive?'])
+          end
+        end
+
+        context "when there's another method invocation on the same line after the target" do
+          let(:expression) do
+            target_method { 1.positive? }; another_method { 2.negative? }
+          end
+
+          it 'correctly extracts the target snippet' do
+            expect(body_content_lines).to eq(['1.positive?'])
+          end
+        end
+
+        context "when there's another method invocation with the same name on the same line before the target" do
+          let(:expression) do
+            dummy_object.target_method { 2.negative? }; target_method { 1.positive? }
+          end
+
+          let(:dummy_object) do
+            double('dummy_object', :target_method => nil)
+          end
+
+          it 'raises AmbiguousTargetError' do
+            expect { body_content_lines }.to raise_error(BlockSnippetExtractor::AmbiguousTargetError)
+          end
+        end
+
+        context "when there's another method invocation with the same name on the same line after the target" do
+          let(:expression) do
+            target_method { 1.positive? }; dummy_object.target_method { 2.negative? }
+          end
+
+          let(:dummy_object) do
+            double('dummy_object', :target_method => nil)
+          end
+
+          it 'raises AmbiguousTargetError' do
+            expect { body_content_lines }.to raise_error(BlockSnippetExtractor::AmbiguousTargetError)
+          end
+        end
+
+        context "when there's another method invocation with the same name without block on the same line before the target" do
+          let(:expression) do
+            dummy_object.target_method; target_method { 1.positive? }
+          end
+
+          let(:dummy_object) do
+            double('dummy_object', :target_method => nil)
+          end
+
+          it 'correctly extracts the target snippet' do
+            expect(body_content_lines).to eq(['1.positive?'])
+          end
+        end
+
+        context "when there's another method invocation with the same name without block on the same line after the target" do
+          let(:expression) do
+            target_method { 1.positive? }; dummy_object.target_method
+          end
+
+          let(:dummy_object) do
+            double('dummy_object', :target_method => nil)
+          end
+
+          it 'correctly extracts the target snippet' do
+            expect(body_content_lines).to eq(['1.positive?'])
+          end
+        end
+
+        context 'when a hash is given as an argument' do
+          let(:expression) do
+            target_method({ :key => "value" }) { 1.positive? }
+          end
+
+          it 'correctly extracts the target snippet' do
+            expect(body_content_lines).to eq(['1.positive?'])
+          end
+        end
+
+        context 'when another method invocation with block is given as an argument' do
+          let(:expression) do
+            target_method(another_method { 2.negative? }) { 1.positive? }
+          end
+
+          it 'correctly extracts the target snippet' do
+            expect(body_content_lines).to eq(['1.positive?'])
+          end
+        end
+
+        context "when the block literal is described on different line with the method invocation" do
+          let(:expression) do
+            block = proc { 1.positive? }
+            target_method(&block)
+          end
+
+          it 'raises TargetNotFoundError' do
+            expect { body_content_lines }.to raise_error(BlockSnippetExtractor::TargetNotFoundError)
+          end
+        end
+
+        context 'with &:symbol syntax' do
+          let(:expression) do
+            target_method(&:positive?)
+          end
+
+          it 'raises TargetNotFoundError' do
+            expect { body_content_lines }.to raise_error(BlockSnippetExtractor::TargetNotFoundError)
+          end
         end
       end
+    end
 
-      context "when there's another method invocation on the same line after the target" do
-        let(:expression) do
-          target_method { 1.positive? }; another_method { 2.negative? }
-        end
+    describe BlockSnippetExtractor::PrismBlockSnippetExtractor, :skip => !RSpec::Support::RubyFeatures.prism_supported? do
+      it_behaves_like 'a block snippet extractor'
+    end
 
-        it 'correctly extracts the target snippet' do
-          expect(body_content_lines).to eq(['1.positive?'])
-        end
-      end
-
-      context "when there's another method invocation with the same name on the same line before the target" do
-        let(:expression) do
-          dummy_object.target_method { 2.negative? }; target_method { 1.positive? }
-        end
-
-        let(:dummy_object) do
-          double('dummy_object', :target_method => nil)
-        end
-
-        it 'raises AmbiguousTargetError' do
-          expect { body_content_lines }.to raise_error(BlockSnippetExtractor::AmbiguousTargetError)
-        end
-      end
-
-      context "when there's another method invocation with the same name on the same line after the target" do
-        let(:expression) do
-          target_method { 1.positive? }; dummy_object.target_method { 2.negative? }
-        end
-
-        let(:dummy_object) do
-          double('dummy_object', :target_method => nil)
-        end
-
-        it 'raises AmbiguousTargetError' do
-          expect { body_content_lines }.to raise_error(BlockSnippetExtractor::AmbiguousTargetError)
-        end
-      end
-
-      context "when there's another method invocation with the same name without block on the same line before the target" do
-        let(:expression) do
-          dummy_object.target_method; target_method { 1.positive? }
-        end
-
-        let(:dummy_object) do
-          double('dummy_object', :target_method => nil)
-        end
-
-        it 'correctly extracts the target snippet' do
-          expect(body_content_lines).to eq(['1.positive?'])
-        end
-      end
-
-      context "when there's another method invocation with the same name without block on the same line after the target" do
-        let(:expression) do
-          target_method { 1.positive? }; dummy_object.target_method
-        end
-
-        let(:dummy_object) do
-          double('dummy_object', :target_method => nil)
-        end
-
-        it 'correctly extracts the target snippet' do
-          expect(body_content_lines).to eq(['1.positive?'])
-        end
-      end
-
-      context 'when a hash is given as an argument' do
-        let(:expression) do
-          target_method({ :key => "value" }) { 1.positive? }
-        end
-
-        it 'correctly extracts the target snippet' do
-          expect(body_content_lines).to eq(['1.positive?'])
-        end
-      end
-
-      context 'when another method invocation with block is given as an argument' do
-        let(:expression) do
-          target_method(another_method { 2.negative? }) { 1.positive? }
-        end
-
-        it 'correctly extracts the target snippet' do
-          expect(body_content_lines).to eq(['1.positive?'])
-        end
-      end
-
-      context "when the block literal is described on different line with the method invocation" do
-        let(:expression) do
-          block = proc { 1.positive? }
-          target_method(&block)
-        end
-
-        it 'raises TargetNotFoundError' do
-          expect { body_content_lines }.to raise_error(BlockSnippetExtractor::TargetNotFoundError)
-        end
-      end
-
-      context 'with &:symbol syntax' do
-        let(:expression) do
-          target_method(&:positive?)
-        end
-
-        it 'raises TargetNotFoundError' do
-          expect { body_content_lines }.to raise_error(BlockSnippetExtractor::TargetNotFoundError)
-        end
-      end
+    describe BlockSnippetExtractor::RipperBlockSnippetExtractor, :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+      it_behaves_like 'a block snippet extractor'
     end
   end
 end

--- a/rspec-expectations/spec/rspec/matchers/built_in/change_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/change_spec.rb
@@ -363,7 +363,7 @@ RSpec.describe "expect { ... }.to change { block }" do
     end.to raise_error(SyntaxError, /Block not received by the `change` matcher/)
   end
 
-  context 'in Ripper supported environment', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+  context 'in parser supported environment', :skip => !RSpec::Support::RubyFeatures.parser_supported? do
     context 'when the block body fits into a single line' do
       it "provides a #description with the block snippet" do
         expect(change { @instance.some_value }.description).to eq "change `@instance.some_value`"
@@ -397,7 +397,7 @@ RSpec.describe "expect { ... }.to change { block }" do
     end
   end
 
-  context 'in Ripper unsupported environment', :skip => RSpec::Support::RubyFeatures.ripper_supported? do
+  context 'in parser unsupported environment', :skip => RSpec::Support::RubyFeatures.parser_supported? do
     it "provides a #description without the block snippet" do
       expect(change { @instance.some_value }.description).to eq "change result"
     end
@@ -601,13 +601,13 @@ RSpec.describe "expect { ... }.to change { block }.by(expected)" do
     end.to fail_with(/expected #{value_pattern} to have changed by 1, but was changed by -1/)
   end
 
-  context 'in Ripper supported environment', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+  context 'in parser supported environment', :skip => !RSpec::Support::RubyFeatures.parser_supported? do
     it "provides a #description with the block snippet" do
       expect(change { @instance.some_value }.by(3).description).to eq "change `@instance.some_value` by 3"
     end
   end
 
-  context 'in Ripper unsupported environment', :skip => RSpec::Support::RubyFeatures.ripper_supported? do
+  context 'in parser unsupported environment', :skip => RSpec::Support::RubyFeatures.parser_supported? do
     it "provides a #description without the block snippet" do
       expect(change { @instance.some_value }.by(3).description).to eq "change result by 3"
     end
@@ -659,13 +659,13 @@ RSpec.describe "expect { ... }.to change { block }.by_at_least(expected)" do
     end.to fail_with(/expected #{value_pattern} to have changed by at least 2, but was changed by 1/)
   end
 
-  context 'in Ripper supported environment', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+  context 'in parser supported environment', :skip => !RSpec::Support::RubyFeatures.parser_supported? do
     it "provides a #description with the block snippet" do
       expect(change { @instance.some_value }.by_at_least(3).description).to eq "change `@instance.some_value` by at least 3"
     end
   end
 
-  context 'in Ripper unsupported environment', :skip => RSpec::Support::RubyFeatures.ripper_supported? do
+  context 'in parser unsupported environment', :skip => RSpec::Support::RubyFeatures.parser_supported? do
     it "provides a #description without the block snippet" do
       expect(change { @instance.some_value }.by_at_least(3).description).to eq "change result by at least 3"
     end
@@ -717,13 +717,13 @@ RSpec.describe "expect { ... }.to change { block }.by_at_most(expected)" do
     end.to fail_with(/expected #{value_pattern} to have changed by at most 1, but was changed by 2/)
   end
 
-  context 'in Ripper supported environment', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+  context 'in parser supported environment', :skip => !RSpec::Support::RubyFeatures.parser_supported? do
     it "provides a #description with the block snippet" do
       expect(change { @instance.some_value }.by_at_most(3).description).to eq "change `@instance.some_value` by at most 3"
     end
   end
 
-  context 'in Ripper unsupported environment', :skip => RSpec::Support::RubyFeatures.ripper_supported? do
+  context 'in parser unsupported environment', :skip => RSpec::Support::RubyFeatures.parser_supported? do
     it "provides a #description without the block snippet" do
       expect(change { @instance.some_value }.by_at_most(3).description).to eq "change result by at most 3"
     end
@@ -792,13 +792,13 @@ RSpec.describe "expect { ... }.to change { block }.from(old)" do
     end.to fail_with(/expected #{value_pattern} to have changed from "string", but did not change/)
   end
 
-  context 'in Ripper supported environment', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+  context 'in parser supported environment', :skip => !RSpec::Support::RubyFeatures.parser_supported? do
     it "provides a #description with the block snippet" do
       expect(change { @instance.some_value }.from(3).description).to eq "change `@instance.some_value` from 3"
     end
   end
 
-  context 'in Ripper unsupported environment', :skip => RSpec::Support::RubyFeatures.ripper_supported? do
+  context 'in parser unsupported environment', :skip => RSpec::Support::RubyFeatures.parser_supported? do
     it "provides a #description without the block snippet" do
       expect(change { @instance.some_value }.from(3).description).to eq "change result from 3"
     end

--- a/rspec-expectations/spec/rspec/matchers/built_in/satisfy_spec.rb
+++ b/rspec-expectations/spec/rspec/matchers/built_in/satisfy_spec.rb
@@ -17,16 +17,16 @@ RSpec.describe "expect(...).to satisfy { block }" do
   end
 
   context "when no custom description is provided" do
-    context 'in Ripper supported environment', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+    context 'in parser supported environment', :skip => !RSpec::Support::RubyFeatures.parser_supported? do
       it "fails with block snippet if block returns false" do
         expect {
           expect(false).to satisfy { |val| val }
         }.to fail_with("expected false to satisfy expression `val`")
 
         expect do
-          expect(false).to satisfy do |val|
+          expect(false).to(satisfy do |val|
             val
-          end
+          end)
         end.to fail_with("expected false to satisfy expression `val`")
       end
 
@@ -41,7 +41,7 @@ RSpec.describe "expect(...).to satisfy { block }" do
       end
     end
 
-    context 'in Ripper unsupported environment', :skip => RSpec::Support::RubyFeatures.ripper_supported? do
+    context 'in parser unsupported environment', :skip => RSpec::Support::RubyFeatures.parser_supported? do
       it "fails without block snippet if block returns false" do
         expect {
           expect(false).to satisfy { |val| val }
@@ -90,7 +90,7 @@ RSpec.describe "expect(...).not_to satisfy { block }" do
   end
 
   context "when no custom description is provided" do
-    context 'in Ripper supported environment', :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+    context 'in parser supported environment', :skip => !RSpec::Support::RubyFeatures.parser_supported? do
       it "fails with block snippet if block returns true" do
         expect {
           expect(true).not_to satisfy { |val| val }
@@ -98,7 +98,7 @@ RSpec.describe "expect(...).not_to satisfy { block }" do
       end
     end
 
-    context 'in Ripper unsupported environment', :skip => RSpec::Support::RubyFeatures.ripper_supported? do
+    context 'in parser unsupported environment', :skip => RSpec::Support::RubyFeatures.parser_supported? do
       it "fails without block snippet if block returns true" do
         expect {
           expect(true).not_to satisfy { |val| val }

--- a/rspec-expectations/spec/spec_helper.rb
+++ b/rspec-expectations/spec/spec_helper.rb
@@ -7,6 +7,11 @@ require 'io/console' if RSpec::Support::Ruby.jruby? && RSpec::Support::OS.apple_
 
 RSpec::Support::Spec::Coverage.setup do
   minimum_coverage 100
+
+  if RUBY_VERSION.to_f < 3.3
+    # We use Prism on later Rubies which can't be checked for coverage here.
+    add_filter "lib/rspec/expectations/block_snippet_extractor.rb"
+  end
 end
 
 Dir['./spec/support/**/*.rb'].each do |f|

--- a/rspec-mocks/features/setting_constraints/matching_arguments.feature
+++ b/rspec-mocks/features/setting_constraints/matching_arguments.feature
@@ -132,7 +132,7 @@ Feature: Matching arguments
       | expected: (a collection containing exactly 1 and 2)           |
       | got: ([1, 3])                                                 |
 
-  @skip-when-no-ripper-or-jruby
+  @skip-when-no-parser-or-jruby
   Scenario: Using satisfy for complex custom expecations
     Given a file named "rspec_satisfy_spec.rb" with:
       """ruby

--- a/rspec-mocks/features/support/env.rb
+++ b/rspec-mocks/features/support/env.rb
@@ -21,12 +21,12 @@ Before do
   end
 end
 
-Before('@skip-when-no-ripper-or-jruby') do |scenario|
-  if RSpec::Support::Ruby.jruby? || !RSpec::Support::RubyFeatures.ripper_supported?
+Before('@skip-when-no-parser-or-jruby') do |scenario|
+  if RSpec::Support::Ruby.jruby? || !RSpec::Support::RubyFeatures.parser_supported?
     if RSpec::Support::Ruby.jruby?
       warn "Skipping scenario due to lack of support by JRuby"
     else
-      warn "Skipping scenario due to lack of Ripper support"
+      warn "Skipping scenario due to lack of parser support"
     end
 
     if Cucumber::VERSION.to_f >= 3.0

--- a/rspec-support/lib/rspec/support/ruby_features.rb
+++ b/rspec-support/lib/rspec/support/ruby_features.rb
@@ -86,6 +86,16 @@ module RSpec
         end
       end
 
+      if RUBY_VERSION.to_f >= 3.3 && !Ruby.rbx? && !Ruby.jruby?
+        def prism_supported?
+          true
+        end
+      else
+        def prism_supported?
+          false
+        end
+      end
+
       # TruffleRuby disables ripper due to low performance
       if Ruby.rbx? || Ruby.truffleruby?
         def ripper_supported?
@@ -95,6 +105,10 @@ module RSpec
         def ripper_supported?
           true
         end
+      end
+
+      def parser_supported?
+        prism_supported? || ripper_supported?
       end
     end
   end

--- a/rspec-support/lib/rspec/support/source.rb
+++ b/rspec-support/lib/rspec/support/source.rb
@@ -38,14 +38,40 @@ module RSpec
         "#<#{self.class} #{path}>"
       end
 
-      if RSpec::Support::RubyFeatures.ripper_supported?
-        RSpec::Support.require_rspec_support 'source/node'
-        RSpec::Support.require_rspec_support 'source/token'
+      class BaseSource
+        attr_reader :source
 
+        def initialize(source)
+          @source = source
+        end
+
+        def path
+          source.path
+        end
+
+        def lines
+          source.lines
+        end
+
+        def inspect
+          source.inspect
+        end
+      end
+
+      class PrismSource < BaseSource
+        def parse_result
+          @parse_result ||= begin
+            require 'prism'
+            Prism.parse(source.source.to_str)
+          end
+        end
+      end
+
+      class RipperSource < BaseSource
         def ast
           @ast ||= begin
             require 'ripper'
-            sexp = Ripper.sexp(source)
+            sexp = Ripper.sexp(source.source)
             raise SyntaxError unless sexp
             Node.new(sexp)
           end
@@ -54,7 +80,7 @@ module RSpec
         def tokens
           @tokens ||= begin
             require 'ripper'
-            tokens = Ripper.lex(source)
+            tokens = Ripper.lex(source.source)
             Token.tokens_from_ripper_tokens(tokens)
           end
         end
@@ -73,6 +99,13 @@ module RSpec
           end
         end
       end
+
+      # :nocov:
+      if RSpec::Support::RubyFeatures.ripper_supported?
+        RSpec::Support.require_rspec_support 'source/node'
+        RSpec::Support.require_rspec_support 'source/token'
+      end
+      # :nocov:
     end
   end
 end

--- a/rspec-support/spec/rspec/support/ruby_features_spec.rb
+++ b/rspec-support/spec/rspec/support/ruby_features_spec.rb
@@ -106,6 +106,27 @@ module RSpec
         expect(RubyFeatures.supports_syntax_suggest?).to eq(RUBY_VERSION.to_f >= 3.2)
       end
 
+      describe "#prism_supported?" do
+        def prism_is_implemented?
+          in_sub_process_if_possible do
+            begin
+              require 'prism'
+              true
+            rescue LoadError
+              false
+            end
+          end
+        end
+
+        it 'returns whether Prism is correctly implemented in the current environment' do
+          expect(RubyFeatures.prism_supported?).to eq(prism_is_implemented?)
+        end
+
+        it 'does not load Prism' do
+          expect { RubyFeatures.prism_supported? }.not_to change { defined?(::Prism) }
+        end
+      end
+
       describe "#ripper_supported?" do
         def ripper_is_implemented?
           in_sub_process_if_possible do

--- a/rspec-support/spec/rspec/support/source_spec.rb
+++ b/rspec-support/spec/rspec/support/source_spec.rb
@@ -3,7 +3,7 @@
 require 'rspec/support/source'
 
 module RSpec::Support
-  RSpec.describe Source, :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+  RSpec.describe Source, :skip => !RSpec::Support::RubyFeatures.parser_supported? do
     subject(:source) do
       Source.new(source_string)
     end
@@ -71,6 +71,42 @@ module RSpec::Support
       end
     end
 
+    describe '#inspect' do
+      it 'returns a string including class name and file path' do
+        expect(source.inspect).to start_with('#<RSpec::Support::Source (string)>')
+      end
+    end
+  end
+
+  RSpec.describe Source::PrismSource, :skip => !RSpec::Support::RubyFeatures.prism_supported? do
+    subject(:source) do
+      Source::PrismSource.new(Source.new(source_string))
+    end
+
+    let(:source_string) { <<-END.gsub(/^ +\|/, '') }
+      |2.times do
+      |  puts :foo
+      |end
+    END
+
+    describe '#parse_result' do
+      it 'returns a Prism::ParseResult' do
+        expect(source.parse_result).to be_a(Prism::ParseResult)
+      end
+    end
+  end
+
+  RSpec.describe Source::RipperSource, :skip => !RSpec::Support::RubyFeatures.ripper_supported? do
+    subject(:source) do
+      Source::RipperSource.new(Source.new(source_string))
+    end
+
+    let(:source_string) { <<-END.gsub(/^ +\|/, '') }
+      |2.times do
+      |  puts :foo
+      |end
+    END
+
     describe '#ast' do
       it 'returns a root node' do
         expect(source.ast).to have_attributes(:type => :program)
@@ -128,12 +164,6 @@ module RSpec::Support
         )
 
         expect(source.tokens_by_line_number[0]).to be_empty
-      end
-    end
-
-    describe '#inspect' do
-      it 'returns a string including class name and file path' do
-        expect(source.inspect).to start_with('#<RSpec::Support::Source (string)>')
       end
     end
   end


### PR DESCRIPTION
There are two places where RSpec uses Ripper for parsing Ruby source: SnippetExtractor and BlockSnippetExtractor. This commit changes them to use Prism instead. A couple of benefits right off the bat:

* The implementation is much simpler. It is about 20 LOC for SnippetExtractor with Prism, and 30 LOC for BlockSnippetExtractor. For Ripper it is about 100 LOC for SnippetExtractor + management of tokens and nodes. For BlockSnippetExtract it is about 200 LOC
  + management of a parsing state machine.
* It is more correct. There is a test failure where it knows it cannot parse the heredoc, but with Prism you get that for free. There is also a place where it was incorrectly attributing a block for the BlockSnippetExtractor in the test, because {} and do/end are not interchangeable in the context of a method call without parentheses. This all comes for free.
* It is faster, sometimes by orders of magnitude depending on the file being parsed.
* It is more portable. CRuby, JRuby, and TruffleRuby will all support this out of the box, so you no longer have to worry about detecting the implementation at runtime.

There is a question here of if you want to drop support for the Ripper implementation entirely (3.2 is EOL in a month). In this commit I have left it in place, prioritizing Prism if it is available.

There are two remaining test failures:
* I wasn't sure if you wanted to explicitly reject there heredoc case or not. Happy to go either way.
* I wasn't sure exactly how you handle requires and sandboxing. I'm sure there's a way to list Prism as an allowed require, but I can't figure out exactly where to put that.