### PR TITLE
Typo in before_and_after_hooks.feature

### DIFF
--- a/rspec-core/features/hooks/before_and_after_hooks.feature
+++ b/rspec-core/features/hooks/before_and_after_hooks.feature
@@ -210,7 +210,7 @@ Feature: `before` and `after` hooks
       before context runs
       before example runs
       after example runs
-      Fafter context runs
+      after context runs
       """
 
   Scenario: Define `before` and `after` blocks in configuration


### PR DESCRIPTION
This PR fixes typo in before_and_after_hooks.feature


Typo Changes:
- Change spelling from "Fafter" to "after"(Line no : 213)