### PR TITLE
Add CI checks for diff-lcs version 2.

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -72,6 +72,30 @@ jobs:
       - run: ../script/bundle
       - run: ../script/run_rspec
 
+  diff_lcs:
+    name: Diff LCS version 2 checks ${{ matrix.ruby }}
+    runs-on: 'ubuntu-latest'
+    strategy:
+      matrix:
+        ruby:
+          - '4.0'
+          - '3.4'
+          - '3.3'
+          - '3.2'
+      fail-fast: false
+    continue-on-error: false
+    defaults:
+      run:
+        working-directory: ${{ inputs.library }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: ../script/update_rubygems_and_install_bundler
+      - run: ../script/bundle diff-lcs
+      - run: bundle exec --gemfile=../Gemfile-diff-lcs rspec
+
   windows:
     name: Ruby ${{ matrix.ruby }} (Windows)
     runs-on: windows-latest

--- a/Gemfile-diff-lcs
+++ b/Gemfile-diff-lcs
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+source "https://gem.coop"
+
+%w[rspec rspec-core rspec-expectations rspec-mocks rspec-support].each do |lib|
+  gem lib, :path => File.expand_path("../#{lib}", __FILE__)
+end
+
+# Core gems required
+gem "aruba"
+gem "coderay"
+gem "rake"
+gem "simplecov"
+
+# Ruby dependencies required
+gem "drb"
+gem "logger"
+gem "thread_order"
+
+gem "diff-lcs", "~> 2.0.0"

--- a/script/bundle
+++ b/script/bundle
@@ -1,13 +1,20 @@
 set -e
 
-SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+SCRIPT_DIR="${ROOT_DIR}/script"
 source $SCRIPT_DIR/functions.sh
 
 echo "Set bundle path to .bundle/gems"
 bundle config set --local path '.bundle/gems'
 
-echo "bundle install --standalone"
-bundle install --standalone
+if [[ -n "$1" ]]; then
+  GEMFILE="Gemfile-${1}"
+  echo "bundle install --standalone --gemfile=${GEMFILE}"
+  bundle install --standalone --gemfile="${ROOT_DIR}/${GEMFILE}"
+else
+  echo "bundle install --standalone"
+  bundle install --standalone
 
-echo "bundle binstubs --all --standalone"
-bundle binstubs --all --standalone
+  echo "bundle binstubs --all --standalone"
+  bundle binstubs --all --standalone
+fi;


### PR DESCRIPTION
This isn't ready yet due to our dependencies combined with Aruba and Cucumber force 1.6 on the normal suite, but because (as coined in #290) this creates a "chicken and egg" scenario I've pushed out the changes that relax our requirement on diff-lcs 1.6.

What this needs to complete is the other gems to update and to check we continue to pass, the failures here are actually due to *outdated* versions of gems which are compatible with diff-lcs 2.0.0

If using diff-lcs 2.0.0 off main please consider it may not function correctly at this time.