### PR TITLE
Silence strict_unused_block warning in SimpleMessageExpectation#invoke

### DIFF
--- a/rspec-mocks/lib/rspec/mocks/message_expectation.rb
+++ b/rspec-mocks/lib/rspec/mocks/message_expectation.rb
@@ -14,7 +14,7 @@ module RSpec
         @received = false
       end
 
-      def invoke(*_)
+      def invoke(*_, &_block)
         @received = true
         @response
       end


### PR DESCRIPTION
Closes #332.

Proxy#message_received forwards the original &block through to
stub.invoke (and to expectation.invoke) so mock implementations can
yield to the caller-provided block. SimpleMessageExpectation#invoke
declared `def invoke(*_)` with no block parameter, which discards the
forwarded &block silently. Under Ruby 3.4 strict_unused_block (enabled
by default on the 3.x line) this surfaces as a noisy warning even
though the existing behaviour is intentional.

Add an explicit `&_block` parameter so the block is named-and-discarded
in the signature, matching the convention used elsewhere in the codebase
and silencing the warning without changing observable behaviour.

AI-assisted: implementation, commit message, and PR text prepared with AI assistance.