### PR TITLE
Correct links to remove rspec-{name} from tags

### DIFF
--- a/rspec-core/rspec-core.gemspec
+++ b/rspec-core/rspec-core.gemspec
@@ -14,10 +14,10 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/tree/rspec-core-v#{s.version}/rspec-core/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}/rspec-core/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/tree/rspec-core-v#{s.version}/rspec-core",
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}/rspec-core",
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-expectations/rspec-expectations.gemspec
+++ b/rspec-expectations/rspec-expectations.gemspec
@@ -16,10 +16,10 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/tree/rspec-expectations-v#{s.version}/rspec-expectations/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}/rspec-expectations/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/tree/rspec-expectations-v#{s.version}/rspec-expectations",
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}/rspec-expectations",
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-mocks/rspec-mocks.gemspec
+++ b/rspec-mocks/rspec-mocks.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/tree/rspec-mocks-v#{s.version}/rspec-mocks/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}/rspec-mocks/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
-    'source_code_uri' => "https://github.com/rspec/rspec/tree/rspec-mocks-v#{s.version}/rspec-mocks",
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}/rspec-mocks",
     'rubygems_mfa_required' => 'true',
   }
 

--- a/rspec-support/rspec-support.gemspec
+++ b/rspec-support/rspec-support.gemspec
@@ -16,11 +16,11 @@ Gem::Specification.new do |s|
 
   s.metadata = {
     'bug_tracker_uri' => 'https://github.com/rspec/rspec/issues',
-    'changelog_uri' => "https://github.com/rspec/rspec/tree/rspec-support-v#{s.version}/rspec-support/Changelog.md",
+    'changelog_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}/rspec-support/Changelog.md",
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
     'rubygems_mfa_required' => 'true',
-    'source_code_uri' => "https://github.com/rspec/rspec/tree/rspec-support-v#{s.version}/rspec-support",
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}/rspec-support",
   }
 
   s.files         = `git ls-files -- lib/*`.split("\n")

--- a/rspec/rspec.gemspec
+++ b/rspec/rspec.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
     'documentation_uri' => 'https://rspec.info/documentation/',
     'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/rspec',
     'rubygems_mfa_required' => 'true',
-    'source_code_uri' => "https://github.com/rspec/rspec/tree/rspec-v#{s.version}/rspec"
+    'source_code_uri' => "https://github.com/rspec/rspec/tree/v#{s.version}/rspec"
   }
 
   s.files            = `git ls-files -- lib/*`.split("\n")


### PR DESCRIPTION
For 4.0.0 beta/rc/release we will use the unified v4.0.0 tag, this fixes links for those future releases.