### PR TITLE
docs: fix grammar typo in pending documentation

### DIFF
--- a/rspec-core/lib/rspec/core/pending.rb
+++ b/rspec-core/lib/rspec/core/pending.rb
@@ -53,7 +53,7 @@ module RSpec
       #     end
       #
       # @note When using `pending` inside an example body using this method
-      #   hooks, such as `before(:example)`, have already be run. This means that
+      #   hooks, such as `before(:example)`, have already been run. This means that
       #   a failure from the code in the `before` hook will prevent the example
       #   from being considered pending, as the example body would not be
       #   executed. If you need to consider hooks as pending as well you can use


### PR DESCRIPTION
Fixes a small grammar typo in the `pending` documentation: "have already be run" → "have already been run".