### PR TITLE
Turn off Lint/DuplicateMethods in specs due to issue with false positives

### DIFF
--- a/common_rubocop_config.yml
+++ b/common_rubocop_config.yml
@@ -99,6 +99,10 @@ Lint/AmbiguousOperatorPrecedence:
   Exclude:
     - '**/benchmarks/**/*'
 
+Lint/DuplicateMethods:
+  Exclude:
+    - '*/spec/**/*_spec.rb'
+
 Lint/EmptyBlock:
   Exclude:
     - '**/benchmarks/**/*'


### PR DESCRIPTION
This rule fails on our specs due to the fact that we define methods on dynamic classes a lot, and it seems it doesn't understand that the same name for a variable will be different classes.