### PR TITLE
chore: correct failing cops

### DIFF
--- a/rspec-core/benchmarks/check_inclusion.rb
+++ b/rspec-core/benchmarks/check_inclusion.rb
@@ -32,7 +32,7 @@ Benchmark.benchmark do |bm|
   3.times do
     bm.report do
       n.times do
-        Foo.included_modules.include?(modules.first) # rubocop:disable Style/ModuleMemberExistenceCheck
+        Foo.included_modules.include?(modules.first)
       end
     end
   end
@@ -42,7 +42,7 @@ Benchmark.benchmark do |bm|
   3.times do
     bm.report do
       n.times do
-        Foo.included_modules.include?(modules.last) # rubocop:disable Style/ModuleMemberExistenceCheck
+        Foo.included_modules.include?(modules.last)
       end
     end
   end


### PR DESCRIPTION
This reverts commit 8b96620688e9e2dd1fe5834ec26646e839285854.

I guess the upstream change was since addressed.