### PR TITLE
test: correct tests for Aruba 2.4.0 / Cucumber 11 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,10 +19,6 @@ group :documentation do
   gem 'yard', '~> 0.9.24', :require => false
 end
 
-platforms :jruby do
-  gem "jruby-openssl"
-end
-
 #
 # Support for gems extracted in Ruby versions
 #

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ end
 gem 'bigdecimal', :require => false if RUBY_VERSION.to_f >= 3.3
 gem 'drb' if RUBY_VERSION.to_f >= 3.3
 gem 'mutex_m', '~> 0.1.0' if RUBY_VERSION.to_f > 3.3
+gem 'tsort', '0.1.0' if RUBY_VERSION.to_f < 3.1
 
 #
 # Tooling / our testing

--- a/Gemfile
+++ b/Gemfile
@@ -29,7 +29,6 @@ end
 
 gem 'bigdecimal', :require => false if RUBY_VERSION.to_f >= 3.3
 gem 'drb' if RUBY_VERSION.to_f >= 3.3
-gem 'mutex_m', '~> 0.1.0' if RUBY_VERSION.to_f > 3.3
 gem 'tsort', '0.1.0' if RUBY_VERSION.to_f < 3.1
 
 #
@@ -49,7 +48,7 @@ gem "rubocop", "~> 1.80" if RUBY_VERSION >= '3.3' && RUBY_ENGINE == 'ruby'
 #
 
 gem 'flexmock', '~> 0.9.0'
-gem 'minitest', '~> 5.12.0'
+gem 'minitest', '~> 5.15'
 gem 'mocha', '~> 0.13.0'
 gem 'rr', "~> 1.0.4"
 gem 'test-unit', '~> 3.0'

--- a/rspec-core/spec/rspec/core/shared_example_group_spec.rb
+++ b/rspec-core/spec/rspec/core/shared_example_group_spec.rb
@@ -161,8 +161,9 @@ module RSpec
               )).and exclude(a_string_matching(anonymous_module_regex))
             )
 
-            expect(example_group.ancestors.map(&:inspect)).to include_a_named_rather_than_anonymous_module
-            expect(example_group.ancestors.map(&:to_s)).to include_a_named_rather_than_anonymous_module
+            relevant_ancestors = example_group.ancestors.take_while { |x| x != RSpec::Core::MemoizedHelpers }
+            expect(relevant_ancestors.map(&:inspect)).to include_a_named_rather_than_anonymous_module
+            expect(relevant_ancestors.map(&:to_s)).to include_a_named_rather_than_anonymous_module
           end
 
           ["name", :name, ExampleModule, ExampleClass].each do |object|

--- a/rspec-core/spec/support/formatter_support.rb
+++ b/rspec-core/spec/support/formatter_support.rb
@@ -34,6 +34,7 @@ module FormatterSupport
     configuration = runner.configuration
     configuration.filter_gems_from_backtrace "gems/bundler"
     configuration.backtrace_formatter.exclusion_patterns << /rspec_with_simplecov/
+    configuration.backtrace_formatter.exclusion_patterns << /erb\.rb/ # remove differences/churn between use of stdlib and bundled erb
     configuration.backtrace_formatter.inclusion_patterns = []
 
     yield runner if block_given?

--- a/rspec-support/spec/rspec/support_spec.rb
+++ b/rspec-support/spec/rspec/support_spec.rb
@@ -11,7 +11,7 @@ module RSpec
       :consider_a_test_env_file => %r{rspec/support/spec},
       :allowed_loaded_feature_regexps => [
         /rbconfig/, # Used by RubyFeatures
-        /prettyprint.rb/, /pp.rb/, /diff\/lcs/ # These are all loaded by the differ.
+        /prettyprint\.rb/, /pp\.rb/, /set\.rb/, /diff\/lcs/ # These are all loaded by the differ.
       ]
 
     describe '.method_handle_for(object, method_name)' do


### PR DESCRIPTION
fixes #325

As discussed in #325, Aruba 2.4.0 adds a dependency on `irb` which in turn brings in Gemified versions of libraries that otherwise were being loaded from default gems or differently across Ruby versions.

The failing tests prior to these changes can be seen at https://github.com/chadlwilson/rspec/actions/runs/25275735223/job/74116339002

I chose the versions such that they should be OK for easier Rspec `3.13` backport but I note that the `Gemfile` has had some refactoring on `main` for `4.x` so that might not be a valid consideration. I'll add comments below.

I'm also happy to raise a PR for 3.13 backport to get tests passing again there too.