### PR TITLE
Document early-stopping behaviour of mocks

### DIFF
--- a/rspec-mocks/lib/rspec/mocks/error_generator.rb
+++ b/rspec-mocks/lib/rspec/mocks/error_generator.rb
@@ -4,6 +4,16 @@ RSpec::Support.require_rspec_support 'ruby_features'
 module RSpec
   module Mocks
     # Raised when a message expectation is not satisfied.
+    #
+    # This inherits from `Exception` (not `StandardError`) so that a
+    # `rescue => e` or `rescue StandardError` in the code under test
+    # will not accidentally swallow it. This allows rspec to immediately
+    # halt execution of the tested code when an unexpected message is received.
+    #
+    # However, code that does `rescue Exception` *will* intercept this error.
+    # The failure will still be reported at the end of the example,
+    # but the tested code will continue executing instead of stopping immediately,
+    # which may cause confusing behavior or misleading secondary errors.
     MockExpectationError = Class.new(Exception)
 
     # Raised when a test double is used after it has been torn

--- a/rspec-mocks/lib/rspec/mocks/message_expectation.rb
+++ b/rspec-mocks/lib/rspec/mocks/message_expectation.rb
@@ -230,6 +230,10 @@ module RSpec
       # Constrain a message expectation to be received a specific number of
       # times.
       #
+      # If the message is received too many times, a {MockExpectationError}
+      # will be raised immediately. This usually stops the rest of the example
+      # from running, but not always. See the {MockExpectationError} documentation.
+      #
       # @return [MessageExpectation] self, to support further chaining.
       # @example
       #   expect(dealer).to receive(:deal_card).exactly(10).times
@@ -262,6 +266,10 @@ module RSpec
       # Constrain a message expectation to be received at most a specific
       # number of times.
       #
+      # If the message is received too many times, a {MockExpectationError}
+      # will be raised immediately. This usually stops the rest of the example
+      # from running, but not always. See the {MockExpectationError} documentation.
+      #
       # @return [MessageExpectation] self, to support further chaining.
       # @example
       #   expect(dealer).to receive(:deal_card).at_most(10).times
@@ -287,6 +295,10 @@ module RSpec
 
       # Expect a message not to be received at all.
       #
+      # If the message is received anyway, a {MockExpectationError}
+      # will be raised immediately. This usually stops the rest of the example
+      # from running, but not always. See the {MockExpectationError} documentation.
+      #
       # @return [MessageExpectation] self, to support further chaining.
       # @example
       #   expect(car).to receive(:stop).never
@@ -297,6 +309,10 @@ module RSpec
       end
 
       # Expect a message to be received exactly one time.
+      #
+      # If the message is received more than once, a {MockExpectationError}
+      # will be raised immediately. This usually stops the rest of the example
+      # from running, but not always. See the {MockExpectationError} documentation.
       #
       # @return [MessageExpectation] self, to support further chaining.
       # @example
@@ -309,6 +325,10 @@ module RSpec
 
       # Expect a message to be received exactly two times.
       #
+      # If the message is received more than twice, a {MockExpectationError}
+      # will be raised immediately. This usually stops the rest of the example
+      # from running, but not always. See the {MockExpectationError} documentation.
+      #
       # @return [MessageExpectation] self, to support further chaining.
       # @example
       #   expect(car).to receive(:go).twice
@@ -319,6 +339,10 @@ module RSpec
       end
 
       # Expect a message to be received exactly three times.
+      #
+      # If the message is received more than thrice, a {MockExpectationError}
+      # will be raised immediately. This usually stops the rest of the example
+      # from running, but not always. See the {MockExpectationError} documentation.
       #
       # @return [MessageExpectation] self, to support further chaining.
       # @example


### PR DESCRIPTION
Mocked methods like `.never` usually end the execution of the code under test, but not always.

```ruby
def get_name = "Bob"
def greet(name) = puts "Hello #{name}"

expect(self).to receive(:get_name).never

begin
  name = get_name # This raises `MockExpectationError` immediately
  greet(name) # Not called
rescue Exception => e
  # swallowed (but RSpec still knows it happened, and will fail the example when it finishes)
end

puts "but this still gets called"
```

This PR documents this behaviour, which might be surprising.