### PR TITLE
test: test against JRuby 10.1

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -56,8 +56,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - jruby-9.4
-          - jruby-10.0
+          - jruby-10.1 # ruby 4.0 compatible
+          - jruby-10.0 # ruby 3.4 compatible
+          - jruby-9.4  # ruby 3.1 compatible
       fail-fast: false
     continue-on-error: false
     defaults:

--- a/rspec-core/spec/integration/bisect_spec.rb
+++ b/rspec-core/spec/integration/bisect_spec.rb
@@ -15,12 +15,6 @@ module RSpec::Core
       normalize_durations(formatter_output.string)
     end
 
-    before do
-      if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version == '9.1.17.0'
-        skip "These specs are currently broken on JRuby 9.1.17.0"
-      end
-    end
-
     context "when a load-time problem occurs while running the suite" do
       it 'surfaces the stdout and stderr output to the user' do
         output = bisect(%w[spec/rspec/core/resources/fail_on_load_spec.rb_], 1)

--- a/rspec-core/spec/integration/spec_file_load_errors_spec.rb
+++ b/rspec-core/spec/integration/spec_file_load_errors_spec.rb
@@ -236,7 +236,10 @@ RSpec.describe 'Spec file load errors' do
         end
       end
     else
-      it 'prints a basic error when no syntax_suggest is available/loaded', :skip => RSpec::Support::Ruby.jruby? do
+      it 'prints a basic error when no syntax_suggest is available/loaded' do
+        if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version < '10'
+          skip 'JRuby < 10 cannot get the __send__ backtrace correctly'
+        end
         run_command "--require ./broken_file"
         expect(last_cmd_exit_status).to eq(error_exit_code)
 

--- a/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
+++ b/rspec-core/spec/rspec/core/formatters/exception_presenter_spec.rb
@@ -587,9 +587,6 @@ module RSpec::Core
 
         context 'and the line count does not exceed RSpec.configuration.max_displayed_failure_line_count' do
           it 'returns all the lines' do
-            if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version < '9.2.0.0'
-              pending 'https://github.com/jruby/jruby/issues/4737'
-            end
             expect(read_failed_lines).to eq([
               "            expect('RSpec').to be_a(String).",
               "                           and start_with('R').",
@@ -604,9 +601,6 @@ module RSpec::Core
           end
 
           it 'returns the lines without exceeding the max count' do
-            if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version < '9.2.0.0'
-              pending 'https://github.com/jruby/jruby/issues/4737'
-            end
             expect(read_failed_lines).to eq([
               "            expect('RSpec').to be_a(String).",
               "                           and start_with('R')."

--- a/rspec-core/spec/rspec/core/formatters/snippet_extractor_spec.rb
+++ b/rspec-core/spec/rspec/core/formatters/snippet_extractor_spec.rb
@@ -160,8 +160,7 @@ module RSpec::Core::Formatters
         end
       end
 
-      argument_error_points_invoker = RSpec::Support::Ruby.jruby?
-      context 'when the expression is a method definition and ends with "end"-only line', :skip => argument_error_points_invoker do
+      context 'when the expression is a method definition and ends with "end"-only line' do
         let(:source) do
           obj = Object.new
 
@@ -222,7 +221,7 @@ module RSpec::Core::Formatters
         end
       end
 
-      context 'when the expression is a setter method definition', :skip => argument_error_points_invoker do
+      context 'when the expression is a setter method definition' do
         let(:source) do
           obj = Object.new
 

--- a/rspec-core/spec/rspec/core_spec.rb
+++ b/rspec-core/spec/rspec/core_spec.rb
@@ -10,9 +10,6 @@ RSpec.describe RSpec do
     %r{/fake_libs/},  # ignore these, obviously
   ]
 
-  # JRuby appears to not respect `--disable=gem` so rubygems also gets loaded.
-  allowed_loaded_features << /rubygems/ if RSpec::Support::Ruby.jruby?
-
   # Truffleruby cext files
   allowed_loaded_features << /\/truffle\/cext/ if RSpec::Support::Ruby.truffleruby?
 

--- a/rspec-core/spec/support/aruba_support.rb
+++ b/rspec-core/spec/support/aruba_support.rb
@@ -1,27 +1,5 @@
 require 'support/helper_methods'
 
-if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version == "9.1.17.0"
-  # A regression appeared in require_relative in JRuby 9.1.17.0 where require some
-  # how ends up private, this monkey patch uses `send`
-  module Kernel
-    module_function
-      def require_relative(relative_arg)
-        relative_arg = relative_arg.to_path if relative_arg.respond_to? :to_path
-        relative_arg = JRuby::Type.convert_to_str(relative_arg)
-
-        caller(1, 1).first.rindex(/:\d+:in /)
-        file = $` # just the filename
-        raise LoadError, "cannot infer basepath" if /\A\((.*)\)/ =~ file # eval etc.
-
-        absolute_feature = File.expand_path(relative_arg, File.dirname(File.realpath(file)))
-
-        # This was the original:
-        # ::Kernel.require absolute_feature
-        ::Kernel.send(:require, absolute_feature)
-      end
-  end
-end
-
 module ArubaLoader
   extend RSpec::Support::WithIsolatedStdErr
 

--- a/rspec-mocks/spec/rspec/mocks/any_instance_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/any_instance_spec.rb
@@ -1432,12 +1432,19 @@ module RSpec
       context "when a class overrides Object#method" do
         let(:http_request_class) { Struct.new(:method, :uri) }
 
-        it "stubs the method correctly" do
+        broken_on_jruby_10_1 =
+          if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version >= '10.1.0.0'
+            "re-raising exceptions currently broken due to https://github.com/jruby/jruby/issues/9398"
+          else
+            false
+          end
+
+        it "stubs the method correctly", :pending => broken_on_jruby_10_1 do
           allow_any_instance_of(http_request_class).to receive(:existing_method).and_return("foo")
           expect(http_request_class.new.existing_method).to eq "foo"
         end
 
-        it "mocks the method correctly" do
+        it "mocks the method correctly", :pending => broken_on_jruby_10_1 do
           expect_any_instance_of(http_request_class).to receive(:existing_method).and_return("foo")
           expect(http_request_class.new.existing_method).to eq "foo"
         end

--- a/rspec-mocks/spec/rspec/mocks/matchers/receive_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/matchers/receive_spec.rb
@@ -612,6 +612,9 @@ module RSpec
           end
 
           it 'does not result in infinite recursion when `respond_to?` is stubbed' do
+            if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version >= '10.1.0.0'
+              skip 'Flaky on JRuby 10.1 due to some interaction with Object#instance_exec (?) https://github.com/rspec/rspec/issues/321'
+            end
             # Setting a method expectation causes the method to be proxied
             # RSpec may call #respond_to? when processing a failed expectation
             # If those internal calls go to the proxied method, that could

--- a/rspec-mocks/spec/support/aruba.rb
+++ b/rspec-mocks/spec/support/aruba.rb
@@ -1,14 +1,9 @@
-begin
-  require 'aruba/rspec'
+require 'aruba/rspec'
 
-  Aruba.configure do |config|
-    if RUBY_PLATFORM =~ /java/ || defined?(Rubinius) || (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'truffleruby')
-      config.exit_timeout = 60
-    else
-      config.exit_timeout = 5
-    end
+Aruba.configure do |config|
+  if RUBY_PLATFORM =~ /java/ || defined?(Rubinius) || (defined?(RUBY_ENGINE) && RUBY_ENGINE == 'truffleruby')
+    config.exit_timeout = 60
+  else
+    config.exit_timeout = 5
   end
-rescue NameError, LoadError => e
-  # This silences a name error on unsupported version of JRuby
-  raise e unless RSpec::Support::Ruby.jruby? && JRUBY_VERSION =~ /9\.1\.17\.0/
 end

--- a/rspec-support/spec/rspec/support_spec.rb
+++ b/rspec-support/spec/rspec/support_spec.rb
@@ -53,6 +53,9 @@ module RSpec
 
       it 'fails with `NameError` when an undefined method is fetched ' +
          'from an object that has overridden `method` to raise an Exception' do
+        if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version >= '10.1.0.0'
+          pending 'https://github.com/jruby/jruby/issues/9398'
+        end
         object = double
         allow(object).to receive(:method).and_raise(Exception)
         expect {


### PR DESCRIPTION
JRuby 10.1 is CRuby 4.0 compatible and has been released: https://www.jruby.org/2026/04/21/jruby-10-1-0-0.html

This PR
- enables tests for 10.1
- pends/skips a few failing specs; linking to their relevant issues
- removes the old spec/test hacks for JRuby 9.1 - this has been long since EOL, and running specs on JRuby I believe is best efforts anyway so don't think maintainer should need to support these.

Needs investigation subsequently:
- https://github.com/rspec/rspec/issues/321 (might be at least partly a JRuby issue)
- https://github.com/jruby/jruby/issues/9398