### PR TITLE
[3.13.x] test: correct tests for Aruba 2.4.0 / Cucumber 11 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,28 +15,28 @@ permissions:
 
 jobs:
   docs:
-    uses: rspec/rspec/.github/workflows/documentation_coverage.yml@3-13-maintenance
+    uses: ./.github/workflows/documentation_coverage.yml
 
   core:
-    uses: rspec/rspec/.github/workflows/rspec.yml@3-13-maintenance
+    uses: ./.github/workflows/rspec.yml
     with:
       library: 'rspec-core'
       rspec_version: '~> 3.13.0'
 
   mocks:
-    uses: rspec/rspec/.github/workflows/rspec.yml@3-13-maintenance
+    uses: ./.github/workflows/rspec.yml
     with:
       library: 'rspec-mocks'
       rspec_version: '~> 3.13.0'
 
   expectations:
-    uses: rspec/rspec/.github/workflows/rspec.yml@3-13-maintenance
+    uses: ./.github/workflows/rspec.yml
     with:
       library: 'rspec-expectations'
       rspec_version: '~> 3.13.0'
 
   support:
-    uses: rspec/rspec/.github/workflows/rspec.yml@3-13-maintenance
+    uses: ./.github/workflows/rspec.yml
     with:
       library: 'rspec-support'
       rspec_version: '~> 3.13.0'

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -123,7 +123,7 @@ jobs:
     steps:
       - run: git config --global --add safe.directory $GITHUB_WORKSPACE
       - run: git init $GITHUB_WORKSPACE
-      - run: git remote add origin https://github.com/rspec/rspec
+      - run: git remote add origin https://github.com/$GITHUB_REPOSITORY
       - run: git config --local gc.auto 0
       - run: git fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +$GITHUB_SHA:$GITHUB_REF
       - run: git checkout --progress --force $GITHUB_REF

--- a/Gemfile
+++ b/Gemfile
@@ -110,6 +110,7 @@ if RUBY_VERSION >= '3.3' && RUBY_ENGINE == 'ruby'
 end
 
 gem 'test-unit', '~> 3.0' if RUBY_VERSION.to_f >= 2.2
+gem 'tsort', '0.1.0' if RUBY_VERSION > '3.0.0' && RUBY_VERSION.to_f < 3.1
 
 gem "thread_order", "~> 1.1.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -87,7 +87,7 @@ end
 if RUBY_VERSION < '2.4.0'
   gem 'minitest', '< 5.12.0'
 else
-  gem 'minitest', '~> 5.12.0'
+  gem 'minitest', '~> 5.15'
 end
 
 gem "mocha", "~> 0.13.0"
@@ -117,10 +117,6 @@ if RUBY_VERSION < '2.0.0'
   gem 'thor', '< 1.0.0'
 else
   gem 'thor', '> 1.0.0'
-end
-
-if RUBY_VERSION.to_f > 3.3
-  gem 'mutex_m', '~> 0.1.0'
 end
 
 eval File.read('Gemfile-custom') if File.exist?('Gemfile-custom')

--- a/rspec-core/spec/support/formatter_support.rb
+++ b/rspec-core/spec/support/formatter_support.rb
@@ -35,6 +35,7 @@ module FormatterSupport
     configuration = runner.configuration
     configuration.filter_gems_from_backtrace "gems/bundler"
     configuration.backtrace_formatter.exclusion_patterns << /rspec_with_simplecov/
+    configuration.backtrace_formatter.exclusion_patterns << /erb\.rb/ # remove differences/churn between use of stdlib and bundled erb
     configuration.backtrace_formatter.inclusion_patterns = []
 
     yield runner if block_given?

--- a/rspec-support/spec/rspec/support_spec.rb
+++ b/rspec-support/spec/rspec/support_spec.rb
@@ -9,7 +9,7 @@ module RSpec
       :consider_a_test_env_file => %r{rspec/support/spec},
       :allowed_loaded_feature_regexps => [
         /rbconfig/, # Used by RubyFeatures
-        /prettyprint.rb/, /pp.rb/, /diff\/lcs/ # These are all loaded by the differ.
+        /prettyprint\.rb/, /pp\.rb/, /set\.rb/, /diff\/lcs/ # These are all loaded by the differ.
       ]
 
     describe '.method_handle_for(object, method_name)' do


### PR DESCRIPTION
Back-ports via cherry-picks the relevant subset of changes from #326 to fix the build on 3.13.x

Enabling change:
- corrects GHA workflows so they can be run for pull requests and on forks (similar to done on `main` via 743e849ae5fb1cc8495d0958059c593d7906bb93 already)