### PR TITLE
Fix NoMethodError when including a shared group with metadata into an example

### DIFF
--- a/rspec-core/lib/rspec/core/example_group.rb
+++ b/rspec-core/lib/rspec/core/example_group.rb
@@ -706,7 +706,16 @@ module RSpec
       # @private
       def self.update_inherited_metadata(updates)
         metadata.update(updates) do |key, existing_group_value, new_inherited_value|
-          @user_metadata.key?(key) ? existing_group_value : new_inherited_value
+          # `@user_metadata` is only assigned by `set_it_up`. The singleton
+          # example group used to include a shared group into an individual
+          # example never goes through it, and its metadata is the example's
+          # own, so the existing value wins -- as it does in
+          # `Example#update_inherited_metadata`.
+          if @user_metadata.nil? || @user_metadata.key?(key)
+            existing_group_value
+          else
+            new_inherited_value
+          end
         end
 
         RSpec.configuration.configure_group(self)

--- a/rspec-core/spec/rspec/core/configuration_spec.rb
+++ b/rspec-core/spec/rspec/core/configuration_spec.rb
@@ -1047,6 +1047,20 @@ module RSpec::Core
 
           expect(foo_value).to eq 19
         end
+
+        it 'includes a shared example group that has its own metadata in the singleton class of matching examples' do
+          RSpec.shared_examples "shared group", :shared_group_metadata do
+            let(:foo) { 20 }
+          end
+          RSpec.configuration.include_context "shared group", :include_it
+
+          foo_value = nil
+          describe_successfully do
+            it("", :include_it, :shared_group_metadata) { foo_value = foo }
+          end
+
+          expect(foo_value).to eq 20
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

Fixes #333.

Including a shared group that carries its own metadata into an individual
example raises `NoMethodError: undefined method 'key?' for nil` whenever the
example declares the same metadata key as the shared group. It surfaces as a
confusing `TypeError: can't convert NilClass into an exact number` from
`calculate_run_time`, because the `NoMethodError` escapes after the example
body has run but before timing is recorded.

`ExampleGroup.update_inherited_metadata` resolves key collisions by consulting
`@user_metadata`, which is only assigned in `set_it_up`. The singleton example
group that `Configuration#configure_example` builds for an individual example
never goes through `set_it_up`, so `@user_metadata` is `nil` there. The
`Hash#update` block only runs on a key collision, which is why the crash needs
the same key on both the shared group and the example.

The issue was filed against 3.13.6 with
`shared_context_metadata_behavior = :apply_to_host_groups`. On `main` that
option is gone and the behavior is unconditional, so the reproduction no longer
needs it — the defect is unchanged.

## Changes

- Treat a `nil` `@user_metadata` as "the existing value wins" in
  `ExampleGroup.update_inherited_metadata`. That matches
  `Example#update_inherited_metadata`, which already always keeps the existing
  value; for a singleton example group the metadata is the example's own, so
  its explicitly-set value should take precedence over the inherited one.
- Regression spec beside the existing singleton-class example in
  `configuration_spec.rb`.

I fixed this at the fault site rather than in `with_replaced_metadata`, since
that helper is used elsewhere and receives the example's full metadata rather
than the user-specified subset. Happy to take it the other way if you'd prefer.

## Testing

- `bundle exec rspec spec/rspec/core/configuration_spec.rb -e 'includes a shared example group that has its own metadata in the singleton class of matching examples'`
  — fails on `main` with the `NoMethodError`, passes with the fix.
- `bundle exec rspec spec --seed 1234` — 2155 examples, 18 failures. The same
  18 fail on unmodified `main` (2154 examples, 18 failures); they are all in
  `spec/rspec/core/formatters/exception_presenter_spec.rb` and appear unrelated
  to this change (backtrace formatting under Ruby 4.0.6 locally).
- `bundle exec rubocop rspec-core/lib/rspec/core/example_group.rb rspec-core/spec/rspec/core/configuration_spec.rb`
  — no offenses.

I left the Changelog alone since the entry format wants a PR number; happy to
add one.

Note: I used Claude Code while preparing this change, and I reviewed the final
diff and ran the listed checks locally.