### PR TITLE
test: cover ConsoleCodes.wrap when color is disabled

### DIFF
--- a/rspec-core/spec/rspec/core/formatters/console_codes_spec.rb
+++ b/rspec-core/spec/rspec/core/formatters/console_codes_spec.rb
@@ -84,5 +84,15 @@ RSpec.describe "RSpec::Core::Formatters::ConsoleCodes" do
         expect(console_codes.wrap('abc', :bold)).to eq "\e[1mabc\e[0m"
       end
     end
+
+    context "when color is disabled" do
+      before do
+        allow(RSpec.configuration).to receive(:color_enabled?) { false }
+      end
+
+      it "returns the text without any console codes" do
+        expect(console_codes.wrap('abc', :green)).to eq 'abc'
+      end
+    end
   end
 end


### PR DESCRIPTION
`ConsoleCodes.wrap` returns the text unwrapped when `color_enabled?` is false, but every existing `#wrap` example stubs `color_enabled?` as `true`, so the no-color branch had no coverage.

This adds a small example asserting that no console codes are applied when color is disabled, matching the existing style of the spec.