### PR TITLE
feat(mocks): verify constant names in stub_const

### DIFF
--- a/rspec-mocks/lib/rspec/mocks/configuration.rb
+++ b/rspec-mocks/lib/rspec/mocks/configuration.rb
@@ -50,10 +50,11 @@ module RSpec
       end
 
       # When this is set to true, an error will be raised when
-      # `instance_double` or `class_double` is given the name of an undefined
-      # constant. You probably only want to set this when running your entire
-      # test suite, with all production code loaded. Setting this for an
-      # isolated unit test will prevent you from being able to isolate it!
+      # `instance_double`, `class_double` or `stub_const` is given the name of
+      # an undefined constant. You probably only want to set this when running
+      # your entire test suite, with all production code loaded. Setting this
+      # for an isolated unit test will prevent you from being able to isolate
+      # it!
       attr_writer :verify_doubled_constant_names
 
       # Provides a way to perform customisations when verifying doubles.

--- a/rspec-mocks/lib/rspec/mocks/configuration.rb
+++ b/rspec-mocks/lib/rspec/mocks/configuration.rb
@@ -6,6 +6,7 @@ module RSpec
         @allow_message_expectations_on_nil = nil
         @yield_receiver_to_any_instance_implementation_blocks = true
         @verify_doubled_constant_names = false
+        @verify_constant_names = :none
         @transfer_nested_constants = false
         @verify_partial_doubles = true
         @temporarily_suppress_partial_double_verification = false
@@ -50,12 +51,38 @@ module RSpec
       end
 
       # When this is set to true, an error will be raised when
-      # `instance_double`, `class_double` or `stub_const` is given the name of
-      # an undefined constant. You probably only want to set this when running
-      # your entire test suite, with all production code loaded. Setting this
-      # for an isolated unit test will prevent you from being able to isolate
-      # it!
+      # `instance_double` or `class_double` is given the name of an undefined
+      # constant. You probably only want to set this when running your entire
+      # test suite, with all production code loaded. Setting this for an
+      # isolated unit test will prevent you from being able to isolate it!
       attr_writer :verify_doubled_constant_names
+
+      # Returns the `stub_const` constant name verification mode.
+      def verify_constant_names
+        @verify_constant_names
+      end
+
+      # Controls whether `stub_const` verifies the constant name it is given.
+      # Accepts one of three values:
+      #
+      # * `:none` (default) - no verification is performed.
+      # * `:namespace` - an error is raised when the constant's enclosing
+      #   namespace is not defined (e.g. stubbing `Foo::Bar` when `Foo` does
+      #   not exist).
+      # * `:full` - an error is raised when the constant itself is not already
+      #   defined.
+      #
+      # You probably only want `:full` when running your entire test suite,
+      # with all production code loaded; it will prevent you from stubbing
+      # constants in isolated unit tests.
+      def verify_constant_names=(value)
+        unless [:none, :namespace, :full].include?(value)
+          raise ArgumentError,
+                "verify_constant_names must be one of :none, :namespace or " \
+                ":full, but got #{value.inspect}"
+        end
+        @verify_constant_names = value
+      end
 
       # Provides a way to perform customisations when verifying doubles.
       #

--- a/rspec-mocks/lib/rspec/mocks/configuration.rb
+++ b/rspec-mocks/lib/rspec/mocks/configuration.rb
@@ -6,7 +6,7 @@ module RSpec
         @allow_message_expectations_on_nil = nil
         @yield_receiver_to_any_instance_implementation_blocks = true
         @verify_doubled_constant_names = false
-        @verify_constant_names = :none
+        @verify_stub_constant_mode = :none
         @transfer_nested_constants = false
         @verify_partial_doubles = true
         @temporarily_suppress_partial_double_verification = false
@@ -58,7 +58,7 @@ module RSpec
       attr_writer :verify_doubled_constant_names
 
       # Returns the `stub_const` constant name verification mode.
-      attr_reader :verify_constant_names
+      attr_reader :verify_stub_constant_mode
 
       # Controls whether `stub_const` verifies the constant name it is given.
       # Accepts one of three values:
@@ -73,13 +73,13 @@ module RSpec
       # You probably only want `:full` when running your entire test suite,
       # with all production code loaded; it will prevent you from stubbing
       # constants in isolated unit tests.
-      def verify_constant_names=(value)
+      def verify_stub_constant_mode=(value)
         unless [:none, :namespace, :full].include?(value)
           raise ArgumentError,
-                "verify_constant_names must be one of :none, :namespace or " \
+                "verify_stub_constant_mode must be one of :none, :namespace or " \
                 ":full, but got #{value.inspect}"
         end
-        @verify_constant_names = value
+        @verify_stub_constant_mode = value
       end
 
       # Provides a way to perform customisations when verifying doubles.

--- a/rspec-mocks/lib/rspec/mocks/configuration.rb
+++ b/rspec-mocks/lib/rspec/mocks/configuration.rb
@@ -58,9 +58,7 @@ module RSpec
       attr_writer :verify_doubled_constant_names
 
       # Returns the `stub_const` constant name verification mode.
-      def verify_constant_names
-        @verify_constant_names
-      end
+      attr_reader :verify_constant_names
 
       # Controls whether `stub_const` verifies the constant name it is given.
       # Accepts one of three values:

--- a/rspec-mocks/lib/rspec/mocks/mutate_const.rb
+++ b/rspec-mocks/lib/rspec/mocks/mutate_const.rb
@@ -111,12 +111,7 @@ module RSpec
 
         defined = recursive_const_defined?(constant_name, &raise_on_invalid_const)
 
-        if !defined && RSpec::Mocks.configuration.verify_doubled_constant_names?
-          raise VerifyingDoubleNotDefinedError,
-                "#{constant_name.inspect} is not a defined constant. " \
-                "Perhaps you misspelt it? " \
-                "Disable check with `verify_doubled_constant_names` configuration option."
-        end
+        verify_constant_name(constant_name) unless defined
 
         mutator = if defined
                     DefinedConstantReplacer
@@ -126,6 +121,29 @@ module RSpec
 
         mutate(mutator.new(constant_name, value, options[:transfer_nested_constants]))
         value
+      end
+
+      # @private
+      def self.verify_constant_name(constant_name)
+        mode = RSpec::Mocks.configuration.verify_constant_names
+        return if mode == :none
+
+        if mode == :namespace
+          parts = normalize_const_name(constant_name).split('::')
+          return if parts.size < 2
+          namespace = parts[0..-2].join('::')
+          return if recursive_const_defined?(namespace)
+
+          raise VerifyingDoubleNotDefinedError,
+                "#{namespace.inspect} is not a defined constant. " \
+                "Perhaps you misspelt #{constant_name.inspect}? " \
+                "Disable check with the `verify_constant_names` configuration option."
+        else
+          raise VerifyingDoubleNotDefinedError,
+                "#{constant_name.inspect} is not a defined constant. " \
+                "Perhaps you misspelt it? " \
+                "Disable check with the `verify_constant_names` configuration option."
+        end
       end
 
       # Hides a constant.

--- a/rspec-mocks/lib/rspec/mocks/mutate_const.rb
+++ b/rspec-mocks/lib/rspec/mocks/mutate_const.rb
@@ -109,7 +109,16 @@ module RSpec
           raise ArgumentError, "`stub_const` requires a String, but you provided a #{constant_name.class.name}"
         end
 
-        mutator = if recursive_const_defined?(constant_name, &raise_on_invalid_const)
+        defined = recursive_const_defined?(constant_name, &raise_on_invalid_const)
+
+        if !defined && RSpec::Mocks.configuration.verify_doubled_constant_names?
+          raise VerifyingDoubleNotDefinedError,
+                "#{constant_name.inspect} is not a defined constant. " \
+                "Perhaps you misspelt it? " \
+                "Disable check with `verify_doubled_constant_names` configuration option."
+        end
+
+        mutator = if defined
                     DefinedConstantReplacer
                   else
                     UndefinedConstantSetter

--- a/rspec-mocks/lib/rspec/mocks/mutate_const.rb
+++ b/rspec-mocks/lib/rspec/mocks/mutate_const.rb
@@ -125,7 +125,7 @@ module RSpec
 
       # @private
       def self.verify_constant_name(constant_name)
-        mode = RSpec::Mocks.configuration.verify_constant_names
+        mode = RSpec::Mocks.configuration.verify_stub_constant_mode
         return if mode == :none
 
         if mode == :namespace
@@ -137,12 +137,12 @@ module RSpec
           raise VerifyingDoubleNotDefinedError,
                 "#{namespace.inspect} is not a defined constant. " \
                 "Perhaps you misspelt #{constant_name.inspect}? " \
-                "Disable check with the `verify_constant_names` configuration option."
+                "Disable check with the `verify_stub_constant_mode` configuration option."
         else
           raise VerifyingDoubleNotDefinedError,
                 "#{constant_name.inspect} is not a defined constant. " \
                 "Perhaps you misspelt it? " \
-                "Disable check with the `verify_constant_names` configuration option."
+                "Disable check with the `verify_stub_constant_mode` configuration option."
         end
       end
 

--- a/rspec-mocks/spec/rspec/mocks/mutate_const_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/mutate_const_spec.rb
@@ -427,11 +427,24 @@ module RSpec
           end
         end
 
-        context 'when `verify_doubled_constant_names` is enabled' do
+        context 'when `verify_constant_names` is `:none`' do
           include_context "with isolated configuration"
 
           before do
-            RSpec::Mocks.configuration.verify_doubled_constant_names = true
+            RSpec::Mocks.configuration.verify_constant_names = :none
+          end
+
+          it 'allows undefined constants to be stubbed' do
+            stub_const("SomeUndefinedConst", Module.new)
+            expect(SomeUndefinedConst).to be_a(Module)
+          end
+        end
+
+        context 'when `verify_constant_names` is `:full`' do
+          include_context "with isolated configuration"
+
+          before do
+            RSpec::Mocks.configuration.verify_constant_names = :full
           end
 
           it 'raises when stubbing an undefined constant' do
@@ -446,6 +459,40 @@ module RSpec
             expect(TestClass).not_to be(orig_value)
             reset_rspec_mocks
             expect(TestClass).to be(orig_value)
+          end
+        end
+
+        context 'when `verify_constant_names` is `:namespace`' do
+          include_context "with isolated configuration"
+
+          before do
+            RSpec::Mocks.configuration.verify_constant_names = :namespace
+          end
+
+          it 'raises when the enclosing namespace is undefined' do
+            expect {
+              stub_const("SomeUndefinedConst::Nested", Module.new)
+            }.to raise_error(/SomeUndefinedConst.*is not a defined constant/)
+          end
+
+          it 'allows a new constant under a defined namespace' do
+            stub_const("TestClass::BrandNew", Module.new)
+            expect(TestClass::BrandNew).to be_a(Module)
+          end
+
+          it 'allows a new top-level constant' do
+            stub_const("SomeUndefinedConst", Module.new)
+            expect(SomeUndefinedConst).to be_a(Module)
+          end
+        end
+
+        context 'when `verify_constant_names` is given an invalid value' do
+          include_context "with isolated configuration"
+
+          it 'raises an ArgumentError' do
+            expect {
+              RSpec::Mocks.configuration.verify_constant_names = :bogus
+            }.to raise_error(ArgumentError, /verify_constant_names/)
           end
         end
       end

--- a/rspec-mocks/spec/rspec/mocks/mutate_const_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/mutate_const_spec.rb
@@ -427,11 +427,11 @@ module RSpec
           end
         end
 
-        context 'when `verify_constant_names` is `:none`' do
+        context 'when `verify_stub_constant_mode` is `:none`' do
           include_context "with isolated configuration"
 
           before do
-            RSpec::Mocks.configuration.verify_constant_names = :none
+            RSpec::Mocks.configuration.verify_stub_constant_mode = :none
           end
 
           it 'allows undefined constants to be stubbed' do
@@ -440,11 +440,11 @@ module RSpec
           end
         end
 
-        context 'when `verify_constant_names` is `:full`' do
+        context 'when `verify_stub_constant_mode` is `:full`' do
           include_context "with isolated configuration"
 
           before do
-            RSpec::Mocks.configuration.verify_constant_names = :full
+            RSpec::Mocks.configuration.verify_stub_constant_mode = :full
           end
 
           it 'raises when stubbing an undefined constant' do
@@ -462,11 +462,11 @@ module RSpec
           end
         end
 
-        context 'when `verify_constant_names` is `:namespace`' do
+        context 'when `verify_stub_constant_mode` is `:namespace`' do
           include_context "with isolated configuration"
 
           before do
-            RSpec::Mocks.configuration.verify_constant_names = :namespace
+            RSpec::Mocks.configuration.verify_stub_constant_mode = :namespace
           end
 
           it 'raises when the enclosing namespace is undefined' do
@@ -486,13 +486,13 @@ module RSpec
           end
         end
 
-        context 'when `verify_constant_names` is given an invalid value' do
+        context 'when `verify_stub_constant_mode` is given an invalid value' do
           include_context "with isolated configuration"
 
           it 'raises an ArgumentError' do
             expect {
-              RSpec::Mocks.configuration.verify_constant_names = :bogus
-            }.to raise_error(ArgumentError, /verify_constant_names/)
+              RSpec::Mocks.configuration.verify_stub_constant_mode = :bogus
+            }.to raise_error(ArgumentError, /verify_stub_constant_mode/)
           end
         end
       end

--- a/rspec-mocks/spec/rspec/mocks/mutate_const_spec.rb
+++ b/rspec-mocks/spec/rspec/mocks/mutate_const_spec.rb
@@ -426,6 +426,28 @@ module RSpec
             expect(defined?(TestClass::Nested::NestedEvenMore::X)).to be_falsey
           end
         end
+
+        context 'when `verify_doubled_constant_names` is enabled' do
+          include_context "with isolated configuration"
+
+          before do
+            RSpec::Mocks.configuration.verify_doubled_constant_names = true
+          end
+
+          it 'raises when stubbing an undefined constant' do
+            expect {
+              stub_const("SomeUndefinedConst", Module.new)
+            }.to raise_error(/SomeUndefinedConst.*is not a defined constant/)
+          end
+
+          it 'still allows defined constants to be stubbed' do
+            orig_value = TestClass
+            stub_const("TestClass", Module.new)
+            expect(TestClass).not_to be(orig_value)
+            reset_rspec_mocks
+            expect(TestClass).to be(orig_value)
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Closes #232. When `verify_doubled_constant_names` is enabled, `stub_const` now raises if given the name of an undefined constant, matching the behaviour of `instance_double`/`class_double`. Following @JonRowe's note that he is "open to a PR that makes stub_const check verify_doubled_constant_names and raise if not set" and that this should be opt-in, the check only fires when the config option is set, so existing behaviour is unchanged by default.