### PR TITLE
chore: remove old JRuby `< 9.2` workarounds/hacks

### DIFF
--- a/rspec-core/features/configuration/backtrace_exclusion_patterns.feature
+++ b/rspec-core/features/configuration/backtrace_exclusion_patterns.feature
@@ -119,7 +119,7 @@ Feature: Excluding lines from the backtrace
     """
     When I run `rspec --backtrace`
     Then the output should contain "1 example, 1 failure"
-    And the output should contain %R{spec/support/custom_helper.rb:2:in ('Object#|`)assert_baz'}
+    And the output should contain %R{spec/support/custom_helper.rb:2:in [`'](Object#)?assert_baz'}
     And the output should contain "lib/rspec/expectations"
     And the output should contain "lib/rspec/core"
 
@@ -150,5 +150,5 @@ Feature: Excluding lines from the backtrace
         config.filter_gems_from_backtrace "my_gem"
       end
       """
-    Then the output from `rspec` should contain %R{vendor/my_gem-1.2.3/lib/my_gem.rb:4:in (`|'MyGem\.)do_amazing_things!'}
-    But the output from `rspec --require spec_helper` should not contain %R{vendor/my_gem-1.2.3/lib/my_gem.rb:4:in (`|'MyGem\.)do_amazing_things!'}
+    Then the output from `rspec` should contain %R{vendor/my_gem-1.2.3/lib/my_gem.rb:4:in [`'](MyGem\.)?do_amazing_things!'}
+    But the output from `rspec --require spec_helper` should not contain %R{vendor/my_gem-1.2.3/lib/my_gem.rb:4:in [`'](MyGem\.)?do_amazing_things!'}

--- a/rspec-core/features/expectation_framework_integration/aggregating_failures.feature
+++ b/rspec-core/features/expectation_framework_integration/aggregating_failures.feature
@@ -94,6 +94,7 @@ Feature: Aggregating Failures
                 # ./spec/use_block_form_spec.rb:12
       """
 
+  @broken-on-jruby
   Scenario: Use `:aggregate_failures` metadata
     Given a file named "spec/use_metadata_spec.rb" with:
       """ruby

--- a/rspec-core/lib/rspec/core/bisect/shell_command.rb
+++ b/rspec-core/lib/rspec/core/bisect/shell_command.rb
@@ -19,13 +19,13 @@ module RSpec
           parts = []
 
           parts << RUBY << load_path
-          parts << open3_safe_escape(RSpec::Core.path_to_executable)
+          parts << escape(RSpec::Core.path_to_executable)
 
           parts << "--format"   << "bisect-drb"
           parts << "--drb-port" << server.drb_port
 
           parts.concat(reusable_cli_options)
-          parts.concat(locations.map { |l| open3_safe_escape(l) })
+          parts.concat(locations.map { |l| escape(l) })
 
           parts.join(" ")
         end
@@ -65,16 +65,6 @@ module RSpec
 
         include RSpec::Core::ShellEscape
 
-        # On JRuby, Open3.popen3 does not handle shellescaped args properly:
-        # https://github.com/jruby/jruby/issues/2767
-        if RSpec::Support::Ruby.jruby?
-          # :nocov:
-          alias open3_safe_escape quote
-          # :nocov:
-        else
-          alias open3_safe_escape escape
-        end
-
         def environment_repro_parts
           bisect_environment_hash.map do |k, v|
             %Q(#{k}="#{v}")
@@ -110,7 +100,7 @@ module RSpec
         end
 
         def load_path
-          @load_path ||= "-I#{$LOAD_PATH.map { |p| open3_safe_escape(p) }.join(':')}"
+          @load_path ||= "-I#{$LOAD_PATH.map { |p| escape(p) }.join(':')}"
         end
 
         # Path to the currently running Ruby executable, borrowed from Rake:

--- a/rspec-core/lib/rspec/core/example.rb
+++ b/rspec-core/lib/rspec/core/example.rb
@@ -262,11 +262,7 @@ module RSpec
                         'Expected example to fail since it is pending, but it passed.',
                         [location]
                 end
-              rescue Pending::SkipDeclaredInExample => _
-                # The "=> _" is normally useless but on JRuby it is a workaround
-                # for a bug that prevents us from getting backtraces:
-                # https://github.com/jruby/jruby/issues/4467
-                #
+              rescue Pending::SkipDeclaredInExample
                 # no-op, required metadata has already been set by the `skip`
                 # method.
               rescue AllExceptionsExcludingDangerousOnesOnRubiesThatAllowIt => e

--- a/rspec-core/spec/integration/spec_file_load_errors_spec.rb
+++ b/rspec-core/spec/integration/spec_file_load_errors_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe 'Spec file load errors' do
     # Remove extra line which is only shown on CRuby
     output = output.sub("# ./helper_with_exit.rb:1:in #{quoted('exit')}\n", "")
 
-    if defined?(JRUBY_VERSION) && !JRUBY_VERSION.empty?
+    if RSpec::Support::Ruby.jruby?
       expect(output).to eq unindent(<<-EOS)
 
         While loading ./helper_with_exit.rb an `exit` / `raise SystemExit` occurred, RSpec will now quit.

--- a/rspec-core/spec/rspec/core/bisect/shell_command_spec.rb
+++ b/rspec-core/spec/rspec/core/bisect/shell_command_spec.rb
@@ -246,7 +246,7 @@ module RSpec::Core
     end
 
     def uses_quoting_for_escaping?
-      RSpec::Support::OS.windows? || RSpec::Support::Ruby.jruby?
+      RSpec::Support::OS.windows?
     end
   end
 end

--- a/rspec-expectations/lib/rspec/expectations/failure_aggregator.rb
+++ b/rspec-expectations/lib/rspec/expectations/failure_aggregator.rb
@@ -75,25 +75,9 @@ module RSpec
       end
 
     private
-
-      if RSpec::Support::Ruby.jruby? && RSpec::Support::Ruby.jruby_version < '9.2.0.0'
-        # On JRuby 9.1.x.x and before, `caller` and `raise` produce different backtraces with
-        # regards to `.java` stack frames. It's important that we use `raise` for JRuby to produce
-        # a backtrace that has a continuous common section with the raised `MultipleExpectationsNotMetError`,
-        # so that rspec-core's truncation logic can work properly on it to list the backtrace
-        # relative to the `aggregate_failures` block.
-        # :nocov:
-        def assign_backtrace(failure)
-          raise failure
-        rescue failure.class => e
-          failure.set_backtrace(e.backtrace)
-        end
-        # :nocov:
-      else
-        # Using `caller` performs better (and is simpler) than `raise` on most Rubies.
-        def assign_backtrace(failure)
-          failure.set_backtrace(caller)
-        end
+      # Using `caller` performs better (and is simpler) than `raise` on most Rubies.
+      def assign_backtrace(failure)
+        failure.set_backtrace(caller)
       end
 
       def initialize(block_label, metadata)

--- a/rspec-mocks/lib/rspec/mocks/test_double.rb
+++ b/rspec-mocks/lib/rspec/mocks/test_double.rb
@@ -90,13 +90,9 @@ module RSpec
         visibility = proxy.visibility_for(message)
 
         # Defined private and protected methods will still trigger `method_missing`
-        # when called publicly. We want ruby's method visibility error to get raised,
-        # so we simply delegate to `super` in that case.
-        #   return super if visibility == :private || visibility == :protected
-        # ...well, we would delegate to `super`, but there's a JRuby
-        # bug, so we raise our own visibility error instead:
-        # https://github.com/jruby/jruby/issues/1398
-        # Only works without this workaround with JRuby 9.2
+        # when called publicly. We originally wanted ruby's method visibility error to get raised,
+        # i.e to delegate to `super` - however workarounds for JRuby bugs (since resolved) were introduced which
+        # also had the benefit across implementations of including additional context via our own visibility error.
         if visibility == :private || visibility == :protected
           ErrorGenerator.new(self).raise_non_public_error(
             message, visibility

--- a/rspec-support/lib/rspec/support/method_signature_verifier.rb
+++ b/rspec-support/lib/rspec/support/method_signature_verifier.rb
@@ -144,50 +144,16 @@ module RSpec
       INFINITY = 1 / 0.0
     end
 
-    if RSpec::Support::Ruby.jruby?
-      # JRuby has only partial support for UnboundMethod#parameters, so we fall back on using #arity
-      # https://github.com/jruby/jruby/issues/2816 and https://github.com/jruby/jruby/issues/2817
-      if Java::JavaLang::String.instance_method(:char_at).parameters == []
+    # JRuby has only partial support for UnboundMethod#parameters, so we fall back on using #arity
+    # https://github.com/jruby/jruby/issues/2817
+    if RSpec::Support::Ruby.jruby? && Java::JavaLang::String.instance_method(:char_at).parameters == []
+      class MethodSignature < remove_const(:MethodSignature)
+      private
 
-        class MethodSignature < remove_const(:MethodSignature)
-        private
-
-          def classify_parameters
-            super
-            if (arity = @method.arity) != 0 && @method.parameters.empty?
-              classify_arity(arity)
-            end
-          end
-        end
-      end
-
-      # JRuby used to always report -1 arity for Java proxy methods.
-      # The workaround essentially makes use of Java's introspection to figure
-      # out matching methods (which could be more than one partly because Java
-      # supports multiple overloads, and partly because JRuby introduces
-      # aliases to make method names look more Rubyesque). If there is only a
-      # single match, we can use that methods arity directly instead of the
-      # default -1 arity.
-      #
-      # This workaround only works for Java proxy methods, and in order to
-      # support regular methods and blocks, we need to be careful about calling
-      # owner and java_class as they might not be available
-      if Java::JavaLang::String.instance_method(:char_at).arity == -1
-        class MethodSignature < remove_const(:MethodSignature)
-        private
-
-          def classify_parameters
-            super
-            return unless @method.arity == -1
-            return unless @method.respond_to?(:owner)
-            return unless @method.owner.respond_to?(:java_class)
-            java_instance_methods = @method.owner.java_class.java_instance_methods
-            compatible_overloads = java_instance_methods.select do |java_method|
-              @method == @method.owner.instance_method(java_method.name)
-            end
-            if compatible_overloads.size == 1
-              classify_arity(compatible_overloads.first.arity)
-            end
+        def classify_parameters
+          super
+          if (arity = @method.arity) != 0 && @method.parameters.empty?
+            classify_arity(arity)
           end
         end
       end

--- a/rspec-support/lib/rspec/support/spec/library_wide_checks.rb
+++ b/rspec-support/lib/rspec/support/spec/library_wide_checks.rb
@@ -67,7 +67,7 @@ RSpec.shared_examples_for "library wide checks" do |lib, options|
 
     stdout, stderr, status = with_env 'NO_COVERAGE' => '1' do
       options = %w[ -w ]
-      options << "--disable=gem" if RSpec::Support::Ruby.mri?
+      options << "--disable=gem"
       run_ruby_with_current_load_path(command, *options)
     end
 

--- a/rspec-support/spec/rspec/support/ruby_features_spec.rb
+++ b/rspec-support/spec/rspec/support/ruby_features_spec.rb
@@ -118,50 +118,8 @@ module RSpec
           end
         end
 
-        def ripper_works_correctly?
-          ripper_reports_correct_line_number? &&
-            ripper_can_parse_source_including_keywordish_symbol? &&
-            ripper_can_parse_source_referencing_keyword_arguments?
-        end
-
-        # https://github.com/jruby/jruby/issues/3386
-        def ripper_reports_correct_line_number?
-          in_sub_process_if_possible do
-            require 'ripper'
-            tokens = ::Ripper.lex('foo')
-            token = tokens.first
-            location = token.first
-            line_number = location.first
-            line_number == 1
-          end
-        end
-
-        # https://github.com/jruby/jruby/issues/4562
-        def ripper_can_parse_source_including_keywordish_symbol?
-          in_sub_process_if_possible do
-            require 'ripper'
-            sexp = ::Ripper.sexp(':if')
-            !sexp.nil?
-          end
-        end
-
-        # https://github.com/jruby/jruby/issues/5209
-        def ripper_can_parse_source_referencing_keyword_arguments?
-          in_sub_process_if_possible do
-            require 'ripper'
-            # It doesn't matter if keyword arguments don't exist.
-            if Ruby.mri? || Ruby.jruby? || Ruby.truffleruby?
-              begin
-                !::Ripper.sexp('def a(**kw_args); end').nil?
-              rescue NoMethodError
-                false
-              end
-            end
-          end
-        end
-
         it 'returns whether Ripper is correctly implemented in the current environment' do
-          expect(RubyFeatures.ripper_supported?).to eq(ripper_is_implemented? && ripper_works_correctly?)
+          expect(RubyFeatures.ripper_supported?).to eq(ripper_is_implemented?)
         end
 
         it 'does not load Ripper' do


### PR DESCRIPTION
As mentioned in #323 removes old production workarounds/hacks that were required to support ancient JRuby versions. Just trying to do what I can to reduce the number of "JRuby WTFs" and lower maintenance cost where I can.

Understand if you'd rather not rock the boat on all or any of these here - just seeing what I can do to help.

Will put inline comments on the changes.

Additional testing
- ran all Cucumber tests locally on JRuby 9.4 and 10.1 (MacOS Tahoe `26.4.1`)
  - all passing except the two scenarios marked as `@broken-on-jruby` 
  - tweaked a couple of Cucumber test expectations to get passes (although these are not run on JRuby CI)
  
For reference:
| JRuby Version | CRuby/Ruby Target | Last Release / EOL |
|---------------|------------------|----------------------|
| 10.1          | Ruby 4.0 | 2026, supported       |
| 10.0          | Ruby 3.4         | 2026, supported |
| 9.4           | Ruby 3.1         | 2025, soft-EOL as of early 2026 |
| 9.3           | Ruby 2.6         | 2024 (EOL)           |
| 9.2           | Ruby 2.5         | 2022 (EOL)           |
| 9.1           | Ruby 2.3         | 2018 (EOL)           |
| 9.0           | Ruby 2.2         | 2015 (EOL)           |
| 1.7           | Ruby 1.9.3         | 2017 (EOL)           |
  